### PR TITLE
add integration datasource

### DIFF
--- a/pagerduty/data_source_pagerduty_integration.go
+++ b/pagerduty/data_source_pagerduty_integration.go
@@ -1,0 +1,100 @@
+package pagerduty
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+func dataSourcePagerDutyIntegration() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourcePagerDutyIntegrationRead,
+
+		Schema: map[string]*schema.Schema{
+			"service_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"integration_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "examples 'Amazon CloudWatch', 'New Relic",
+			},
+
+			"integration_key": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+		},
+	}
+}
+
+func dataSourcePagerDutyIntegrationRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*pagerduty.Client)
+
+	log.Printf("[INFO] Reading PagerDuty service")
+
+	searchName := d.Get("service_name").(string)
+
+	o := &pagerduty.ListServicesOptions{
+		Query: searchName,
+	}
+
+	return resource.Retry(2*time.Minute, func() *resource.RetryError {
+		resp, _, err := client.Services.List(o)
+		if err != nil {
+			if isErrCode(err, 429) {
+				// Delaying retry by 30s as recommended by PagerDuty
+				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+				time.Sleep(30 * time.Second)
+				return resource.RetryableError(err)
+			}
+
+			return resource.NonRetryableError(err)
+		}
+
+		var found *pagerduty.Service
+
+		for _, service := range resp.Services {
+			if service.Name == searchName {
+				found = service
+				break
+			}
+		}
+
+		if found == nil {
+			return resource.NonRetryableError(
+				fmt.Errorf("Unable to locate any service with the name: %s", searchName),
+			)
+		}
+
+		integrationType := d.Get("integration_type").(string)
+		for _, integration := range found.Integrations {
+			if strings.EqualFold(integration.Summary, integrationType) {
+				integrationDetails, _, err := client.Services.GetIntegration(found.ID, integration.ID, &pagerduty.GetIntegrationOptions{})
+				if err != nil {
+					if isErrCode(err, 429) {
+						time.Sleep(30 * time.Second)
+						return resource.RetryableError(err)
+					}
+					return resource.NonRetryableError(err)
+				}
+				d.SetId(integration.ID)
+				d.Set("service_name", found.Name)
+				d.Set("integration_key", integrationDetails.IntegrationKey)
+
+				return nil
+			}
+
+		}
+		return resource.NonRetryableError(
+			fmt.Errorf("Unable to locate any integration of type %s on service %s", integrationType, searchName),
+		)
+	})
+}

