### PR TITLE
Fixing numloops Issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go v0.71.0 // indirect
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.7.0
-	github.com/heimweh/go-pagerduty v0.0.0-20210401200608-e772e426d1d0
+	github.com/heimweh/go-pagerduty v0.0.0-20210412205347-cc0e5d3c14d4
 	golang.org/x/tools v0.0.0-20201110124207-079ba7bd75cd // indirect
 	google.golang.org/api v0.35.0 // indirect
 	google.golang.org/genproto v0.0.0-20201109203340-2640f1f9cdfb // indirect

--- a/go.sum
+++ b/go.sum
@@ -240,6 +240,8 @@ github.com/heimweh/go-pagerduty v0.0.0-20210309231526-3275f6c029e3 h1:W26FTjH1Sg
 github.com/heimweh/go-pagerduty v0.0.0-20210309231526-3275f6c029e3/go.mod h1:6+bccpjQ/PM8uQY9m8avM4MJea+3vo3ta9r8kGQ4XFY=
 github.com/heimweh/go-pagerduty v0.0.0-20210401200608-e772e426d1d0 h1:fF/STDApEmPMx5pxXOrliPnWim3K1w0f9Ma06OqrKeI=
 github.com/heimweh/go-pagerduty v0.0.0-20210401200608-e772e426d1d0/go.mod h1:6+bccpjQ/PM8uQY9m8avM4MJea+3vo3ta9r8kGQ4XFY=
+github.com/heimweh/go-pagerduty v0.0.0-20210412205347-cc0e5d3c14d4 h1:uyHgKwTluKHt2ctmyZfdVxECwSqYflYDo+RwyZZEdR0=
+github.com/heimweh/go-pagerduty v0.0.0-20210412205347-cc0e5d3c14d4/go.mod h1:6+bccpjQ/PM8uQY9m8avM4MJea+3vo3ta9r8kGQ4XFY=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/pagerduty/resource_pagerduty_escalation_policy.go
+++ b/pagerduty/resource_pagerduty_escalation_policy.go
@@ -87,9 +87,8 @@ func buildEscalationPolicyStruct(d *schema.ResourceData) *pagerduty.EscalationPo
 		escalationPolicy.Description = attr.(string)
 	}
 
-	if attr, ok := d.GetOk("num_loops"); ok {
-		escalationPolicy.NumLoops = attr.(int)
-	}
+	loops := d.Get("num_loops").(int)
+	escalationPolicy.NumLoops = &loops
 
 	if attr, ok := d.GetOk("teams"); ok {
 		escalationPolicy.Teams = expandTeams(attr.([]interface{}))

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/escalation_policy.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/escalation_policy.go
@@ -21,7 +21,7 @@ type EscalationPolicy struct {
 	HTMLURL          string              `json:"html_url,omitempty"`
 	ID               string              `json:"id,omitempty"`
 	Name             string              `json:"name,omitempty"`
-	NumLoops         int                 `json:"num_loops,omitempty"`
+	NumLoops         *int                `json:"num_loops,omitempty"`
 	RepeatEnabled    bool                `json:"repeat_enabled,omitempty"`
 	Self             string              `json:"self,omitempty"`
 	Services         []*ServiceReference `json:"services,omitempty"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -188,7 +188,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20210401200608-e772e426d1d0
+# github.com/heimweh/go-pagerduty v0.0.0-20210412205347-cc0e5d3c14d4
 ## explicit
 github.com/heimweh/go-pagerduty/pagerduty
 # github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af


### PR DESCRIPTION
This PR fixes the issue referenced in #323 where `pagerduty_escalation_policy.num_loops` could not be unset. Test results are as follows.

```
TF_ACC=1 go test -run "TestAccPagerDutyEscalationPolicy" ./pagerduty -v -timeout 120m
=== RUN   TestAccPagerDutyEscalationPolicy_import
--- PASS: TestAccPagerDutyEscalationPolicy_import (8.03s)
=== RUN   TestAccPagerDutyEscalationPolicy_Basic
--- PASS: TestAccPagerDutyEscalationPolicy_Basic (9.22s)
=== RUN   TestAccPagerDutyEscalationPolicyWithTeams_Basic
--- PASS: TestAccPagerDutyEscalationPolicyWithTeams_Basic (9.23s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	28.098s
```