### PR TITLE
Make endpoint_url sensitive

### DIFF
--- a/pagerduty/resource_pagerduty_extension.go
+++ b/pagerduty/resource_pagerduty_extension.go
@@ -40,6 +40,7 @@ func resourcePagerDutyExtension() *schema.Resource {
 			"endpoint_url": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Sensitive: true,
 			},
 			"extension_objects": {
 				Type:     schema.TypeSet,


### PR DESCRIPTION
The endpoint URL on extensions can contain sensive data. For example when setting up integration with Datadog.

The Datadog API key is persisted to the state as it is included as a query parameter in the endpoint URL.

![image](https://user-images.githubusercontent.com/56073682/92493611-9e61b200-f1ec-11ea-80ba-5c9288843734.png)
