### PR TITLE
Add Parent Field to Teams Resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go v0.71.0 // indirect
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.7.0
-	github.com/heimweh/go-pagerduty v0.0.0-20210309231526-3275f6c029e3
+	github.com/heimweh/go-pagerduty v0.0.0-20210401200608-e772e426d1d0
 	golang.org/x/tools v0.0.0-20201110124207-079ba7bd75cd // indirect
 	google.golang.org/api v0.35.0 // indirect
 	google.golang.org/genproto v0.0.0-20201109203340-2640f1f9cdfb // indirect

--- a/go.sum
+++ b/go.sum
@@ -238,6 +238,8 @@ github.com/heimweh/go-pagerduty v0.0.0-20210226020252-e256912df9d4 h1:SdP0fGf1bS
 github.com/heimweh/go-pagerduty v0.0.0-20210226020252-e256912df9d4/go.mod h1:6+bccpjQ/PM8uQY9m8avM4MJea+3vo3ta9r8kGQ4XFY=
 github.com/heimweh/go-pagerduty v0.0.0-20210309231526-3275f6c029e3 h1:W26FTjH1Sg3ngrdGuep+t6a0fpoELVEGbZh62ykkw7k=
 github.com/heimweh/go-pagerduty v0.0.0-20210309231526-3275f6c029e3/go.mod h1:6+bccpjQ/PM8uQY9m8avM4MJea+3vo3ta9r8kGQ4XFY=
+github.com/heimweh/go-pagerduty v0.0.0-20210401200608-e772e426d1d0 h1:fF/STDApEmPMx5pxXOrliPnWim3K1w0f9Ma06OqrKeI=
+github.com/heimweh/go-pagerduty v0.0.0-20210401200608-e772e426d1d0/go.mod h1:6+bccpjQ/PM8uQY9m8avM4MJea+3vo3ta9r8kGQ4XFY=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/pagerduty/data_source_pagerduty_team.go
+++ b/pagerduty/data_source_pagerduty_team.go
@@ -25,7 +25,7 @@ func dataSourcePagerDutyTeam() *schema.Resource {
 				Computed: true,
 			},
 			"parent": {
-				Type: schema.TypeString,
+				Type:     schema.TypeString,
 				Optional: true,
 			},
 		},

--- a/pagerduty/data_source_pagerduty_team.go
+++ b/pagerduty/data_source_pagerduty_team.go
@@ -24,6 +24,10 @@ func dataSourcePagerDutyTeam() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"parent": {
+				Type: schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -70,6 +74,7 @@ func dataSourcePagerDutyTeamRead(d *schema.ResourceData, meta interface{}) error
 		d.SetId(found.ID)
 		d.Set("name", found.Name)
 		d.Set("description", found.Description)
+		d.Set("parent", found.Parent)
 
 		return nil
 	})

