### PR TITLE
Restoring Needed omitempty o RuleAction.Suppress Fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go v0.71.0 // indirect
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.7.0
-	github.com/heimweh/go-pagerduty v0.0.0-20210209211114-6eef07a31388
+	github.com/heimweh/go-pagerduty v0.0.0-20210211225831-18708f545aa5
 	golang.org/x/tools v0.0.0-20201110124207-079ba7bd75cd // indirect
 	google.golang.org/api v0.35.0 // indirect
 	google.golang.org/genproto v0.0.0-20201109203340-2640f1f9cdfb // indirect

--- a/go.sum
+++ b/go.sum
@@ -232,6 +232,8 @@ github.com/heimweh/go-pagerduty v0.0.0-20210208230541-602e6af0197d h1:Cu1SpAcafU
 github.com/heimweh/go-pagerduty v0.0.0-20210208230541-602e6af0197d/go.mod h1:6+bccpjQ/PM8uQY9m8avM4MJea+3vo3ta9r8kGQ4XFY=
 github.com/heimweh/go-pagerduty v0.0.0-20210209211114-6eef07a31388 h1:g9ukOOud162IdWcssRS2aqoKjSRISm4LLPsQL3QFr9w=
 github.com/heimweh/go-pagerduty v0.0.0-20210209211114-6eef07a31388/go.mod h1:6+bccpjQ/PM8uQY9m8avM4MJea+3vo3ta9r8kGQ4XFY=
+github.com/heimweh/go-pagerduty v0.0.0-20210211225831-18708f545aa5 h1:8yYQBU2sa5ScRfurxdT1EqzXWfXnEqb6NIuT3pg7rZI=
+github.com/heimweh/go-pagerduty v0.0.0-20210211225831-18708f545aa5/go.mod h1:6+bccpjQ/PM8uQY9m8avM4MJea+3vo3ta9r8kGQ4XFY=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/pagerduty/resource_pagerduty_ruleset_rule_test.go
+++ b/pagerduty/resource_pagerduty_ruleset_rule_test.go
@@ -191,6 +191,9 @@ resource "pagerduty_ruleset_rule" "foo" {
 		annotate {
 			value = "%s"
 		}
+		suppress {
+			value = true
+		}
 		extractions {
 			target = "dedup_key"
 			source = "details.host"
@@ -261,6 +264,9 @@ resource "pagerduty_ruleset_rule" "foo" {
 		}
 		annotate {
 			value = "%s"
+		}
+		suppress {
+			value = false
 		}
 		extractions {
 			target = "dedup_key"

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/ruleset.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/ruleset.go
@@ -143,9 +143,9 @@ type RuleActionIntParameter struct {
 // RuleActionSuppress represents a rule suppress action object
 type RuleActionSuppress struct {
 	Value               bool   `json:"value"`
-	ThresholdValue      int    `json:"threshold_value"`
-	ThresholdTimeUnit   string `json:"threshold_time_unit"`
-	ThresholdTimeAmount int    `json:"threshold_time_amount"`
+	ThresholdValue      int    `json:"threshold_value,omitempty"`
+	ThresholdTimeUnit   string `json:"threshold_time_unit,omitempty"`
+	ThresholdTimeAmount int    `json:"threshold_time_amount,omitempty"`
 }
 
 // RuleActionExtraction represents a rule extraction action object

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -188,7 +188,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20210209211114-6eef07a31388
+# github.com/heimweh/go-pagerduty v0.0.0-20210211225831-18708f545aa5
 ## explicit
 github.com/heimweh/go-pagerduty/pagerduty
 # github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af


### PR DESCRIPTION
Recent change to the `RuleAction.Suppress` object made it impossible to simply set the `value` field. This change will allow for that and also includes the `suppress` field in tests. This change affects both Ruleset Rules and Service Event Rules.

Ruleset Rule Test Results
```
TF_ACC=1 go test -run "TestAccPagerDutyRulesetRule" ./pagerduty -v -timeout 120m     
=== RUN   TestAccPagerDutyRulesetRule_import
--- PASS: TestAccPagerDutyRulesetRule_import (5.33s)
=== RUN   TestAccPagerDutyRulesetRule_Basic
--- PASS: TestAccPagerDutyRulesetRule_Basic (6.60s)
=== RUN   TestAccPagerDutyRulesetRule_MultipleRules
--- PASS: TestAccPagerDutyRulesetRule_MultipleRules (6.83s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	24.884s
```

Service Event Rule Test Results
```
TF_ACC=1 go test -run "TestAccPagerDutyServiceEventRule" ./pagerduty -v -timeout 120m
=== RUN   TestAccPagerDutyServiceEventRule_import
--- PASS: TestAccPagerDutyServiceEventRule_import (10.65s)
=== RUN   TestAccPagerDutyServiceEventRule_Basic
--- PASS: TestAccPagerDutyServiceEventRule_Basic (11.74s)
=== RUN   TestAccPagerDutyServiceEventRule_MultipleRules
--- PASS: TestAccPagerDutyServiceEventRule_MultipleRules (12.39s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	35.365s
```


