### PR TITLE
[Task] Add "template" field for Global Event Rules and Service Event Rules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go v0.71.0 // indirect
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.7.0
-	github.com/heimweh/go-pagerduty v0.0.0-20210226020252-e256912df9d4
+	github.com/heimweh/go-pagerduty v0.0.0-20210309231526-3275f6c029e3
 	golang.org/x/tools v0.0.0-20201110124207-079ba7bd75cd // indirect
 	google.golang.org/api v0.35.0 // indirect
 	google.golang.org/genproto v0.0.0-20201109203340-2640f1f9cdfb // indirect

--- a/go.sum
+++ b/go.sum
@@ -236,6 +236,8 @@ github.com/heimweh/go-pagerduty v0.0.0-20210211225831-18708f545aa5 h1:8yYQBU2sa5
 github.com/heimweh/go-pagerduty v0.0.0-20210211225831-18708f545aa5/go.mod h1:6+bccpjQ/PM8uQY9m8avM4MJea+3vo3ta9r8kGQ4XFY=
 github.com/heimweh/go-pagerduty v0.0.0-20210226020252-e256912df9d4 h1:SdP0fGf1bSiJ807RIDprhs3XIIZXubNpUQPCdp1rMEU=
 github.com/heimweh/go-pagerduty v0.0.0-20210226020252-e256912df9d4/go.mod h1:6+bccpjQ/PM8uQY9m8avM4MJea+3vo3ta9r8kGQ4XFY=
+github.com/heimweh/go-pagerduty v0.0.0-20210309231526-3275f6c029e3 h1:W26FTjH1Sg3ngrdGuep+t6a0fpoELVEGbZh62ykkw7k=
+github.com/heimweh/go-pagerduty v0.0.0-20210309231526-3275f6c029e3/go.mod h1:6+bccpjQ/PM8uQY9m8avM4MJea+3vo3ta9r8kGQ4XFY=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/pagerduty/resource_pagerduty_ruleset_rule.go
+++ b/pagerduty/resource_pagerduty_ruleset_rule.go
@@ -248,6 +248,10 @@ func resourcePagerDutyRulesetRule() *schema.Resource {
 										Type:     schema.TypeString,
 										Optional: true,
 									},
+									"template": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
 								},
 							},
 						},
@@ -513,9 +517,10 @@ func expandExtractions(v interface{}) []*pagerduty.RuleActionExtraction {
 	for _, eai := range v.([]interface{}) {
 		ea := eai.(map[string]interface{})
 		ext := &pagerduty.RuleActionExtraction{
-			Target: ea["target"].(string),
-			Source: ea["source"].(string),
-			Regex:  ea["regex"].(string),
+			Target:   ea["target"].(string),
+			Source:   ea["source"].(string),
+			Regex:    ea["regex"].(string),
+			Template: ea["template"].(string),
 		}
 		rae = append(rae, ext)
 	}
@@ -677,9 +682,10 @@ func flattenExtractions(rae []*pagerduty.RuleActionExtraction) []interface{} {
 
 	for _, ex := range rae {
 		flatExtract := map[string]interface{}{
-			"target": ex.Target,
-			"source": ex.Source,
-			"regex":  ex.Regex,
+			"target":   ex.Target,
+			"source":   ex.Source,
+			"regex":    ex.Regex,
+			"template": ex.Template,
 		}
 		flatExtractList = append(flatExtractList, flatExtract)
 	}

--- a/pagerduty/resource_pagerduty_ruleset_rule_test.go
+++ b/pagerduty/resource_pagerduty_ruleset_rule_test.go
@@ -43,6 +43,8 @@ func TestAccPagerDutyRulesetRule_Basic(t *testing.T) {
 						"pagerduty_ruleset_rule.foo", "conditions.0.subconditions.0.parameter.0.value", "disk space"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_ruleset_rule.foo", "actions.0.annotate.0.value", rule),
+					resource.TestCheckResourceAttr(
+						"pagerduty_ruleset_rule.foo", "actions.0.extractions.1.template", "{{VAR1}} | {{VAR2}}"),
 				),
 			},
 			{
@@ -198,6 +200,10 @@ resource "pagerduty_ruleset_rule" "foo" {
 			target = "dedup_key"
 			source = "details.host"
 			regex = "(.*)"
+		}
+		extractions {
+			target   = "summary"
+			template = "{{VAR1}} | {{VAR2}}"
 		}
 	}
 	variable {

--- a/pagerduty/resource_pagerduty_service_event_rule.go
+++ b/pagerduty/resource_pagerduty_service_event_rule.go
@@ -236,6 +236,10 @@ func resourcePagerDutyServiceEventRule() *schema.Resource {
 										Type:     schema.TypeString,
 										Optional: true,
 									},
+									"template": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
 								},
 							},
 						},

