### PR TITLE
Add type as computed attributes to service & business_service data sources + resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ Building The Provider
 Clone repository to: `$GOPATH/src/github.com/terraform-providers/terraform-provider-pagerduty`
 
 ```sh
-$ mkdir -p $GOPATH/src/github.com/terraform-providers; cd $GOPATH/src/github.com/terraform-providers
-$ git clone git@github.com:terraform-providers/terraform-provider-pagerduty
+$ mkdir -p $GOPATH/src/github.com/PagerDuty; cd $GOPATH/src/github.com/PagerDuty
+$ git clone git@github.com:PagerDuty/terraform-provider-pagerduty
 ```
 
 Enter the provider directory and build the provider
 
 ```sh
-$ cd $GOPATH/src/github.com/terraform-providers/terraform-provider-pagerduty
+$ cd $GOPATH/src/github.com/PagerDuty/terraform-provider-pagerduty
 $ make build
 ```
 

--- a/pagerduty/data_source_pagerduty_business_service.go
+++ b/pagerduty/data_source_pagerduty_business_service.go
@@ -19,7 +19,7 @@ func dataSourcePagerDutyBusinessService() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"dependency_type": {
+			"type": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -64,7 +64,7 @@ func dataSourcePagerDutyBusinessServiceRead(d *schema.ResourceData, meta interfa
 
 		d.SetId(found.ID)
 		d.Set("name", found.Name)
-		d.Set("dependency_type", found.Type)
+		d.Set("type", found.Type)
 
 		return nil
 	})

--- a/pagerduty/data_source_pagerduty_business_service.go
+++ b/pagerduty/data_source_pagerduty_business_service.go
@@ -19,6 +19,10 @@ func dataSourcePagerDutyBusinessService() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -60,6 +64,7 @@ func dataSourcePagerDutyBusinessServiceRead(d *schema.ResourceData, meta interfa
 
 		d.SetId(found.ID)
 		d.Set("name", found.Name)
+		d.Set("type", found.Type)
 
 		return nil
 	})

--- a/pagerduty/data_source_pagerduty_business_service.go
+++ b/pagerduty/data_source_pagerduty_business_service.go
@@ -19,7 +19,7 @@ func dataSourcePagerDutyBusinessService() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"type": {
+			"dependency_type": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -64,7 +64,7 @@ func dataSourcePagerDutyBusinessServiceRead(d *schema.ResourceData, meta interfa
 
 		d.SetId(found.ID)
 		d.Set("name", found.Name)
-		d.Set("type", found.Type)
+		d.Set("dependency_type", found.Type)
 
 		return nil
 	})

--- a/pagerduty/data_source_pagerduty_service.go
+++ b/pagerduty/data_source_pagerduty_service.go
@@ -19,6 +19,10 @@ func dataSourcePagerDutyService() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -64,6 +68,7 @@ func dataSourcePagerDutyServiceRead(d *schema.ResourceData, meta interface{}) er
 
 		d.SetId(found.ID)
 		d.Set("name", found.Name)
+		d.Set("type", found.Type)
 
 		return nil
 	})

--- a/pagerduty/data_source_pagerduty_service.go
+++ b/pagerduty/data_source_pagerduty_service.go
@@ -19,7 +19,7 @@ func dataSourcePagerDutyService() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"type": {
+			"dependency_type": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -68,7 +68,7 @@ func dataSourcePagerDutyServiceRead(d *schema.ResourceData, meta interface{}) er
 
 		d.SetId(found.ID)
 		d.Set("name", found.Name)
-		d.Set("type", found.Type)
+		d.Set("dependency_type", found.Type)
 
 		return nil
 	})

--- a/pagerduty/data_source_pagerduty_service.go
+++ b/pagerduty/data_source_pagerduty_service.go
@@ -19,7 +19,7 @@ func dataSourcePagerDutyService() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"dependency_type": {
+			"type": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -68,7 +68,7 @@ func dataSourcePagerDutyServiceRead(d *schema.ResourceData, meta interface{}) er
 
 		d.SetId(found.ID)
 		d.Set("name", found.Name)
-		d.Set("dependency_type", found.Type)
+		d.Set("type", found.Type)
 
 		return nil
 	})

--- a/pagerduty/resource_pagerduty_business_service.go
+++ b/pagerduty/resource_pagerduty_business_service.go
@@ -41,12 +41,12 @@ func resourcePagerDutyBusinessService() *schema.Resource {
 				Computed: true,
 			},
 			"type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "business_service",
