### PR TITLE
Add team membership to the docs

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -30,7 +30,12 @@ resource "pagerduty_team" "engineering" {
 resource "pagerduty_user" "earline" {
   name  = "Earline Greenholt"
   email = "125.greenholt.earline@graham.name"
-  teams = [pagerduty_team.engineering.id]
+}
+
+# Create a team membership
+resource "pagerduty_team_membership" "earline_engineering" {
+  user_id = pagerduty_user.earline.id
+  team_id = pagerduty_team.engineering.id
 }
 ```
 


### PR DESCRIPTION
Prior to this change, a straightforward `terraform plan` of the resources in the front page documentation at https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs would throw the following warning:

>   Warning: "teams": [DEPRECATED] Use the 'pagerduty_team_membership'
>   resource instead.

After this change, it doesn't.

Submitting since this bit me while testing out this provider 😄 