### PR TITLE
Response Play Responder to Optional and User Email to Case Insensitive

### DIFF
--- a/pagerduty/resource_pagerduty_response_play.go
+++ b/pagerduty/resource_pagerduty_response_play.go
@@ -65,7 +65,7 @@ func resourcePagerDutyResponsePlay() *schema.Resource {
 			},
 			"responder": {
 				Type:     schema.TypeList,
-				Required: true,
+				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {

--- a/pagerduty/resource_pagerduty_user.go
+++ b/pagerduty/resource_pagerduty_user.go
@@ -29,8 +29,8 @@ func resourcePagerDutyUser() *schema.Resource {
 			},
 
 			"email": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:             schema.TypeString,
+				Required:         true,
 				DiffSuppressFunc: suppressCaseDiff,
 			},
 

--- a/pagerduty/resource_pagerduty_user.go
+++ b/pagerduty/resource_pagerduty_user.go
@@ -25,17 +25,13 @@ func resourcePagerDutyUser() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				// Suppress the diff shown if there are leading or trailing spaces
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					if old == strings.TrimSpace(new) {
-						return true
-					}
-					return false
-				},
+				DiffSuppressFunc: suppressLeadTrailSpaceDiff,
 			},
 
 			"email": {
 				Type:     schema.TypeString,
 				Required: true,
+				DiffSuppressFunc: suppressCaseDiff,
 			},
 
 			"color": {

--- a/pagerduty/resource_pagerduty_user_test.go
+++ b/pagerduty/resource_pagerduty_user_test.go
@@ -54,6 +54,7 @@ func testSweepUser(region string) error {
 
 func TestAccPagerDutyUser_Basic(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	usernameSpaces := " " + username + " "
 	usernameUpdated := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	email := fmt.Sprintf("%s@Foo.com", username)
 	emailUpdated := fmt.Sprintf("%s@foo.com", usernameUpdated)
@@ -64,7 +65,7 @@ func TestAccPagerDutyUser_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckPagerDutyUserDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckPagerDutyUserConfig(username, email),
+				Config: testAccCheckPagerDutyUserConfig(usernameSpaces, email),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyUserExists("pagerduty_user.foo"),
 					resource.TestCheckResourceAttr(

--- a/pagerduty/resource_pagerduty_user_test.go
+++ b/pagerduty/resource_pagerduty_user_test.go
@@ -55,7 +55,7 @@ func testSweepUser(region string) error {
 func TestAccPagerDutyUser_Basic(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	usernameUpdated := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@Foo.com", username)
 	emailUpdated := fmt.Sprintf("%s@foo.com", usernameUpdated)
 
 	resource.Test(t, resource.TestCase{
@@ -70,7 +70,7 @@ func TestAccPagerDutyUser_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"pagerduty_user.foo", "name", username),
 					resource.TestCheckResourceAttr(
-						"pagerduty_user.foo", "email", email),
+						"pagerduty_user.foo", "email", strings.ToLower(email)),
 					resource.TestCheckResourceAttr(
 						"pagerduty_user.foo", "color", "green"),
 					resource.TestCheckResourceAttr(

--- a/pagerduty/util.go
+++ b/pagerduty/util.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"time"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
@@ -40,6 +41,20 @@ func suppressRFC3339Diff(k, oldTime, newTime string, d *schema.ResourceData) boo
 		return false
 	}
 	return oldT.Equal(newT)
+}
+
+func suppressLeadTrailSpaceDiff(k, old, new string, d *schema.ResourceData) bool {
+	if old == strings.TrimSpace(new) {
+		return true
+	}
+	return false
+}
+
+func suppressCaseDiff(k, old, new string, d *schema.ResourceData) bool {
+	if old == strings.ToLower(new) {
+		return true
+	}
+	return false
 }
 
 // Validate a value against a set of possible values

--- a/pagerduty/util.go
+++ b/pagerduty/util.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"time"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )

--- a/pagerduty/util.go
+++ b/pagerduty/util.go
@@ -44,17 +44,11 @@ func suppressRFC3339Diff(k, oldTime, newTime string, d *schema.ResourceData) boo
 }
 
 func suppressLeadTrailSpaceDiff(k, old, new string, d *schema.ResourceData) bool {
-	if old == strings.TrimSpace(new) {
-		return true
-	}
-	return false
+	return old == strings.TrimSpace(new)
 }
 
 func suppressCaseDiff(k, old, new string, d *schema.ResourceData) bool {
-	if old == strings.ToLower(new) {
-		return true
-	}
-	return false
+	return old == strings.ToLower(new)
 }
 
 // Validate a value against a set of possible values


### PR DESCRIPTION
The `responder` field on the `pagerduty_response_play` resource is, in fact, not required on the PagerDuty API. Correcting the resource schema to match that fact. Response Play test results.

```
TF_ACC=1 go test -run "TestAccPagerDutyResponsePlay" ./pagerduty -v -timeout 120m
=== RUN   TestAccPagerDutyResponsePlay_import
--- PASS: TestAccPagerDutyResponsePlay_import (7.50s)
=== RUN   TestAccPagerDutyResponsePlay_Basic
--- PASS: TestAccPagerDutyResponsePlay_Basic (9.21s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	17.387s
```

Also set the `email` field to suppress diff when there is a difference in case, since emails are case insensative.

```
TF_ACC=1 go test -run "TestAccPagerDutyUser_Basic" ./pagerduty -v -timeout 120m
=== RUN   TestAccPagerDutyUser_Basic
--- PASS: TestAccPagerDutyUser_Basic (7.43s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	8.063s
```
