### PR TITLE
Add validation on schedule layer turn rotation length

### DIFF
--- a/pagerduty/resource_pagerduty_schedule.go
+++ b/pagerduty/resource_pagerduty_schedule.go
@@ -97,6 +97,7 @@ func resourcePagerDutySchedule() *schema.Resource {
 						"rotation_turn_length_seconds": {
 							Type:     schema.TypeInt,
 							Required: true,
+							ValidateFunc: validation.IntBetween(3600, 365 * 24 * 3600),
 						},
 
 						"users": {


### PR DESCRIPTION
For values outside of this range, the API will respond with a 400