### PR TITLE
docs: clarify service event rules time frame parameters

### DIFF
--- a/website/docs/r/service_event_rule.html.markdown
+++ b/website/docs/r/service_event_rule.html.markdown
@@ -136,11 +136,11 @@ The following arguments are supported:
 * `scheduled_weekly` (Optional) - Values for executing the rule on a recurring schedule.
 	* `weekdays` - An integer array representing which days during the week the rule executes. For example `weekdays = [1,3,7]` would execute on Monday, Wednesday and Sunday.
 	* `timezone` - Timezone for the given schedule.
-	* `start_time` - Time when the schedule will start. Unix timestamp in milliseconds. For example, if you have a rule with a `start_time` of `0` and a `duration` of `60,000` then that rule would be active from `00:00` to `00:01`. If the `start_time` was `3,600,000` the it would be active starting at `01:00`.
-	* `duration` - Length of time the schedule will be active.  Unix timestamp in milliseconds.
+	* `start_time` - Time when the schedule will start. Timestamp in milliseconds relative to the beginning of the day. For example, if you have a rule with a `start_time` of `0` and a `duration` of `60,000` then that rule would be active from `00:00` to `00:01`. If the `start_time` was `3,600,000` the it would be active starting at `01:00`.
+	* `duration` - Length of time the schedule will be active.  Duration in milliseconds.
 * `active_between` (Optional) - Values for executing the rule during a specific time period.
-	* `start_time` - Beginning of the scheduled time when the rule should execute.  Unix timestamp in milliseconds.
-	* `end_time` - Ending of the scheduled time when the rule should execute.  Unix timestamp in milliseconds.
+	* `start_time` - Beginning of the scheduled time when the rule should execute.  Timestamp in milliseconds relative to the beginning of the day.
+	* `end_time` - Ending of the scheduled time when the rule should execute.  Timestamp in milliseconds relative to the beginning of the day.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Usage of `Unix timestamp` here is confusing, as that usually means _the number of (milli-)seconds that have elapsed since the Unix Epoch (January 1st, 1970 at UTC)_.

Note that official API docs do not mention _Unix_ or _timestamp_:

```
              "time_frame": {
                "description": "Time-based conditions for limiting when the rule is active.",
                "type": "object",
                "properties": {
                  "active_between": {
                    "type": "object",
                    "required": [
                      "start_time",
                      "end_time"
                    ],
                    "description": "A fixed window of time during which the rule is active.",
                    "properties": {
                      "start_time": {
                        "type": "integer",
                        "description": "The start time in milliseconds."
                      },
                      "end_time": {
                        "type": "integer",
                        "description": "End time in milliseconds."
                      }
                    }
                  },
                  "scheduled_weekly": {
                    "type": "object",
                    "required": [
                      "start_time",
                      "duration",
                      "timezone",
                      "weekdays"
                    ],
                    "description": "A reccuring window of time based on the day of the week, during which the rule is active.",
                    "properties": {
                      "start_time": {
                        "type": "integer",
                        "description": "The amount of milliseconds into the day at which the window starts."
                      },
                      "duration": {
                        "type": "integer",
                        "description": "The duration of the window in milliseconds."
                      },
                      "timezone": {
                        "type": "string",
                        "description": "The timezone."
                      },
                      "weekdays": {
                        "type": "array",
                        "description": "An array of day values. Ex [1, 3, 5] is Monday, Wednesday, Friday.",
                        "items": {
                          "type": "integer"
                        }
                      }
                    }
                  }
                }
              },
```

https://github.com/PagerDuty/api-schema/blob/main/reference/REST/openapiv3.json
https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1services~1%7Bid%7D~1rules/post