--- a/pagerduty/resource_pagerduty_service_event_rule_test.go
+++ b/pagerduty/resource_pagerduty_service_event_rule_test.go
@@ -43,6 +43,8 @@ func TestAccPagerDutyServiceEventRule_Basic(t *testing.T) {
 						"pagerduty_service_event_rule.foo", "conditions.0.subconditions.0.parameter.0.value", "disk space"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service_event_rule.foo", "actions.0.annotate.0.value", rule),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service_event_rule.foo", "actions.0.extractions.1.template", "Overriding Summary"),
 				),
 			},
 			{
@@ -216,6 +218,10 @@ resource "pagerduty_service_event_rule" "foo" {
 			target = "dedup_key"
 			source = "source"
 			regex = "(.*)"
+		}
+		extractions {
+			target   = "summary"
+			template = "Overriding Summary"
 		}
 	}
 }

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/ruleset.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/ruleset.go
@@ -150,9 +150,10 @@ type RuleActionSuppress struct {
 
 // RuleActionExtraction represents a rule extraction action object
 type RuleActionExtraction struct {
-	Target string `json:"target,omitempty"`
-	Source string `json:"source,omitempty"`
-	Regex  string `json:"regex,omitempty"`
+	Target   string `json:"target,omitempty"`
+	Source   string `json:"source,omitempty"`
+	Regex    string `json:"regex,omitempty"`
+	Template string `json:"template,omitempty"`
 }
 
 // List lists existing rulesets.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -188,7 +188,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20210226020252-e256912df9d4
+# github.com/heimweh/go-pagerduty v0.0.0-20210309231526-3275f6c029e3
 ## explicit
 github.com/heimweh/go-pagerduty/pagerduty
 # github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af

--- a/website/docs/r/ruleset_rule.html.markdown
+++ b/website/docs/r/ruleset_rule.html.markdown
@@ -52,6 +52,14 @@ resource "pagerduty_ruleset_rule" "foo" {
 	  }
 	}
   }
