### PR TITLE
Fix error message for contact method import

### DIFF
--- a/pagerduty/resource_pagerduty_user_contact_method.go
+++ b/pagerduty/resource_pagerduty_user_contact_method.go
@@ -176,7 +176,7 @@ func resourcePagerDutyUserContactMethodImport(d *schema.ResourceData, meta inter
 	ids := strings.Split(d.Id(), ":")
 
 	if len(ids) != 2 {
-		return []*schema.ResourceData{}, fmt.Errorf("Error importing pagerduty_user_contact_method. Expecting an ID formed as '<user_id>.<contact_method_id>'")
+		return []*schema.ResourceData{}, fmt.Errorf("Error importing pagerduty_user_contact_method. Expecting an ID formed as '<user_id>:<contact_method_id>'")
 	}
 	uid, id := ids[0], ids[1]
 


### PR DESCRIPTION
noted while importing that "user_id.contact_method_id" doesn't work but "user_id:contact_method_id" does.