### PR TITLE
Add validation to Escalation Policy Teams: MaxItems 1

### DIFF
--- a/pagerduty/resource_pagerduty_escalation_policy.go
+++ b/pagerduty/resource_pagerduty_escalation_policy.go
@@ -41,6 +41,7 @@ func resourcePagerDutyEscalationPolicy() *schema.Resource {
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
+				MaxItems: 1,
 			},
 			"rule": {
 				Type:     schema.TypeList,


### PR DESCRIPTION
The PagerDuty API doesn't allow more than one team to be associated with an escalation policy. The provider would run a successful `plan` but then fail on `apply`. This change catches that condition during the `plan`. 

Test results:

```
TF_ACC=1 go test -run "TestAccPagerDutyEscalationPolicy" ./pagerduty -v -timeout 120m
=== RUN   TestAccPagerDutyEscalationPolicy_import
--- PASS: TestAccPagerDutyEscalationPolicy_import (10.53s)
=== RUN   TestAccPagerDutyEscalationPolicy_Basic
--- PASS: TestAccPagerDutyEscalationPolicy_Basic (13.03s)
=== RUN   TestAccPagerDutyEscalationPolicyWithTeams_Basic
--- PASS: TestAccPagerDutyEscalationPolicyWithTeams_Basic (12.50s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	36.604s
```
