### PR TITLE
Fixed Bug in Event Rule Positioning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go v0.71.0 // indirect
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.7.0
-	github.com/heimweh/go-pagerduty v0.0.0-20210208230541-602e6af0197d
+	github.com/heimweh/go-pagerduty v0.0.0-20210209211114-6eef07a31388
 	golang.org/x/tools v0.0.0-20201110124207-079ba7bd75cd // indirect
 	google.golang.org/api v0.35.0 // indirect
 	google.golang.org/genproto v0.0.0-20201109203340-2640f1f9cdfb // indirect

--- a/go.sum
+++ b/go.sum
@@ -230,6 +230,8 @@ github.com/heimweh/go-pagerduty v0.0.0-20210204180239-b6fd4689b860 h1:3Su9c7I3Fq
 github.com/heimweh/go-pagerduty v0.0.0-20210204180239-b6fd4689b860/go.mod h1:6+bccpjQ/PM8uQY9m8avM4MJea+3vo3ta9r8kGQ4XFY=
 github.com/heimweh/go-pagerduty v0.0.0-20210208230541-602e6af0197d h1:Cu1SpAcafU1JNnMbX7rfMSZ1x0FdK8oEB7p85YE68h0=
 github.com/heimweh/go-pagerduty v0.0.0-20210208230541-602e6af0197d/go.mod h1:6+bccpjQ/PM8uQY9m8avM4MJea+3vo3ta9r8kGQ4XFY=
+github.com/heimweh/go-pagerduty v0.0.0-20210209211114-6eef07a31388 h1:g9ukOOud162IdWcssRS2aqoKjSRISm4LLPsQL3QFr9w=
+github.com/heimweh/go-pagerduty v0.0.0-20210209211114-6eef07a31388/go.mod h1:6+bccpjQ/PM8uQY9m8avM4MJea+3vo3ta9r8kGQ4XFY=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/ruleset.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/ruleset.go
@@ -42,7 +42,7 @@ type ListRulesetsResponse struct {
 // RulesetRule represents a Ruleset rule
 type RulesetRule struct {
 	ID         string            `json:"id,omitempty"`
-	Position   int               `json:"position,omitempty"`
+	Position   *int              `json:"position,omitempty"`
 	Disabled   bool              `json:"disabled"`
 	Conditions *RuleConditions   `json:"conditions,omitempty"`
 	Actions    *RuleActions      `json:"actions,omitempty"`

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/service.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/service.go
@@ -89,11 +89,11 @@ type Service struct {
 type ServiceEventRule struct {
 	ID         string            `json:"id,omitempty"`
 	Self       string            `json:"self,omitempty"`
-	Disabled   bool              `json:"disabled,omitempty"`
+	Disabled   bool              `json:"disabled"`
 	Conditions *RuleConditions   `json:"conditions,omitempty"`
 	TimeFrame  *RuleTimeFrame    `json:"time_frame,omitempty"`
 	Variables  []*RuleVariable   `json:"variables,omitempty"`
-	Position   int               `json:"position,omitempty"`
+	Position   *int              `json:"position,omitempty"`
 	Actions    *RuleActions      `json:"actions,omitempty"`
 	Service    *ServiceReference `json:"service_id,omitempty"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -188,7 +188,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20210208230541-602e6af0197d
+# github.com/heimweh/go-pagerduty v0.0.0-20210209211114-6eef07a31388
 ## explicit
 github.com/heimweh/go-pagerduty/pagerduty
 # github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af


### PR DESCRIPTION
Changes in the last provider release caused Event Rule positioning (both in  Service Event Rules and Ruleset Rules) to have issues setting position 0, as well as ignoring when positions weren't set. This fix should change that. #300 

RulesetRule Test Results
```
TF_ACC=1 go test -run "TestAccPagerDutyRulesetRule" ./pagerduty -v -timeout 120m
=== RUN   TestAccPagerDutyRulesetRule_import
--- PASS: TestAccPagerDutyRulesetRule_import (4.86s)
=== RUN   TestAccPagerDutyRulesetRule_Basic
--- PASS: TestAccPagerDutyRulesetRule_Basic (6.06s)
=== RUN   TestAccPagerDutyRulesetRule_MultipleRules
--- PASS: TestAccPagerDutyRulesetRule_MultipleRules (6.12s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	18.277s
```

ServiceEventRule Test Rules
```
TF_ACC=1 go test -run "TestAccPagerDutyServiceEventRule" ./pagerduty -v -timeout 120m        
=== RUN   TestAccPagerDutyServiceEventRule_import
--- PASS: TestAccPagerDutyServiceEventRule_import (11.76s)
=== RUN   TestAccPagerDutyServiceEventRule_Basic
--- PASS: TestAccPagerDutyServiceEventRule_Basic (12.94s)
=== RUN   TestAccPagerDutyServiceEventRule_MultipleRules
--- PASS: TestAccPagerDutyServiceEventRule_MultipleRules (12.96s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	38.307s
```