### PR TITLE
Add optional base_url configuration

### DIFF
--- a/pagerduty/config.go
+++ b/pagerduty/config.go
@@ -14,6 +14,9 @@ type Config struct {
 	// The PagerDuty API URL
 	ApiUrl string
 
+	// Override default PagerDuty API URL
+	ApiUrlOverride string
+
 	// The PagerDuty APP URL
 	AppUrl string
 
@@ -48,8 +51,13 @@ func (c *Config) Client() (*pagerduty.Client, error) {
 	httpClient = http.DefaultClient
 	httpClient.Transport = logging.NewTransport("PagerDuty", http.DefaultTransport)
 
+	var apiUrl = c.ApiUrl
+	if c.ApiUrlOverride != "" {
+		apiUrl = c.ApiUrlOverride
+	}
+
 	config := &pagerduty.Config{
-		BaseURL:    c.ApiUrl,
+		BaseURL:    apiUrl,
 		Debug:      logging.IsDebugOrHigher(),
 		HTTPClient: httpClient,
 		Token:      c.Token,

--- a/pagerduty/config_test.go
+++ b/pagerduty/config_test.go
@@ -40,6 +40,19 @@ func TestConfigCustomApiUrl(t *testing.T) {
 	}
 }
 
+// Test config with a custom ApiUrl override
+func TestConfigCustomApiUrlOverride(t *testing.T) {
+	config := Config{
+		Token:               "foo",
+		ApiUrlOverride:      "https://api.domain-override.tld",
+		SkipCredsValidation: true,
+	}
+
+	if _, err := config.Client(); err != nil {
+		t.Fatalf("error: expected the client to not fail: %v", err)
+	}
+}
+
 // Test config with a custom AppUrl
 func TestConfigCustomAppUrl(t *testing.T) {
 	config := Config{

--- a/pagerduty/provider.go
+++ b/pagerduty/provider.go
@@ -37,6 +37,12 @@ func Provider() *schema.Provider {
 				Optional: true,
 				Default:  "",
 			},
+
+			"api_url_override": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
@@ -131,6 +137,7 @@ func providerConfigure(data *schema.ResourceData, terraformVersion string) (inte
 		Token:               data.Get("token").(string),
 		UserToken:           data.Get("user_token").(string),
 		UserAgent:           fmt.Sprintf("(%s %s) Terraform/%s", runtime.GOOS, runtime.GOARCH, terraformVersion),
+		ApiUrlOverride:      data.Get("api_url_override").(string),
 	}
 
 	log.Println("[INFO] Initializing PagerDuty client")

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -47,3 +47,4 @@ The following arguments are supported:
 * `user_token` - (Optional) The v2 user level authorization token. It can also be sourced from the PAGERDUTY_USER_TOKEN environment variable. See [API Documentation](https://developer.pagerduty.com/docs/rest-api-v2/authentication/) for more information.
 * `skip_credentials_validation` - (Optional) Skip validation of the token against the PagerDuty API.
 * `service_region` - (Optional) The PagerDuty service region to use. Default to empty (uses US region). Supported value: `eu`.
+* `api_url_override` - (Optional) It can be used to set a custom proxy endpoint as PagerDuty client api url overriding `service_region` setup.


### PR DESCRIPTION
This pr adds the optional `base_url` configuration argument that is passed to the API client. 

```terraform
provider "pagerduty" {
  token     = "xxxxxxxxxxxx"
  base_url  = "https://custom-cache-proxy.com"
}
```