### PR TITLE
Added teams to Schedule resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go v0.71.0 // indirect
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.7.0
-	github.com/heimweh/go-pagerduty v0.0.0-20210727215404-3da4ffdbaa95
+	github.com/heimweh/go-pagerduty v0.0.0-20210810155842-7de939d717c0
 	go.mongodb.org/mongo-driver v1.7.0 // indirect
 	golang.org/x/tools v0.0.0-20201110124207-079ba7bd75cd // indirect
 	google.golang.org/api v0.35.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -209,6 +209,8 @@ github.com/heimweh/go-pagerduty v0.0.0-20210605042823-5a9026c44cb2 h1:ZHlT48cTcm
 github.com/heimweh/go-pagerduty v0.0.0-20210605042823-5a9026c44cb2/go.mod h1:6+bccpjQ/PM8uQY9m8avM4MJea+3vo3ta9r8kGQ4XFY=
 github.com/heimweh/go-pagerduty v0.0.0-20210727215404-3da4ffdbaa95 h1:Urqoj46k8QuRBMWUB/CoWjygFZpKiMm4I96eSJCZ/x8=
 github.com/heimweh/go-pagerduty v0.0.0-20210727215404-3da4ffdbaa95/go.mod h1:6+bccpjQ/PM8uQY9m8avM4MJea+3vo3ta9r8kGQ4XFY=
+github.com/heimweh/go-pagerduty v0.0.0-20210810155842-7de939d717c0 h1:F3c5KAaStFpCvNWo8x0mniARDa0D16hIkfw6chMqTRI=
+github.com/heimweh/go-pagerduty v0.0.0-20210810155842-7de939d717c0/go.mod h1:6+bccpjQ/PM8uQY9m8avM4MJea+3vo3ta9r8kGQ4XFY=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/schedule.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/schedule.go
@@ -33,6 +33,7 @@ type Schedule struct {
 	TimeZone             string                       `json:"time_zone,omitempty"`
 	Type                 string                       `json:"type,omitempty"`
 	Users                []*UserReference             `json:"users,omitempty"`
+	Teams                []*TeamReference             `json:"teams,omitempty"`
 }
 
 // SubSchedule represents a sub-schedule of a schedule.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -192,7 +192,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20210727215404-3da4ffdbaa95
+# github.com/heimweh/go-pagerduty v0.0.0-20210810155842-7de939d717c0
 ## explicit
 github.com/heimweh/go-pagerduty/pagerduty
 # github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af

--- a/website/docs/r/schedule.html.markdown
+++ b/website/docs/r/schedule.html.markdown
@@ -17,7 +17,10 @@ A [schedule](https://v2.developer.pagerduty.com/v2/page/api-reference#!/Schedule
 resource "pagerduty_user" "example" {
   name  = "Earline Greenholt"
   email = "125.greenholt.earline@graham.name"
-  teams = [pagerduty_team.example.id]
+}
+
+resource "pagerduty_team" "example" {
+  name = "A Team"
 }
 
 resource "pagerduty_schedule" "foo" {
@@ -29,7 +32,7 @@ resource "pagerduty_schedule" "foo" {
     start                        = "2015-11-06T20:00:00-05:00"
     rotation_virtual_start       = "2015-11-06T20:00:00-05:00"
     rotation_turn_length_seconds = 86400
-    users                        = [pagerduty_user.foo.id]
+    users                        = [pagerduty_user.example.id]
 
     restriction {
       type              = "daily_restriction"
@@ -37,6 +40,8 @@ resource "pagerduty_schedule" "foo" {
       duration_seconds  = 32400
     }
   }
+
+  teams = [pagerduty_team.example.id]
 }
 ```
 
@@ -51,6 +56,7 @@ The following arguments are supported:
 * `overflow` - (Optional) Any on-call schedule entries that pass the date range bounds will be truncated at the bounds, unless the parameter `overflow` is passed. For instance, if your schedule is a rotation that changes daily at midnight UTC, and your date range is from `2011-06-01T10:00:00Z` to `2011-06-01T14:00:00Z`:
 If you don't pass the overflow=true parameter, you will get one schedule entry returned with a start of `2011-06-01T10:00:00Z` and end of `2011-06-01T14:00:00Z`.
 If you do pass the `overflow` parameter, you will get one schedule entry returned with a start of `2011-06-01T00:00:00Z` and end of `2011-06-02T00:00:00Z`.
+* `teams` - (Optional) Teams associated with the schedule.
 
 
 Schedule layers (`layer`) supports the following:


### PR DESCRIPTION
Added `teams` field as an array of strings to the `resource_pagerduty_schedule`. Test results

```
TF_ACC=1 go test -run "TestAccPagerDutyScheduleWithTeams_Basic" ./pagerduty -v -timeout 120m
=== RUN   TestAccPagerDutyScheduleWithTeams_Basic
--- PASS: TestAccPagerDutyScheduleWithTeams_Basic (7.15s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	8.007s
```