### PR TITLE
Adding Retry to Escalation Policy Delete and Trim to User.name

### DIFF
--- a/pagerduty/resource_pagerduty_escalation_policy.go
+++ b/pagerduty/resource_pagerduty_escalation_policy.go
@@ -171,8 +171,20 @@ func resourcePagerDutyEscalationPolicyDelete(d *schema.ResourceData, meta interf
 
 	log.Printf("[INFO] Deleting PagerDuty escalation policy: %s", d.Id())
 
-	if _, err := client.EscalationPolicies.Delete(d.Id()); err != nil {
-		return err
+	// Retrying to give other resources (such as services) to delete
+	retryErr := resource.Retry(30*time.Second, func() *resource.RetryError {
+		if _, err := client.EscalationPolicies.Delete(d.Id()); err != nil {
+			if isErrCode(err, 400) {
+				return resource.RetryableError(err)
+			}
+
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	if retryErr != nil {
+		time.Sleep(2 * time.Second)
+		return retryErr
 	}
 
 	d.SetId("")


### PR DESCRIPTION
Adding retry logic to `resource_pagerduty_escalation_policy` delete function to help give dependent objects time to delete.

Test results:
```
TF_ACC=1 go test -run "TestAccPagerDutyEscalationPolicy" ./pagerduty -v -timeout 120m
=== RUN   TestAccPagerDutyEscalationPolicy_import
--- PASS: TestAccPagerDutyEscalationPolicy_import (7.24s)
=== RUN   TestAccPagerDutyEscalationPolicy_Basic
--- PASS: TestAccPagerDutyEscalationPolicy_Basic (8.76s)
=== RUN   TestAccPagerDutyEscalationPolicyWithTeams_Basic
--- PASS: TestAccPagerDutyEscalationPolicyWithTeams_Basic (9.01s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	36.389s
```

Adding a trim on the `resource_pagerduty_user.name` field so that leading and trailing spaces don't trigger diffs.

Test results:
```
TF_ACC=1 go test -run "TestAccPagerDutyUser" ./pagerduty -v -timeout 120m
=== RUN   TestAccPagerDutyUserContactMethod_import
--- PASS: TestAccPagerDutyUserContactMethod_import (6.46s)
=== RUN   TestAccPagerDutyUserNotificationRule_import
--- PASS: TestAccPagerDutyUserNotificationRule_import (8.36s)
=== RUN   TestAccPagerDutyUser_import
--- PASS: TestAccPagerDutyUser_import (4.96s)
=== RUN   TestAccPagerDutyUserContactMethodEmail_Basic
--- PASS: TestAccPagerDutyUserContactMethodEmail_Basic (7.98s)
=== RUN   TestAccPagerDutyUserContactMethodPhone_Basic
--- PASS: TestAccPagerDutyUserContactMethodPhone_Basic (8.26s)
=== RUN   TestAccPagerDutyUserContactMethodSMS_Basic
--- PASS: TestAccPagerDutyUserContactMethodSMS_Basic (9.51s)
=== RUN   TestAccPagerDutyUserNotificationRuleContactMethod_Basic
--- PASS: TestAccPagerDutyUserNotificationRuleContactMethod_Basic (12.28s)
=== RUN   TestAccPagerDutyUser_Basic
--- PASS: TestAccPagerDutyUser_Basic (7.00s)
=== RUN   TestAccPagerDutyUserWithTeams_Basic
--- PASS: TestAccPagerDutyUserWithTeams_Basic (11.54s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	87.708s
```