+				Type:       schema.TypeString,
+				Optional:   true,
+				Default:    "business_service",
+				Deprecated: "This will change to a computed resource in the next major release.",
 				ValidateFunc: validateValueFunc([]string{
 					"business_service",
-					"business_service_reference",
 				}),
 			},
 			"point_of_contact": {
@@ -56,10 +56,6 @@ func resourcePagerDutyBusinessService() *schema.Resource {
 			"team": {
 				Type:     schema.TypeString,
 				Optional: true,
-			},
-			"dependency_type": {
-				Type:     schema.TypeString,
-				Computed: true,
 			},
 		},
 	}
@@ -134,7 +130,6 @@ func resourcePagerDutyBusinessServiceRead(d *schema.ResourceData, meta interface
 			d.Set("html_url", businessService.HTMLUrl)
 			d.Set("description", businessService.Description)
 			d.Set("type", businessService.Type)
-			d.Set("dependency_type", businessService.Type)
 			d.Set("point_of_contact", businessService.PointOfContact)
 			d.Set("summary", businessService.Summary)
 			d.Set("self", businessService.Self)

--- a/pagerduty/resource_pagerduty_business_service.go
+++ b/pagerduty/resource_pagerduty_business_service.go
@@ -57,6 +57,10 @@ func resourcePagerDutyBusinessService() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"dependency_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -130,6 +134,7 @@ func resourcePagerDutyBusinessServiceRead(d *schema.ResourceData, meta interface
 			d.Set("html_url", businessService.HTMLUrl)
 			d.Set("description", businessService.Description)
 			d.Set("type", businessService.Type)
+			d.Set("dependency_type", businessService.Type)
 			d.Set("point_of_contact", businessService.PointOfContact)
 			d.Set("summary", businessService.Summary)
 			d.Set("self", businessService.Self)

--- a/pagerduty/resource_pagerduty_business_service_test.go
+++ b/pagerduty/resource_pagerduty_business_service_test.go
@@ -71,6 +71,8 @@ func TestAccPagerDutyBusinessService_Basic(t *testing.T) {
 						"pagerduty_business_service.foo", "point_of_contact", pointOfContact),
 					resource.TestCheckResourceAttrSet(
 						"pagerduty_business_service.foo", "self"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_business_service.foo", "dependency_type", pointOfContact),
 				),
 			},
 			{

--- a/pagerduty/resource_pagerduty_business_service_test.go
+++ b/pagerduty/resource_pagerduty_business_service_test.go
@@ -72,7 +72,7 @@ func TestAccPagerDutyBusinessService_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(
 						"pagerduty_business_service.foo", "self"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_business_service.foo", "dependency_type", pointOfContact),
+						"pagerduty_business_service.foo", "dependency_type", "business_service"),
 				),
 			},
 			{

--- a/pagerduty/resource_pagerduty_business_service_test.go
+++ b/pagerduty/resource_pagerduty_business_service_test.go
@@ -72,7 +72,7 @@ func TestAccPagerDutyBusinessService_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(
 						"pagerduty_business_service.foo", "self"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_business_service.foo", "dependency_type", "business_service"),
+						"pagerduty_business_service.foo", "type", "business_service"),
 				),
 			},
 			{

--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -269,6 +269,10 @@ func resourcePagerDutyService() *schema.Resource {
 					},
 				},
 			},
+			"dependency_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -434,6 +438,7 @@ func resourcePagerDutyServiceDelete(d *schema.ResourceData, meta interface{}) er
 
 func flattenService(d *schema.ResourceData, service *pagerduty.Service) error {
 	d.Set("name", service.Name)
+	d.Set("dependency_type", service.Type)
 	d.Set("html_url", service.HTMLURL)
 	d.Set("status", service.Status)
 	d.Set("created_at", service.CreatedAt)

--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -269,7 +269,7 @@ func resourcePagerDutyService() *schema.Resource {
 					},
 				},
 			},
