### PR TITLE
Allow Any Business Service to be Datasource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go v0.71.0 // indirect
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.7.0
-	github.com/heimweh/go-pagerduty v0.0.0-20210810155842-7de939d717c0
+	github.com/heimweh/go-pagerduty v0.0.0-20210811005434-dc24e464325a
 	go.mongodb.org/mongo-driver v1.7.0 // indirect
 	golang.org/x/tools v0.0.0-20201110124207-079ba7bd75cd // indirect
 	google.golang.org/api v0.35.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -211,6 +211,8 @@ github.com/heimweh/go-pagerduty v0.0.0-20210727215404-3da4ffdbaa95 h1:Urqoj46k8Q
 github.com/heimweh/go-pagerduty v0.0.0-20210727215404-3da4ffdbaa95/go.mod h1:6+bccpjQ/PM8uQY9m8avM4MJea+3vo3ta9r8kGQ4XFY=
 github.com/heimweh/go-pagerduty v0.0.0-20210810155842-7de939d717c0 h1:F3c5KAaStFpCvNWo8x0mniARDa0D16hIkfw6chMqTRI=
 github.com/heimweh/go-pagerduty v0.0.0-20210810155842-7de939d717c0/go.mod h1:6+bccpjQ/PM8uQY9m8avM4MJea+3vo3ta9r8kGQ4XFY=
+github.com/heimweh/go-pagerduty v0.0.0-20210811005434-dc24e464325a h1:mPx+k0gk1FNkQgWutkSFO/IYcHFv8ueUdA/1hIDkO9E=
+github.com/heimweh/go-pagerduty v0.0.0-20210811005434-dc24e464325a/go.mod h1:6+bccpjQ/PM8uQY9m8avM4MJea+3vo3ta9r8kGQ4XFY=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/business_service.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/business_service.go
@@ -45,12 +45,34 @@ func (s *BusinessServiceService) List() (*ListBusinessServicesResponse, *Respons
 	u := "/business_services"
 	v := new(ListBusinessServicesResponse)
 
-	resp, err := s.client.newRequestDo("GET", u, nil, nil, &v)
+	businessServices := make([]*BusinessService, 0)
+
+	// Create a handler closure capable of parsing data from the business_services endpoint
+	// and appending resultant response plays to the return slice.
+	responseHandler := func(response *Response) (ListResp, *Response, error) {
+		var result ListBusinessServicesResponse
+
+		if err := s.client.DecodeJSON(response, &result); err != nil {
+			return ListResp{}, response, err
+		}
+
+		businessServices = append(businessServices, result.BusinessServices...)
+
+		// Return stats on the current page. Caller can use this information to
+		// adjust for requesting additional pages.
+		return ListResp{
+			More:   result.More,
+			Offset: result.Offset,
+			Limit:  result.Limit,
+		}, response, nil
+	}
+	err := s.client.newRequestPagedGetDo(u, responseHandler)
 	if err != nil {
 		return nil, nil, err
 	}
+	v.BusinessServices = businessServices
 
-	return v, resp, nil
+	return v, nil, nil
 }
 
 // Create creates a new business service.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -192,7 +192,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20210810155842-7de939d717c0
+# github.com/heimweh/go-pagerduty v0.0.0-20210811005434-dc24e464325a
 ## explicit
 github.com/heimweh/go-pagerduty/pagerduty
 # github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af

--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -23,7 +23,7 @@ resource "pagerduty_team" "parent" {
 resource "pagerduty_team" "example" {
   name        = "Engineering"
   description = "All engineering"
-  parent      = pagerduty.team.id
+  parent      = pagerduty_team.parent.id
 }
 ```
 


### PR DESCRIPTION
This allows any business service to be a data source. It fixes #361. 

```
TF_ACC=1 go test -run "TestAccPagerDutyBusinessService_" ./pagerduty -v -timeout 120m
=== RUN   TestAccPagerDutyBusinessService_import
--- PASS: TestAccPagerDutyBusinessService_import (2.02s)
=== RUN   TestAccPagerDutyBusinessService_Basic
--- PASS: TestAccPagerDutyBusinessService_Basic (2.83s)
=== RUN   TestAccPagerDutyBusinessService_WithTeam
--- PASS: TestAccPagerDutyBusinessService_WithTeam (3.64s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	9.266s
```

Also, minor fix on teams doc. Fixes #367