### PR TITLE
Library Updates 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,8 @@ go 1.16
 
 require (
 	cloud.google.com/go v0.71.0 // indirect
-	github.com/heimweh/go-pagerduty v0.0.0-20210930203304-530eff2acdc6
-	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.7.1
-	go.mongodb.org/mongo-driver v1.7.0 // indirect
+	github.com/heimweh/go-pagerduty v0.0.0-20211027200436-ac3c86fd0ce5
 	golang.org/x/tools v0.0.0-20201110124207-079ba7bd75cd // indirect
 	google.golang.org/api v0.35.0 // indirect
 	google.golang.org/genproto v0.0.0-20201109203340-2640f1f9cdfb // indirect

--- a/go.sum
+++ b/go.sum
@@ -174,6 +174,8 @@ github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -241,6 +243,8 @@ github.com/heimweh/go-pagerduty v0.0.0-20210831220234-54710c5e87d1 h1:yBAqdyzvIp
 github.com/heimweh/go-pagerduty v0.0.0-20210831220234-54710c5e87d1/go.mod h1:6+bccpjQ/PM8uQY9m8avM4MJea+3vo3ta9r8kGQ4XFY=
 github.com/heimweh/go-pagerduty v0.0.0-20210930203304-530eff2acdc6 h1:/D0VtHEOCdotE1vSB9XznceAjIGkUieZ4BF6VKUIqNU=
 github.com/heimweh/go-pagerduty v0.0.0-20210930203304-530eff2acdc6/go.mod h1:JtJGtgN0y9KOCaqFMZFaBCWskpO/KK3Ro9TwjP9ss6w=
+github.com/heimweh/go-pagerduty v0.0.0-20211027200436-ac3c86fd0ce5 h1:lAh9VAHBA09RKMNdbwdeWuzWSDbQ3wnUaa7mzrCKsCI=
+github.com/heimweh/go-pagerduty v0.0.0-20211027200436-ac3c86fd0ce5/go.mod h1:JtJGtgN0y9KOCaqFMZFaBCWskpO/KK3Ro9TwjP9ss6w=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/extension.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/extension.go
@@ -26,6 +26,9 @@ type ListExtensionsOptions struct {
 	Query             string   `url:"query,omitempty"`
 	ExtensionSchemaID string   `url:"extension_schema_id,omitempty"`
 	Include           []string `url:"include,omitempty,brackets"`
+	Limit             int      `url:"limit,omitempty"`
+	Offset            int      `url:"offset,omitemtpy"`
+	Total             bool     `url:"total,omitempty"`
 }
 
 // ListExtensionsResponse represents a list response of extensions.

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/service.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/service.go
@@ -1,6 +1,8 @@
 package pagerduty
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // ServicesService handles the communication with service
 // related methods of the PagerDuty API.
@@ -57,17 +59,66 @@ type IncidentUrgencyRule struct {
 
 // Integration represents a service integration.
 type Integration struct {
-	CreatedAt        string            `json:"created_at,omitempty"`
-	HTMLURL          string            `json:"html_url,omitempty"`
-	ID               string            `json:"id,omitempty"`
-	IntegrationEmail string            `json:"integration_email,omitempty"`
-	IntegrationKey   string            `json:"integration_key,omitempty"`
-	Name             string            `json:"name,omitempty"`
-	Self             string            `json:"self,omitempty"`
-	Service          *ServiceReference `json:"service,omitempty"`
-	Summary          string            `json:"summary,omitempty"`
-	Type             string            `json:"type,omitempty"`
-	Vendor           *VendorReference  `json:"vendor,omitempty"`
+	CreatedAt             string            `json:"created_at,omitempty"`
+	EmailIncidentCreation string            `json:"email_incident_creation,omitempty"`
+	EmailFilterMode       string            `json:"email_filter_mode,omitempty"`
+	EmailParsers          []*EmailParser    `json:"email_parsers,omitempty"`
+	EmailParsingFallback  string            `json:"email_parsing_fallback,omitempty"`
+	EmailFilters          []*EmailFilter    `json:"email_filters,omitempty"`
+	HTMLURL               string            `json:"html_url,omitempty"`
+	ID                    string            `json:"id,omitempty"`
+	Integration           *Integration      `json:"integration,omitempty"`
+	IntegrationEmail      string            `json:"integration_email,omitempty"`
+	IntegrationKey        string            `json:"integration_key,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	Self                  string            `json:"self,omitempty"`
+	Service               *ServiceReference `json:"service,omitempty"`
+	Summary               string            `json:"summary,omitempty"`
+	Type                  string            `json:"type,omitempty"`
+	Vendor                *VendorReference  `json:"vendor,omitempty"`
+}
+
+// EmailFilter represents a integration email filters
+type EmailFilter struct {
+	BodyMode       string `json:"body_mode,omitempty"`
+	BodyRegex      string `json:"body_regex,omitempty"`
+	FromEmailMode  string `json:"from_email_mode,omitempty"`
+	FromEmailRegex string `json:"from_email_regex,omitempty"`
+	ID             string `json:"id,omitempty"`
+	SubjectMode    string `json:"subject_mode,omitempty"`
+	SubjectRegex   string `json:"subject_regex,omitempty"`
+}
+
+// EmailParser represents a integration email parsers
+type EmailParser struct {
+	Action          string            `json:"action,omitempty"`
+	ID              *int              `json:"id,omitempty"`
+	MatchPredicate  *MatchPredicate   `json:"match_predicate,omitempty"`
+	ValueExtractors []*ValueExtractor `json:"value_extractors,omitempty"`
+}
+
+// MatchPredicate represents a integration email MatchPredicate
+type MatchPredicate struct {
+	Predicates []*Predicate `json:"children,omitempty"`
+	Type       string       `json:"type,omitempty"`
+}
+
+// Predicate represents a integration email Predicate
+type Predicate struct {
+	Matcher    string       `json:"matcher,omitempty"`
+	Part       string       `json:"part,omitempty"`
+	Predicates []*Predicate `json:"children,omitempty"`
+	Type       string       `json:"type,omitempty"`
+}
+
+// ValueExtractor represents a integration email ValueExtractor
+type ValueExtractor struct {
+	ValueName   string `json:"value_name,omitempty"`
+	Part        string `json:"part,omitempty"`
+	StartsAfter string `json:"starts_after,omitempty"`
+	EndsBefore  string `json:"ends_before,omitempty"`
+	Type        string `json:"type,omitempty"`
+	Regex       string `json:"regex,omitempty"`
 }
 
 // Service represents a service.

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/user.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/user.go
@@ -230,8 +230,10 @@ func (s *UserService) Get(id string, o *GetUserOptions) (*User, *Response, error
 	u := fmt.Sprintf("/users/%s", id)
 	v := new(UserPayload)
 
-	if err := cacheGetUser(id, v); err == nil {
-		return v.User, nil, nil
+	cv := new(User)
+	if err := cacheGetUser(id, cv); err == nil {
+		log.Printf("Got user %q from cache", id)
+		return cv, nil, nil
 	}
 
 	resp, err := s.client.newRequestDo("GET", u, o, nil, v)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -77,14 +77,7 @@ github.com/golang/protobuf/ptypes/empty
 github.com/golang/protobuf/ptypes/timestamp
 # github.com/golang/snappy v0.0.1
 github.com/golang/snappy
-# github.com/google/go-cmp v0.5.2
-github.com/google/go-cmp/cmp
-github.com/google/go-cmp/cmp/internal/diff
-github.com/google/go-cmp/cmp/internal/flags
-github.com/google/go-cmp/cmp/internal/function
-github.com/google/go-cmp/cmp/internal/value
-# github.com/google/go-querystring v1.0.0
-## explicit
+# github.com/google/go-querystring v1.1.0
 github.com/google/go-querystring/query
 # github.com/googleapis/gax-go/v2 v2.0.5
 github.com/googleapis/gax-go/v2
@@ -163,7 +156,7 @@ github.com/hashicorp/terraform-plugin-sdk/v2/plugin
 github.com/hashicorp/terraform-plugin-sdk/v2/terraform
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20210930203304-530eff2acdc6
+# github.com/heimweh/go-pagerduty v0.0.0-20211027200436-ac3c86fd0ce5
 ## explicit
 github.com/heimweh/go-pagerduty/pagerduty
 # github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
@@ -222,14 +215,7 @@ github.com/zclconf/go-cty/cty/function/stdlib
 github.com/zclconf/go-cty/cty/gocty
 github.com/zclconf/go-cty/cty/json
 github.com/zclconf/go-cty/cty/set
-<<<<<<< HEAD
-# github.com/zclconf/go-cty-yaml v1.0.1
-github.com/zclconf/go-cty-yaml
 # go.mongodb.org/mongo-driver v1.7.2
-=======
-# go.mongodb.org/mongo-driver v1.7.0
-## explicit
->>>>>>> master
 go.mongodb.org/mongo-driver/bson
 go.mongodb.org/mongo-driver/bson/bsoncodec
 go.mongodb.org/mongo-driver/bson/bsonoptions


### PR DESCRIPTION
This brings in updates from the [go-pagerduty](https://github.com/heimweh/go-pagerduty) library that supports the provider.

Fixes include:
* [fix crash related to user data structure change](https://github.com/heimweh/go-pagerduty/pull/69)
* [add ListExtensionOptions fields](https://github.com/heimweh/go-pagerduty/pull/68)
* [Add service integration email filters](https://github.com/heimweh/go-pagerduty/pull/31)

