### PR TITLE
resource/pagerduty_schedule: suppress spurious start diff

### DIFF
--- a/pagerduty/resource_pagerduty_schedule.go
+++ b/pagerduty/resource_pagerduty_schedule.go
@@ -60,7 +60,7 @@ func resourcePagerDutySchedule() *schema.Resource {
 							Type:             schema.TypeString,
 							Required:         true,
 							ValidateFunc:     validateRFC3339,
-							DiffSuppressFunc: suppressRFC3339Diff,
+							DiffSuppressFunc: suppressScheduleLayerStartDiff,
 						},
 
 						"end": {


### PR DESCRIPTION
Issue: https://github.com/PagerDuty/terraform-provider-pagerduty/issues/200

When both schedule layer start time (the old one read from PagerDuty API, and the new one read
from configuration files) are in the past, there is no need to show Diff as the acutual start
time will be updated by PagerDuty API to current time.

Otherwise, users will have to sync the configuration files from time to time, when they make
irrelevant changes to their schedules (e.g., adding a user) or even no changes at all.