+  variable {
+    type = "regex"
+    name = "Src"
+    parameters {
+      value = "(.*)"
+      path  = "payload.source"
+    }
+  }
   actions {
     route {
 	  value = "P5DTL0K"
@@ -67,6 +75,10 @@ resource "pagerduty_ruleset_rule" "foo" {
 	  source = "details.host"
 	  regex = "(.*)"
 	}
+    extractions {
+      target = "summary"
+      template = "Warning: Disk Space Low on {{Src}}"
+    }
   }
 }
 ```
@@ -96,11 +108,17 @@ The following arguments are supported:
 * `priority` (Optional) - The ID of the priority applied to the event.
 * `severity` (Optional)  - The [severity level](https://support.pagerduty.com/docs/rulesets#section-set-severity-with-event-rules) of the event. Can be either `info`,`error`,`warning`, or `critical`.
 * `annotate` (Optional) - Note added to the event.
-* `extractions` (Optional) - Allows you to copy important data from one event field to another. Extraction rules must use valid [RE2 regular expression syntax](https://github.com/google/re2/wiki/Syntax). Extraction objects consist of the following fields:
-	* `source` - Field where the data is being copied from.
-	* `target` - Field where the data is being copied to.
-	* `regex` - The conditions that need to be met for the extraction to happen.
-	* *NOTE: A rule can have multiple `extraction` objects attributed to it.*
+* `extractions` (Optional) - Allows you to copy important data from one event field to another. Extraction objects may use *either* of the following field structures:
+	* `source` - Field where the data is being copied from. Must be a [PagerDuty Common Event Format (PD-CEF)](https://support.pagerduty.com/docs/pd-cef) field.
+	* `target` - Field where the data is being copied to. Must be a [PagerDuty Common Event Format (PD-CEF)](https://support.pagerduty.com/docs/pd-cef) field.
+	* `regex` - The conditions that need to be met for the extraction to happen. Must use valid [RE2 regular expression syntax](https://github.com/google/re2/wiki/Syntax). 
+
+	*- **OR** -*  
+	
+	* `template` - A customized field message. This can also include variables extracted from the payload by using string interpolation.
+	* `target` - Field where the data is being copied to. Must be a [PagerDuty Common Event Format (PD-CEF)](https://support.pagerduty.com/docs/pd-cef) field.
+
+	*NOTE: A rule can have multiple `extraction` objects attributed to it.*
 
 * `suppress` (Optional) - Controls whether an alert is [suppressed](https://support.pagerduty.com/docs/rulesets#section-suppress-but-create-triggering-thresholds-with-event-rules) (does not create an incident).
 	* `value` - Boolean value that indicates if the alert should be suppressed before the indicated threshold values are met.

--- a/website/docs/r/service_event_rule.html.markdown
+++ b/website/docs/r/service_event_rule.html.markdown
@@ -35,6 +35,14 @@ resource "pagerduty_service_event_rule" "foo" {
 			}
 		}
 	}
+	variable {
+		type = "regex"
+		name = "Src"
+		parameters {
+			value = "(.*)"
+			path = "source"
+		}
+	}
 	actions {
 		annotate {
 			value = "From Terraform"
@@ -43,6 +51,10 @@ resource "pagerduty_service_event_rule" "foo" {
 			target = "dedup_key"
 			source = "source"
 			regex = "(.*)"
+		}
+		extractions {
+			target = "summary"
+			template = "Warning: Disk Space Low on {{Src}}"
 		}
 	}
 }
@@ -93,11 +105,17 @@ The following arguments are supported:
 * `priority` (Optional) - The ID of the priority applied to the event.
 * `severity` (Optional)  - The [severity level](https://support.pagerduty.com/docs/rulesets#section-set-severity-with-event-rules) of the event. Can be either `info`,`error`,`warning`, or `critical`.
 * `annotate` (Optional) - Note added to the event.
-* `extractions` (Optional) - Allows you to copy important data from one event field to another. Extraction rules must use valid [RE2 regular expression syntax](https://github.com/google/re2/wiki/Syntax). Extraction objects consist of the following fields:
-	* `source` - Field where the data is being copied from. Must be a [PagerDuty Common Event Format (PD-CEF)](https://support.pagerduty.com/docs/pd-cef) field
-	* `target` - Field where the data is being copied to. must be a [PagerDuty Common Event Format (PD-CEF)](https://support.pagerduty.com/docs/pd-cef) field
-	* `regex` - The conditions that need to be met for the extraction to happen.
-	* *NOTE: A rule can have multiple `extraction` objects attributed to it.*
+* `extractions` (Optional) - Allows you to copy important data from one event field to another. Extraction objects may use *either* of the following field structures:
+	* `source` - Field where the data is being copied from. Must be a [PagerDuty Common Event Format (PD-CEF)](https://support.pagerduty.com/docs/pd-cef) field.
+	* `target` - Field where the data is being copied to. Must be a [PagerDuty Common Event Format (PD-CEF)](https://support.pagerduty.com/docs/pd-cef) field.
+	* `regex` - The conditions that need to be met for the extraction to happen. Must use valid [RE2 regular expression syntax](https://github.com/google/re2/wiki/Syntax).
+
+	*- **OR** -*  
+	
+	* `template` - A customized field message. This can also include variables extracted from the payload by using string interpolation.
+	* `target` - Field where the data is being copied to. Must be a [PagerDuty Common Event Format (PD-CEF)](https://support.pagerduty.com/docs/pd-cef) field.
+
+	*NOTE: A rule can have multiple `extraction` objects attributed to it.*
 
 * `suppress` (Optional) - Controls whether an alert is [suppressed](https://support.pagerduty.com/docs/rulesets#section-suppress-but-create-triggering-thresholds-with-event-rules) (does not create an incident).
 	* `value` - Boolean value that indicates if the alert should be suppressed before the indicated threshold values are met.


### PR DESCRIPTION
## Summary
This PR enables users to define the "template" field within the `action.extractions` object, required for the "Customize Event Fields" section within the UI. This functionality is GA'd with the following public documentation:
* [Documentation - Customize Event Fields ](https://support.pagerduty.com/docs/rulesets#step-11-customize-event-fields-optional)
* [REST API - Create an Event Rule](https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1rulesets~1%7Bid%7D~1rules/post)

## Tests
`testAccCheckPagerDutyRulesetRuleConfig` was updated to include the template field
```
% TF_ACC=1 go test -v ./pagerduty -run TestAccPagerDutyRulesetRule           
=== RUN   TestAccPagerDutyRulesetRule_import
--- PASS: TestAccPagerDutyRulesetRule_import (9.51s)
=== RUN   TestAccPagerDutyRulesetRule_Basic
--- PASS: TestAccPagerDutyRulesetRule_Basic (11.60s)
=== RUN   TestAccPagerDutyRulesetRule_MultipleRules
--- PASS: TestAccPagerDutyRulesetRule_MultipleRules (13.14s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   34.830s
```

`testAccCheckPagerDutyServiceEventRuleConfig` was updated to include the template field
```
% TF_ACC=1 go test -v ./pagerduty -run TestAccPagerDutyServiceEventRule      
=== RUN   TestAccPagerDutyServiceEventRule_import
--- PASS: TestAccPagerDutyServiceEventRule_import (15.35s)
=== RUN   TestAccPagerDutyServiceEventRule_Basic
--- PASS: TestAccPagerDutyServiceEventRule_Basic (18.25s)
=== RUN   TestAccPagerDutyServiceEventRule_MultipleRules
--- PASS: TestAccPagerDutyServiceEventRule_MultipleRules (18.68s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   52.888s
```

## Example
I've included the Global Event Rule outputs below, similar outputs are seen for the Service Event Rule.

#### Code
```hcl
resource "pagerduty_ruleset" "example_ruleset" {
  name = "Example Ruleset"
}

resource "pagerduty_ruleset_rule" "example_ruleset_rule" {
  ruleset = pagerduty_ruleset.example_ruleset.id
  conditions {
    operator = "and"
    subconditions {
      operator = "contains"
      parameter {
        value = "disk space"
        path  = "summary"
      }
    }
  }
  variable {
    type = "regex"
    name = "Src"
    parameters {
      value = "(.*)"
      path  = "payload.source"
    }
  }
  actions {
    extractions {
      target   = "summary"
      template = "{{Src}} | Some Issue Title"
    }
    extractions {
      target = "dedup_key"
      source = "payload.class"
      regex  = "(.*)"
    }
  }
}
```

#### Screenshots
<img width="1086" alt="Screenshot 2021-03-04 at 22 24 05" src="https://user-images.githubusercontent.com/20474443/110038944-628d4c80-7d38-11eb-9bd2-c9a6f16ced01.png">
<img width="701" alt="Screenshot 2021-03-04 at 22 24 18" src="https://user-images.githubusercontent.com/20474443/110038948-63be7980-7d38-11eb-9d4c-657cd097c024.png">

