### PR TITLE
don't send blank snow_password when changes are ignored

### DIFF
--- a/pagerduty/resource_pagerduty_extension_servicenow.go
+++ b/pagerduty/resource_pagerduty_extension_servicenow.go
@@ -14,7 +14,7 @@ import (
 
 type PagerDutyExtensionServiceNowConfig struct {
 	User        string `json:"snow_user"`
-	Password    string `json:"snow_password"`
+	Password    string `json:"snow_password,omitempty"`
 	SyncOptions string `json:"sync_options"`
 	Target      string `json:"target"`
 	TaskType    string `json:"task_type"`


### PR DESCRIPTION
This is a fix for issue #370. snow_password should not be sent when it's blank (due to lifecycle ignore_changes)