### PR TITLE
Validate start time of week in a schedule

### DIFF
--- a/pagerduty/resource_pagerduty_schedule.go
+++ b/pagerduty/resource_pagerduty_schedule.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"log"
 	"time"
 
@@ -110,6 +111,7 @@ func resourcePagerDutySchedule() *schema.Resource {
 									"start_day_of_week": {
 										Type:     schema.TypeInt,
 										Optional: true,
+										ValidateFunc: validation.IntBetween(1, 7),
 									},
 
 									"duration_seconds": {


### PR DESCRIPTION
This can catch the errors when a user assumes 0 is the first day of the week.