### PR TITLE
Update tag.html.markdown

### DIFF
--- a/website/docs/r/tag.html.markdown
+++ b/website/docs/r/tag.html.markdown
@@ -15,7 +15,6 @@ A [tag](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODIxNw-list-tags) 
 ```hcl
 resource "pagerduty_tag" "example" {
   label = "Product"
-  type = "tag"
 }
 ```
 


### PR DESCRIPTION
Hi all o/

So tags, finally! Thank you!

Re the [documentation](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/tag), it currently has:

```
resource "pagerduty_tag" "example" {
  label = "Product"
  type = "tag"
}
```


If I try this as is (Terraform 1.0.9) I get:

```
$ terraform validate

 Error: Unsupported argument
 
   on pagerduty_tag.tf line 3, in resource "pagerduty_tag" "example":
    3:   type  = "tag"
 
 An argument named "type" is not expected here.
```

Removing the type attribute and it applys just fine

```
resource "pagerduty_tag" "example" {
  label = "Product"
}
```

```
  # pagerduty_tag.example will be created
  + resource "pagerduty_tag" "example" {
      + html_url = (known after apply)
      + id       = (known after apply)
      + label    = "example"
      + summary  = (known after apply)
    }
```