--- a/pagerduty/data_source_pagerduty_integration.go
+++ b/pagerduty/data_source_pagerduty_integration.go
@@ -49,14 +49,7 @@ func dataSourcePagerDutyIntegrationRead(d *schema.ResourceData, meta interface{}
 	return resource.Retry(2*time.Minute, func() *resource.RetryError {
 		resp, _, err := client.Services.List(o)
 		if err != nil {
-			if isErrCode(err, 429) {
-				// Delaying retry by 30s as recommended by PagerDuty
-				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-				time.Sleep(30 * time.Second)
-				return resource.RetryableError(err)
-			}
-
-			return resource.NonRetryableError(err)
+			return handleError(err)
 		}
 
 		var found *pagerduty.Service
@@ -79,11 +72,7 @@ func dataSourcePagerDutyIntegrationRead(d *schema.ResourceData, meta interface{}
 			if strings.EqualFold(integration.Summary, integrationType) {
 				integrationDetails, _, err := client.Services.GetIntegration(found.ID, integration.ID, &pagerduty.GetIntegrationOptions{})
 				if err != nil {
-					if isErrCode(err, 429) {
-						time.Sleep(30 * time.Second)
-						return resource.RetryableError(err)
-					}
-					return resource.NonRetryableError(err)
+					return handleError(err)
 				}
 				d.SetId(integration.ID)
 				d.Set("service_name", found.Name)
@@ -94,7 +83,16 @@ func dataSourcePagerDutyIntegrationRead(d *schema.ResourceData, meta interface{}
 
 		}
 		return resource.NonRetryableError(
-			fmt.Errorf("Unable to locate any integration of type %s on service %s", integrationType, searchName),
+			fmt.Errorf("unable to locate any integration of type %s on service %s", integrationType, searchName),
 		)
 	})
+}
+
+func handleError(err error) *resource.RetryError {
+	if isErrCode(err, 429) {
+		time.Sleep(30 * time.Second)
+		return resource.RetryableError(err)
+	}
+
+	return resource.NonRetryableError(err)
 }

--- a/pagerduty/data_source_pagerduty_service_integration.go
+++ b/pagerduty/data_source_pagerduty_service_integration.go
@@ -11,9 +11,9 @@ import (
 	"github.com/heimweh/go-pagerduty/pagerduty"
 )
 
-func dataSourcePagerDutyIntegration() *schema.Resource {
+func dataSourcePagerDutyServiceIntegration() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourcePagerDutyIntegrationRead,
+		Read: dataSourcePagerDutyServiceIntegrationRead,
 
 		Schema: map[string]*schema.Schema{
 			"service_name": {
@@ -35,7 +35,7 @@ func dataSourcePagerDutyIntegration() *schema.Resource {
 	}
 }
 
-func dataSourcePagerDutyIntegrationRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourcePagerDutyServiceIntegrationRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*pagerduty.Client)
 
 	log.Printf("[INFO] Reading PagerDuty service")

--- a/pagerduty/data_source_pagerduty_service_integration.go
+++ b/pagerduty/data_source_pagerduty_service_integration.go
@@ -63,7 +63,7 @@ func dataSourcePagerDutyIntegrationRead(d *schema.ResourceData, meta interface{}
 
 		if found == nil {
 			return resource.NonRetryableError(
-				fmt.Errorf("Unable to locate any service with the name: %s", searchName),
+				fmt.Errorf("unable to locate any service with the name: %s", searchName),
 			)
 		}
 

--- a/pagerduty/data_source_pagerduty_service_integration.go
+++ b/pagerduty/data_source_pagerduty_service_integration.go
@@ -20,7 +20,7 @@ func dataSourcePagerDutyIntegration() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"integration_type": {
+			"integration_summary": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "examples 'Amazon CloudWatch', 'New Relic",
@@ -67,9 +67,9 @@ func dataSourcePagerDutyIntegrationRead(d *schema.ResourceData, meta interface{}
 			)
 		}
 
-		integrationType := d.Get("integration_type").(string)
+		integrationSummary := d.Get("integration_summary").(string)
 		for _, integration := range found.Integrations {
-			if strings.EqualFold(integration.Summary, integrationType) {
+			if strings.EqualFold(integration.Summary, integrationSummary) {
 				integrationDetails, _, err := client.Services.GetIntegration(found.ID, integration.ID, &pagerduty.GetIntegrationOptions{})
 				if err != nil {
 					return handleError(err)
@@ -83,7 +83,7 @@ func dataSourcePagerDutyIntegrationRead(d *schema.ResourceData, meta interface{}
 
 		}
 		return resource.NonRetryableError(
-			fmt.Errorf("unable to locate any integration of type %s on service %s", integrationType, searchName),
+			fmt.Errorf("unable to locate any integration of type %s on service %s", integrationSummary, searchName),
 		)
 	})
 }

--- a/pagerduty/data_source_pagerduty_service_integration_test.go
+++ b/pagerduty/data_source_pagerduty_service_integration_test.go
@@ -22,7 +22,6 @@ func TestAccDataSourcePagerDutyIntegration_Basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourcePagerDutyIntegrationConfigStep1(service, serviceIntegration, email, escalationPolicy),
-				//Destroy: false,
 				Check: func(state *terraform.State) error {
 					resource.Test(t, resource.TestCase{
 						Providers: testAccProviders,

--- a/pagerduty/data_source_pagerduty_service_integration_test.go
+++ b/pagerduty/data_source_pagerduty_service_integration_test.go
@@ -1,0 +1,132 @@
+package pagerduty
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccDataSourcePagerDutyIntegration_Basic(t *testing.T) {
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.com", username)
+	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	serviceIntegration := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourcePagerDutyIntegrationConfigStep1(username, email, service, escalationPolicy, serviceIntegration),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourcePagerDutyIntegration("pagerduty_service.test", "data.pagerduty_service.by_name"),
+				),
+			},
+			{
+				Config: testAccDataSourcePagerDutyIntegrationConfigStep2(service, serviceIntegration),
+				Check:  verifyOutput("output_id"),
+			},
+		},
+	})
+}
+
+func verifyOutput(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		ms := s.RootModule()
+		rs, ok := ms.Outputs[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		if rs.Type != "string" {
+			return fmt.Errorf("expected an error: %#v", rs)
+		}
+
+		return nil
+	}
+}
+
+func testAccDataSourcePagerDutyIntegration(src, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		srcR := s.RootModule().Resources[src]
+		srcA := srcR.Primary.Attributes
+
+		r := s.RootModule().Resources[n]
+		a := r.Primary.Attributes
+
+		if a["id"] == "" {
+			return fmt.Errorf("expected to get a service ID from PagerDuty")
+		}
+
+		testAtts := []string{"id", "name"}
+
+		for _, att := range testAtts {
+			if a[att] != srcA[att] {
+				return fmt.Errorf("Expected the service %s to be: %s, but got: %s", att, srcA[att], a[att])
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccDataSourcePagerDutyIntegrationConfigStep1(username, email, service, escalationPolicy, serviceIntegration string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "test" {
+  name  = "%s"
+  email = "%s"
+}
+
+resource "pagerduty_service" "test" {
+  name                    = "%s"
+  auto_resolve_timeout    = 14400
+  acknowledgement_timeout = 600
+  escalation_policy       = pagerduty_escalation_policy.test.id
+  alert_creation          = "create_incidents"
+}
+
+resource "pagerduty_escalation_policy" "test" {
+  name        = "%s"
+  num_loops   = 2
+  rule {
+    escalation_delay_in_minutes = 10
+    target {
+      type = "user_reference"
+      id   = pagerduty_user.test.id
+    }
+  }
+}
+
+resource "pagerduty_service_integration" "foo" {
+  name    = "%s"
+  service = pagerduty_service.test.id
+  vendor  = data.pagerduty_vendor.datadog.id
+}
+
+data "pagerduty_vendor" "datadog" {
+  name = "datadog"
+}
+
+data "pagerduty_service" "by_name" {
+ name = pagerduty_service.test.name
+}
+`, username, email, service, escalationPolicy, serviceIntegration)
+}
+
+func testAccDataSourcePagerDutyIntegrationConfigStep2(service, serviceIntegration string) string {
+	return fmt.Sprintf(`
+data "pagerduty_service_integration" "service_integration" {
+  service_name = "%s"
+  integration_type = "%s"
+}
+
+output "output_id" {
+  value = data.pagerduty_service_integration.service_integration.integration_key
+}
+`, service, serviceIntegration)
+}

--- a/pagerduty/provider.go
+++ b/pagerduty/provider.go
@@ -36,7 +36,7 @@ func Provider() terraform.ResourceProvider {
 			"pagerduty_vendor":              dataSourcePagerDutyVendor(),
 			"pagerduty_extension_schema":    dataSourcePagerDutyExtensionSchema(),
 			"pagerduty_service":             dataSourcePagerDutyService(),
-			"pagerduty_service_integration": dataSourcePagerDutyIntegration(),
+			"pagerduty_service_integration": dataSourcePagerDutyServiceIntegration(),
 			"pagerduty_business_service":    dataSourcePagerDutyBusinessService(),
 			"pagerduty_priority":            dataSourcePagerDutyPriority(),
 			"pagerduty_ruleset":             dataSourcePagerDutyRuleset(),

--- a/pagerduty/provider.go
+++ b/pagerduty/provider.go
@@ -36,7 +36,7 @@ func Provider() terraform.ResourceProvider {
 			"pagerduty_vendor":              dataSourcePagerDutyVendor(),
 			"pagerduty_extension_schema":    dataSourcePagerDutyExtensionSchema(),
 			"pagerduty_service":             dataSourcePagerDutyService(),
-			"pagerduty_integration":         dataSourcePagerDutyIntegration(),
+			"pagerduty_service_integration": dataSourcePagerDutyIntegration(),
 			"pagerduty_business_service":    dataSourcePagerDutyBusinessService(),
 			"pagerduty_priority":            dataSourcePagerDutyPriority(),
 			"pagerduty_ruleset":             dataSourcePagerDutyRuleset(),

--- a/pagerduty/provider.go
+++ b/pagerduty/provider.go
@@ -36,6 +36,7 @@ func Provider() terraform.ResourceProvider {
 			"pagerduty_vendor":              dataSourcePagerDutyVendor(),
 			"pagerduty_extension_schema":    dataSourcePagerDutyExtensionSchema(),
 			"pagerduty_service":             dataSourcePagerDutyService(),
+			"pagerduty_integration":         dataSourcePagerDutyIntegration(),
 			"pagerduty_business_service":    dataSourcePagerDutyBusinessService(),
 			"pagerduty_priority":            dataSourcePagerDutyPriority(),
 			"pagerduty_ruleset":             dataSourcePagerDutyRuleset(),

--- a/website/docs/d/service_integration.html.markdown
+++ b/website/docs/d/service_integration.html.markdown
@@ -1,0 +1,30 @@
+---
+layout: "pagerduty"
+page_title: "PagerDuty: pagerduty_service_integration"
+sidebar_current: "docs-pagerduty-datasource-service_integration"
+description: |-
+  Get information about a service integration.
+---
+
+# pagerduty\_service\_integration
+
+Use this data source to get information about a specific service_integration.
+
+## Example Usage
+
+```hcl
+data "pagerduty_service_integration" "example" {
+  service_name = "My Service"
+  integration_summary = "Datadog"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_name` - (Required) The service name to use to find a service in the PagerDuty API.
+* `integration_summary` - (Required) The integration summary used to find the desired integration on the service
+
+## Attributes Reference
+* `integration_key` - The integration key for the integration. This can be used to configure alerts.

--- a/website/pagerduty.erb
+++ b/website/pagerduty.erb
@@ -34,6 +34,9 @@
                 <li<%= sidebar_current("docs-pagerduty-datasource-service") %>>
                     <a href="/docs/providers/pagerduty/d/service.html">pagerduty_service</a>
                 </li>
+                <li<%= sidebar_current("docs-pagerduty-datasource-service-integration") %>>
+                    <a href="/docs/providers/pagerduty/d/service_integration.html">pagerduty_service_integration</a>
+                </li>
                 <li<%= sidebar_current("docs-pagerduty-datasource-user") %>>
                     <a href="/docs/providers/pagerduty/d/user.html">pagerduty_user</a>
                 </li>
@@ -75,7 +78,7 @@
                 </li>
                 <li<%= sidebar_current("docs-pagerduty-resource-response-play") %>>
                     <a href="/docs/providers/pagerduty/r/response_play.html">pagerduty_response_play</a>
-                </li>                
+                </li>
                 <li<%= sidebar_current("docs-pagerduty-resource-ruleset") %>>
                     <a href="/docs/providers/pagerduty/r/ruleset.html">pagerduty_ruleset</a>
                 </li>
@@ -87,7 +90,7 @@
                 </li>
                 <li<%= sidebar_current("docs-pagerduty-resource-service") %>>
                     <a href="/docs/providers/pagerduty/r/service.html">pagerduty_service</a>
-                </li>                
+                </li>
                 <li<%= sidebar_current("docs-pagerduty-resource-service-event-rule") %>>
                     <a href="/docs/providers/pagerduty/r/serve_event_rule.html">pagerduty_service_event_rule</a>
                 </li>


### PR DESCRIPTION
This PR adds support for `data.pagerduty_service_integration` so that integration keys can be fetched from PagerDuty when configuring alerts from third party systems in Terraform

Example usage:
```hcl
data "pagerduty_integration" pdint {
  service_name = "my-service-name"
  integration_summary = "Amazon CloudWatch"
}
```