-			"dependency_type": {
+			"type": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -438,7 +438,7 @@ func resourcePagerDutyServiceDelete(d *schema.ResourceData, meta interface{}) er
 
 func flattenService(d *schema.ResourceData, service *pagerduty.Service) error {
 	d.Set("name", service.Name)
-	d.Set("dependency_type", service.Type)
+	d.Set("type", service.Type)
 	d.Set("html_url", service.HTMLURL)
 	d.Set("status", service.Status)
 	d.Set("created_at", service.CreatedAt)

--- a/pagerduty/resource_pagerduty_service_test.go
+++ b/pagerduty/resource_pagerduty_service_test.go
@@ -87,7 +87,7 @@ func TestAccPagerDutyService_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(
 						"pagerduty_service.foo", "html_url"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "dependency_type", "service"),
+						"pagerduty_service.foo", "type", "service"),
 				),
 			},
 			{

--- a/pagerduty/resource_pagerduty_service_test.go
+++ b/pagerduty/resource_pagerduty_service_test.go
@@ -86,6 +86,8 @@ func TestAccPagerDutyService_Basic(t *testing.T) {
 						"pagerduty_service.foo", "incident_urgency_rule.0.type", "constant"),
 					resource.TestCheckResourceAttrSet(
 						"pagerduty_service.foo", "html_url"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "dependency_type", "service"),
 				),
 			},
 			{

--- a/website/docs/d/business_service.html.markdown
+++ b/website/docs/d/business_service.html.markdown
@@ -27,5 +27,6 @@ The following arguments are supported:
 ## Attributes Reference
 * `id` - The ID of the found business service.
 * `name` - The short name of the found business service.
+* `dependency_type` - The type for passing to a service dependency.
 
 [1]: https://api-reference.pagerduty.com/#!/Business_Services/get_business_services

--- a/website/docs/d/business_service.html.markdown
+++ b/website/docs/d/business_service.html.markdown
@@ -27,6 +27,6 @@ The following arguments are supported:
 ## Attributes Reference
 * `id` - The ID of the found business service.
 * `name` - The short name of the found business service.
-* `type` - The type for passing to a service dependency.
+* `type` - The type of object. The value returned will be `business_service`. Can be used for passing to a service dependency.
 
-[1]: https://api-reference.pagerduty.com/#!/Business_Services/get_business_services
+* [1]: https://api-reference.pagerduty.com/#!/Business_Services/get_business_services

--- a/website/docs/d/business_service.html.markdown
+++ b/website/docs/d/business_service.html.markdown
@@ -27,6 +27,6 @@ The following arguments are supported:
 ## Attributes Reference
 * `id` - The ID of the found business service.
 * `name` - The short name of the found business service.
-* `dependency_type` - The type for passing to a service dependency.
+* `type` - The type for passing to a service dependency.
 
 [1]: https://api-reference.pagerduty.com/#!/Business_Services/get_business_services

--- a/website/docs/d/service.html.markdown
+++ b/website/docs/d/service.html.markdown
@@ -39,6 +39,6 @@ The following arguments are supported:
 
 * `id` - The ID of the found service.
 * `name` - The short name of the found service.
-* `dependency_type` - The type for passing to a service dependency.
+* `type` - The type for passing to a service dependency.
 
 [1]: https://api-reference.pagerduty.com/#!/Services/get_services

--- a/website/docs/d/service.html.markdown
+++ b/website/docs/d/service.html.markdown
@@ -39,5 +39,6 @@ The following arguments are supported:
 
 * `id` - The ID of the found service.
 * `name` - The short name of the found service.
+* `dependency_type` - The type for passing to a service dependency.
 
 [1]: https://api-reference.pagerduty.com/#!/Services/get_services

--- a/website/docs/d/service.html.markdown
+++ b/website/docs/d/service.html.markdown
@@ -39,6 +39,6 @@ The following arguments are supported:
 
 * `id` - The ID of the found service.
 * `name` - The short name of the found service.
-* `type` - The type for passing to a service dependency.
+* `type` - The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
 
 [1]: https://api-reference.pagerduty.com/#!/Services/get_services

--- a/website/docs/r/business_service.html.markdown
+++ b/website/docs/r/business_service.html.markdown
@@ -30,7 +30,7 @@ The following arguments are supported:
   * `description` - (Optional) A human-friendly description of the service.
     If not set, a placeholder of "Managed by Terraform" will be set.
   * `point_of_contact` - (Optional) The owner of the business service. 
-  * `type` - (Optional) Default value is `business_service`. Can also be set as `business_service_reference`.
+  * `type` - **Deprecated** (Optional) Default (and only supported) value is `business_service`.
   * `team` - (Optional) ID of the team that owns the business service.
   
 ## Attributes Reference
@@ -41,7 +41,6 @@ The following attributes are exported:
   * `summary`- A short-form, server-generated string that provides succinct, important information about an object suitable for primary labeling of an entity in a client. In many cases, this will be identical to `name`, though it is not intended to be an identifier.
   * `html_url`- A URL at which the entity is uniquely displayed in the Web app.
   * `self`- The API show URL at which the object is accessible.
-  * `dependency_type` - The type for passing to a service dependency.
 
 ## Import
 

--- a/website/docs/r/business_service.html.markdown
+++ b/website/docs/r/business_service.html.markdown
@@ -41,6 +41,7 @@ The following attributes are exported:
   * `summary`- A short-form, server-generated string that provides succinct, important information about an object suitable for primary labeling of an entity in a client. In many cases, this will be identical to `name`, though it is not intended to be an identifier.
   * `html_url`- A URL at which the entity is uniquely displayed in the Web app.
   * `self`- The API show URL at which the object is accessible.
+  * `dependency_type` - The type for passing to a service dependency.
 
 ## Import
 

--- a/website/docs/r/service.html.markdown
+++ b/website/docs/r/service.html.markdown
@@ -154,7 +154,7 @@ The following attributes are exported:
   * `created_at`- Creation timestamp of the service.
   * `status`- The status of the service.
   * `html_url`- URL at which the entity is uniquely displayed in the Web app.
-  * `type` - The type for passing to a service dependency.
+  * `type` - The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
 
 ## Import
 

--- a/website/docs/r/service.html.markdown
+++ b/website/docs/r/service.html.markdown
@@ -154,6 +154,7 @@ The following attributes are exported:
   * `created_at`- Creation timestamp of the service.
   * `status`- The status of the service.
   * `html_url`- URL at which the entity is uniquely displayed in the Web app.
+  * `dependency_type` - The type for passing to a service dependency.
 
 ## Import
 

--- a/website/docs/r/service.html.markdown
+++ b/website/docs/r/service.html.markdown
@@ -154,7 +154,7 @@ The following attributes are exported:
   * `created_at`- Creation timestamp of the service.
   * `status`- The status of the service.
   * `html_url`- URL at which the entity is uniquely displayed in the Web app.
-  * `dependency_type` - The type for passing to a service dependency.
+  * `type` - The type for passing to a service dependency.
 
 ## Import
 

--- a/website/docs/r/service_dependency.html.markdown
+++ b/website/docs/r/service_dependency.html.markdown
@@ -18,11 +18,11 @@ resource "pagerduty_service_dependency" "foo" {
 	dependency {
 		dependent_service {
 			id = pagerduty_business_service.foo.id
-			type = pagerduty_business_service.foo.dependency_type
+			type = pagerduty_business_service.foo.type
 		}
 		supporting_service {
 			id = pagerduty_service.foo.id
-			type = pagerduty_service.foo.dependency_type
+			type = pagerduty_service.foo.type
 		}
 	}
 }
@@ -31,11 +31,11 @@ resource "pagerduty_service_dependency" "bar" {
 	dependency {
 		dependent_service {
 			id = pagerduty_business_service.foo.id
-			type = pagerduty_business_service.foo.dependency_type
+			type = pagerduty_business_service.foo.type
 		}
 		supporting_service {
 			id = pagerduty_service.two.id
-			type = pagerduty_service.two.dependency_type
+			type = pagerduty_service.two.type
 		}
 	}
 }

--- a/website/docs/r/service_dependency.html.markdown
+++ b/website/docs/r/service_dependency.html.markdown
@@ -18,11 +18,11 @@ resource "pagerduty_service_dependency" "foo" {
 	dependency {
 		dependent_service {
 			id = pagerduty_business_service.foo.id
-			type = "business_service"
+			type = pagerduty_business_service.foo.dependency_type
 		}
 		supporting_service {
 			id = pagerduty_service.foo.id
-			type = "service"
+			type = pagerduty_service.foo.dependency_type
 		}
 	}
 }
@@ -31,11 +31,11 @@ resource "pagerduty_service_dependency" "bar" {
 	dependency {
 		dependent_service {
 			id = pagerduty_business_service.foo.id
-			type = "business_service"
+			type = pagerduty_business_service.foo.dependency_type
 		}
 		supporting_service {
 			id = pagerduty_service.two.id
-			type = "service"
+			type = pagerduty_service.two.dependency_type
 		}
 	}
 }


### PR DESCRIPTION
As was discussed on this weeks PagerDuty Terraform round table, raising a PR to add a `dependency_type` commuted attribute for the following:

- `data pagerduty_service`
- `data pagerduty_business_service`
- `resource pagerduty_service`
- `pagerduty_business_service`

Also a correct the repo name in the README, as the repo is now owned by PagerDuty.

**ToDo:**
- [x] Update docs
- [x] Update tests.