### PR TITLE
Set MinItems: 1 on schedule layers

### DIFF
--- a/pagerduty/resource_pagerduty_schedule.go
+++ b/pagerduty/resource_pagerduty_schedule.go
@@ -85,6 +85,7 @@ func resourcePagerDutySchedule() *schema.Resource {
 						"users": {
 							Type:     schema.TypeList,
 							Required: true,
+							MinItems: 1,
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 							},


### PR DESCRIPTION
Empty users returns a 400 on the PD API.