--- a/pagerduty/data_source_pagerduty_team_test.go
+++ b/pagerduty/data_source_pagerduty_team_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestAccDataSourcePagerDutyTeam_Basic(t *testing.T) {
 	name := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	parent := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	description := "team description"
 
 	resource.Test(t, resource.TestCase{
@@ -18,7 +19,7 @@ func TestAccDataSourcePagerDutyTeam_Basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourcePagerDutyTeamConfig(name, description),
+				Config: testAccDataSourcePagerDutyTeamConfig(name, parent, description),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourcePagerDutyTeam("pagerduty_team.test", "data.pagerduty_team.by_name"),
 				),
@@ -40,7 +41,7 @@ func testAccDataSourcePagerDutyTeam(src, n string) resource.TestCheckFunc {
 			return fmt.Errorf("Expected to get a user ID from PagerDuty")
 		}
 
-		testAtts := []string{"id", "name", "description"}
+		testAtts := []string{"id", "name", "description", "parent"}
 
 		for _, att := range testAtts {
 			if a[att] != srcA[att] {
@@ -52,8 +53,13 @@ func testAccDataSourcePagerDutyTeam(src, n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccDataSourcePagerDutyTeamConfig(name, description string) string {
+func testAccDataSourcePagerDutyTeamConfig(name, parent, description string) string {
 	return fmt.Sprintf(`
+resource "pagerduty_team" "parent" {
+  name        = "%s"
+  description = "parent team"
+}
+
 resource "pagerduty_team" "test" {
   name        = "%s"
   description = "%s"
@@ -62,5 +68,5 @@ resource "pagerduty_team" "test" {
 data "pagerduty_team" "by_name" {
 	name = pagerduty_team.test.name
 }
-`, name, description)
+`, parent, name, description)
 }

--- a/pagerduty/resource_pagerduty_response_play.go
+++ b/pagerduty/resource_pagerduty_response_play.go
@@ -240,7 +240,6 @@ func resourcePagerDutyResponsePlayCreate(d *schema.ResourceData, meta interface{
 			d.SetId(responsePlay.ID)
 			d.Set("from", responsePlay.FromEmail)
 			log.Printf("[INFO] Created PagerDuty response play: %s (from: %s)", d.Id(), responsePlay.FromEmail)
-
 		}
 		return nil
 	})
@@ -305,7 +304,7 @@ func resourcePagerDutyResponsePlayUpdate(d *schema.ResourceData, meta interface{
 		time.Sleep(2 * time.Second)
 		return retryErr
 	}
-	return nil
+	return resourcePagerDutyResponsePlayRead(d, meta)
 }
 
 func resourcePagerDutyResponsePlayDelete(d *schema.ResourceData, meta interface{}) error {

--- a/pagerduty/resource_pagerduty_team.go
+++ b/pagerduty/resource_pagerduty_team.go
@@ -33,7 +33,7 @@ func resourcePagerDutyTeam() *schema.Resource {
 				Computed: true,
 			},
 			"parent": {
-				Type: schema.TypeString,
+				Type:     schema.TypeString,
 				Optional: true,
 			},
 		},

--- a/pagerduty/resource_pagerduty_team.go
+++ b/pagerduty/resource_pagerduty_team.go
@@ -32,6 +32,10 @@ func resourcePagerDutyTeam() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"parent": {
+				Type: schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -44,7 +48,12 @@ func buildTeamStruct(d *schema.ResourceData) *pagerduty.Team {
 	if attr, ok := d.GetOk("description"); ok {
 		team.Description = attr.(string)
 	}
-
+	if attr, ok := d.GetOk("parent"); ok {
+		team.Parent = &pagerduty.TeamReference{
+			ID:   attr.(string),
+			Type: "team_reference",
+		}
+	}
 	return team
 }
 
@@ -55,12 +64,18 @@ func resourcePagerDutyTeamCreate(d *schema.ResourceData, meta interface{}) error
 
 	log.Printf("[INFO] Creating PagerDuty team %s", team.Name)
 
-	team, _, err := client.Teams.Create(team)
-	if err != nil {
-		return err
+	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
+		if team, _, err := client.Teams.Create(team); err != nil {
+			return resource.RetryableError(err)
+		} else if team != nil {
+			d.SetId(team.ID)
+		}
+		return nil
+	})
+	if retryErr != nil {
+		time.Sleep(2 * time.Second)
+		return retryErr
 	}
-
-	d.SetId(team.ID)
 
 	return resourcePagerDutyTeamRead(d, meta)
 
@@ -91,10 +106,16 @@ func resourcePagerDutyTeamUpdate(d *schema.ResourceData, meta interface{}) error
 
 	log.Printf("[INFO] Updating PagerDuty team %s", d.Id())
 
-	if _, _, err := client.Teams.Update(d.Id(), team); err != nil {
-		return err
+	retryErr := resource.Retry(30*time.Second, func() *resource.RetryError {
+		if _, _, err := client.Teams.Update(d.Id(), team); err != nil {
+			return resource.RetryableError(err)
+		}
+		return nil
+	})
+	if retryErr != nil {
+		time.Sleep(2 * time.Second)
+		return retryErr
 	}
-
 	return resourcePagerDutyTeamRead(d, meta)
 }
 

--- a/pagerduty/resource_pagerduty_team_test.go
+++ b/pagerduty/resource_pagerduty_team_test.go
@@ -87,6 +87,36 @@ func TestAccPagerDutyTeam_Basic(t *testing.T) {
 	})
 }
 
+func TestAccPagerDutyTeam_Parent(t *testing.T) {
+	team := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	parent := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyTeamDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyTeamWithParentConfig(team, parent),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyTeamExists("pagerduty_team.foo"),
+					testAccCheckPagerDutyTeamExists("pagerduty_team.parent"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_team.foo", "name", team),
+					resource.TestCheckResourceAttr(
+						"pagerduty_team.foo", "description", "foo"),
+					resource.TestCheckResourceAttrSet(
+						"pagerduty_team.foo", "html_url"),
+					resource.TestCheckResourceAttrSet(
+						"pagerduty_team.foo", "parent"),			
+					resource.TestCheckResourceAttr(
+						"pagerduty_team.parent", "name", parent),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckPagerDutyTeamDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*pagerduty.Client)
 	for _, r := range s.RootModule().Resources {
@@ -116,6 +146,7 @@ func testAccCheckPagerDutyTeamExists(n string) resource.TestCheckFunc {
 
 func testAccCheckPagerDutyTeamConfig(team string) string {
 	return fmt.Sprintf(`
+
 resource "pagerduty_team" "foo" {
   name        = "%s"
   description = "foo"
@@ -125,7 +156,20 @@ resource "pagerduty_team" "foo" {
 func testAccCheckPagerDutyTeamConfigUpdated(team string) string {
 	return fmt.Sprintf(`
 resource "pagerduty_team" "foo" {
-  name        = "%s"
-  description = "bar"
+	name        = "%s"
+	description = "bar"
 }`, team)
+}
+
+func testAccCheckPagerDutyTeamWithParentConfig(team, parent string) string {
+		return fmt.Sprintf(`
+resource "pagerduty_team" "parent" {
+	name        = "%s"
+	description = "parent"
+}	
+resource "pagerduty_team" "foo" {
+	name        = "%s"
+	description = "foo"
+	parent = pagerduty_team.parent.id
+}`, parent, team)
 }

--- a/pagerduty/resource_pagerduty_team_test.go
+++ b/pagerduty/resource_pagerduty_team_test.go
@@ -108,7 +108,7 @@ func TestAccPagerDutyTeam_Parent(t *testing.T) {
 					resource.TestCheckResourceAttrSet(
 						"pagerduty_team.foo", "html_url"),
 					resource.TestCheckResourceAttrSet(
-						"pagerduty_team.foo", "parent"),			
+						"pagerduty_team.foo", "parent"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_team.parent", "name", parent),
 				),
@@ -162,7 +162,7 @@ resource "pagerduty_team" "foo" {
 }
 
 func testAccCheckPagerDutyTeamWithParentConfig(team, parent string) string {
-		return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "pagerduty_team" "parent" {
 	name        = "%s"
 	description = "parent"

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/team.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/team.go
@@ -8,14 +8,15 @@ type TeamService service
 
 // Team represents a team.
 type Team struct {
-	Description string `json:"description,omitempty"`
-	HTMLURL     string `json:"html_url,omitempty"`
-	ID          string `json:"id,omitempty"`
-	Name        string `json:"name,omitempty"`
-	Self        string `json:"self,omitempty"`
-	Summary     string `json:"summary,omitempty"`
-	Team        *Team  `json:"team,omitempty"`
-	Type        string `json:"type,omitempty"`
+	Description string         `json:"description,omitempty"`
+	HTMLURL     string         `json:"html_url,omitempty"`
+	ID          string         `json:"id,omitempty"`
+	Name        string         `json:"name,omitempty"`
+	Self        string         `json:"self,omitempty"`
+	Summary     string         `json:"summary,omitempty"`
+	Team        *Team          `json:"team,omitempty"`
+	Type        string         `json:"type,omitempty"`
+	Parent      *TeamReference `json:"parent,omitempty"`
 }
 
 // Member represents a team member.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -188,7 +188,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20210309231526-3275f6c029e3
+# github.com/heimweh/go-pagerduty v0.0.0-20210401200608-e772e426d1d0
 ## explicit
 github.com/heimweh/go-pagerduty/pagerduty
 # github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af

--- a/website/docs/d/team.html.markdown
+++ b/website/docs/d/team.html.markdown
@@ -48,5 +48,6 @@ The following arguments are supported:
 * `id` - The ID of the found team.
 * `name` - The name of the found team.
 * `description` - A description of the found team.
+* `parent` - ID of the parent team. This is available to accounts with the Team Hierarchy feature enabled. Please contact your account manager for more information.
 
 [1]: https://v1.developer.pagerduty.com/documentation/rest/teams/list

--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -15,9 +15,15 @@ The account must have the `teams` ability to use the following resource.
 ## Example Usage
 
 ```hcl
+resource "pagerduty_team" "parent" {
+  name        = "Product Development"
+  description = "Product and Engineering
+}
+
 resource "pagerduty_team" "example" {
   name        = "Engineering"
   description = "All engineering"
+  parent      = pagerduty.team.id
 }
 ```
 
@@ -28,6 +34,7 @@ The following arguments are supported:
   * `name` - (Required) The name of the group.
   * `description` - (Optional) A human-friendly description of the team.
     If not set, a placeholder of "Managed by Terraform" will be set.
+  * `parent` - (Optional) ID of the parent team. This is available to accounts with the Team Hierarchy feature enabled. Please contact your account manager for more information.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Even thought I can't spell hierarchy correctly in my branch name, I did add the `parent` field to the `pagerduty_team` resource. This feature is only available to accounts that have the Team Hierarchy feature enabled, and this is noted in the documentation. This was added to the resource as well as the datasource. Here are the test results:

```
TF_ACC=1 go test -run "TestAccPagerDutyTeam" ./pagerduty -v -timeout 120m       
=== RUN   TestAccPagerDutyTeamMembership_import
--- PASS: TestAccPagerDutyTeamMembership_import (6.56s)
=== RUN   TestAccPagerDutyTeamMembership_importWithRole
--- PASS: TestAccPagerDutyTeamMembership_importWithRole (5.99s)
=== RUN   TestAccPagerDutyTeam_import
--- PASS: TestAccPagerDutyTeam_import (3.96s)
=== RUN   TestAccPagerDutyTeamMembership_Basic
--- PASS: TestAccPagerDutyTeamMembership_Basic (5.93s)
=== RUN   TestAccPagerDutyTeamMembership_WithRole
--- PASS: TestAccPagerDutyTeamMembership_WithRole (6.32s)
=== RUN   TestAccPagerDutyTeam_Basic
--- PASS: TestAccPagerDutyTeam_Basic (4.99s)
=== RUN   TestAccPagerDutyTeam_Parent
--- PASS: TestAccPagerDutyTeam_Parent (5.58s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	39.973s
```
Also added the `parent` field to the `pagerduty_team` datasource.
```
TF_ACC=1 go test -run "TestAccDataSourcePagerDutyTeam_Basic" ./pagerduty -v -timeout 120m
=== RUN   TestAccDataSourcePagerDutyTeam_Basic
--- PASS: TestAccDataSourcePagerDutyTeam_Basic (4.44s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	15.835s
```
Addresses: #207


Updated the `resourcePagerDutyResponsePlayUpdate` function to load the `ResponsePlay` object after updating. Here are the test results:

```
TF_ACC=1 go test -run "TestAccPagerDutyResponsePlay" ./pagerduty -v -timeout 120m
=== RUN   TestAccPagerDutyResponsePlay_import
--- PASS: TestAccPagerDutyResponsePlay_import (8.11s)
=== RUN   TestAccPagerDutyResponsePlay_Basic
--- PASS: TestAccPagerDutyResponsePlay_Basic (8.46s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	17.259s
```