### PR TITLE
resource/pagerduty_extension: Allow config to be computed

### DIFF
--- a/pagerduty/resource_pagerduty_extension.go
+++ b/pagerduty/resource_pagerduty_extension.go
@@ -49,6 +49,7 @@ func resourcePagerDutyExtension() *schema.Resource {
 			},
 			"config": {
 				Type:             schema.TypeString,
+				Computed:         true,
 				Optional:         true,
 				ValidateFunc:     validation.ValidateJsonString,
 				DiffSuppressFunc: structure.SuppressJsonDiff,


### PR DESCRIPTION
This PR brings changes to the `config` field and allows it to be `computed`.

Unfortunately testing this proved to be quite difficult due to how the API behaves with a missing `config` on resource creation, but this should resolve the issue described in #94.

Fixes #94.