### PR TITLE
Update to fix non-working ruleset data source which does not return routing_keys

### DIFF
--- a/pagerduty/data_source_pagerduty_ruleset.go
+++ b/pagerduty/data_source_pagerduty_ruleset.go
@@ -19,6 +19,13 @@ func dataSourcePagerDutyRuleset() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"routing_keys": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 		},
 	}
 }


### PR DESCRIPTION
This commit is an extension of the following issue:
https://github.com/PagerDuty/terraform-provider-pagerduty/issues/307

It adds the required extra schema definition to fully enable the
ruleset data source to return routing_keys.