### PR TITLE
resource/pagerduty_extension: add import test case without config and use ImportStatePassthrough

### DIFF
--- a/pagerduty/import_pagerduty_extension_test.go
+++ b/pagerduty/import_pagerduty_extension_test.go
@@ -30,3 +30,79 @@ func TestAccPagerDutyExtension_import(t *testing.T) {
 		},
 	})
 }
+
+func TestAccPagerDutyExtension_importNoConfig(t *testing.T) {
+	extension_name := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	name := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	url := "https://example.com/receive_a_pagerduty_webhook"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyExtensionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyExtensionConfigNoConfig(name, extension_name, url),
+			},
+
+			{
+				ResourceName:      "pagerduty_extension.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckPagerDutyExtensionConfigNoConfig(name string, extension_name string, url string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "foo" {
+  name        = "%[1]v"
+  email       = "%[1]v@foo.test"
+  color       = "green"
+  role        = "user"
+  job_title   = "foo"
+  description = "foo"
+}
+
+resource "pagerduty_escalation_policy" "foo" {
+  name        = "%[1]v"
+  description = "bar"
+  num_loops   = 2
+
+  rule {
+    escalation_delay_in_minutes = 10
+
+    target {
+      type = "user_reference"
+      id   = "${pagerduty_user.foo.id}"
+    }
+  }
+}
+
+resource "pagerduty_service" "foo" {
+  name                    = "%[1]v"
+  description             = "foo"
+  auto_resolve_timeout    = 1800
+  acknowledgement_timeout = 1800
+  escalation_policy       = "${pagerduty_escalation_policy.foo.id}"
+
+  incident_urgency_rule {
+    type    = "constant"
+    urgency = "high"
+  }
+}
+
+data "pagerduty_extension_schema" "foo" {
+	name = "Generic V2 Webhook"
+}
+
+resource "pagerduty_extension" "foo"{
+  name = "%s"
+  endpoint_url = "%s"
+  extension_schema = "${data.pagerduty_extension_schema.foo.id}"
+  extension_objects = ["${pagerduty_service.foo.id}"]
+}
+
+`, name, extension_name, url)
+}

--- a/pagerduty/resource_pagerduty_extension.go
+++ b/pagerduty/resource_pagerduty_extension.go
@@ -55,6 +55,7 @@ func resourcePagerDutyExtension() *schema.Resource {
 			},
 			"config": {
 				Type:             schema.TypeString,
+				Computed:         true,
 				Optional:         true,
 				ValidateFunc:     validation.StringIsJSON,
 				DiffSuppressFunc: structure.SuppressJsonDiff,

--- a/pagerduty/resource_pagerduty_extension.go
+++ b/pagerduty/resource_pagerduty_extension.go
@@ -2,7 +2,6 @@ package pagerduty
 
 import (
 	"encoding/json"
-	"fmt"
 	"log"
 	"time"
 
@@ -20,7 +19,7 @@ func resourcePagerDutyExtension() *schema.Resource {
 		Update: resourcePagerDutyExtensionUpdate,
 		Delete: resourcePagerDutyExtensionDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourcePagerDutyExtensionImport,
+			State: schema.ImportStatePassthrough,
 		},
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -183,25 +182,6 @@ func resourcePagerDutyExtensionDelete(d *schema.ResourceData, meta interface{}) 
 	d.SetId("")
 
 	return nil
-}
-
-func resourcePagerDutyExtensionImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	client, err := meta.(*Config).Client()
-	if err != nil {
-		return []*schema.ResourceData{}, err
-	}
-
-	extension, _, err := client.Extensions.Get(d.Id())
-
-	if err != nil {
-		return []*schema.ResourceData{}, fmt.Errorf("error importing pagerduty_extension. Expecting an importation ID for extension")
-	}
-
-	d.Set("endpoint_url", extension.EndpointURL)
-	d.Set("extension_objects", []string{extension.ExtensionObjects[0].ID})
-	d.Set("extension_schema", extension.ExtensionSchema.ID)
-
-	return []*schema.ResourceData{d}, err
 }
 
 func expandServiceObjects(v interface{}) []*pagerduty.ServiceReference {


### PR DESCRIPTION
This PR adds a test case for importing the config field of a service extension.

Also, the `resourcePagerDutyExtensionImport` function is replaced by the generic pass through function based on the read function.
This revealed an issue in the `resourcePagerDutyExtensionRead` function where `extension_schema` was set to `extension.ExtensionSchema` instead of `extension.ExtensionSchema.ID`.