### PR TITLE
Suppress Equal Diff on Schedule Layer Timestamps

### DIFF
--- a/pagerduty/resource_pagerduty_schedule.go
+++ b/pagerduty/resource_pagerduty_schedule.go
@@ -182,18 +182,7 @@ func resourcePagerDutyScheduleRead(d *schema.ResourceData, meta interface{}) err
 			d.Set("name", schedule.Name)
 			d.Set("time_zone", schedule.TimeZone)
 			d.Set("description", schedule.Description)
-			// Here we override whatever `start` value we get back from the API
-			// and use what's in the configuration. This is to prevent a diff issue
-			// because we always get back a new `start` value from the PagerDuty API.
-			for _, sl := range schedule.ScheduleLayers {
-				for _, rsl := range d.Get("layer").([]interface{}) {
-					ssl := rsl.(map[string]interface{})
 
-					if sl.ID == ssl["id"].(string) {
-						sl.Start = ssl["start"].(string)
-					}
-				}
-			}
 			layers, err := flattenScheduleLayers(schedule.ScheduleLayers)
 			if err != nil {
 				return resource.NonRetryableError(err)

--- a/pagerduty/resource_pagerduty_schedule.go
+++ b/pagerduty/resource_pagerduty_schedule.go
@@ -57,18 +57,24 @@ func resourcePagerDutySchedule() *schema.Resource {
 						},
 
 						"start": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateFunc:     validateRFC3339,
+							DiffSuppressFunc: suppressRFC3339Diff,
 						},
 
 						"end": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:             schema.TypeString,
+							Optional:         true,
+							ValidateFunc:     validateRFC3339,
+							DiffSuppressFunc: suppressRFC3339Diff,
 						},
 
 						"rotation_virtual_start": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateFunc:     validateRFC3339,
+							DiffSuppressFunc: suppressRFC3339Diff,
 						},
 
 						"rotation_turn_length_seconds": {


### PR DESCRIPTION
This change allows the provider to treat UTC values for the `start`, `rotation_virtual_start`, and `end` fields on `pagerduty_schedule.layer` as equal to the equivalent offset returned by the PagerDuty API. This comes in handy for handling daylight savings.  This change also validates that the timestamps are the proper format as well.

Related issue: #200 

Test output on schedule object

```
 TF_ACC=1 go test -run "TestAccPagerDutySchedule" ./pagerduty -v -timeout 120m 
=== RUN   TestAccPagerDutySchedule_import
--- PASS: TestAccPagerDutySchedule_import (7.16s)
=== RUN   TestAccPagerDutySchedule_Basic
--- PASS: TestAccPagerDutySchedule_Basic (8.21s)
=== RUN   TestAccPagerDutyScheduleOverflow_Basic
--- PASS: TestAccPagerDutyScheduleOverflow_Basic (7.58s)
=== RUN   TestAccPagerDutySchedule_BasicWeek
--- PASS: TestAccPagerDutySchedule_BasicWeek (7.56s)
=== RUN   TestAccPagerDutySchedule_Multi
--- PASS: TestAccPagerDutySchedule_Multi (9.22s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	48.751s
```