### PR TITLE
Use go1.16 for release task

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.16
       -
         name: Import GPG key
         id: import_gpg


### PR DESCRIPTION
Using go1.16 in the release task will enable a `darwin_arm64` binary to
be built. Allowing terraform projects using this provider to be ran on
new Apple M1 chips.

Closes #297 