### PR TITLE
update vendor docs to update inaccurate example

### DIFF
--- a/website/docs/d/vendor.html.markdown
+++ b/website/docs/d/vendor.html.markdown
@@ -45,9 +45,9 @@ resource "pagerduty_service" "example" {
 }
 
 resource "pagerduty_service_integration" "example" {
-  name            = "Datadog Integration"
-  vendor          = data.pagerduty_vendor.datadog.id
-  service         = pagerduty_service.example.id
+  name    = "Datadog Integration"
+  vendor  = data.pagerduty_vendor.datadog.id
+  service = pagerduty_service.example.id
 }
 ```
 

--- a/website/docs/d/vendor.html.markdown
+++ b/website/docs/d/vendor.html.markdown
@@ -45,10 +45,9 @@ resource "pagerduty_service" "example" {
 }
 
 resource "pagerduty_service_integration" "example" {
-  name    = "Datadog Integration"
-  vendor  = data.pagerduty_vendor.datadog.id
-  service = pagerduty_service.example.id
-  type    = "generic_events_api_inbound_integration"
+  name            = "Datadog Integration"
+  vendor          = data.pagerduty_vendor.datadog.id
+  service         = pagerduty_service.example.id
 }
 ```
 


### PR DESCRIPTION
# Why
the example for `pagerduty_service_integration` within `data.pagerduty_vendor` had both type and vendor defined. This resulted in an error for me when i copied over the code and modified it for my usage.

# Fix
As per [service_integration docs](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/service_integration#argument-reference), type cannot be used when vendor is defined. So in accordance to that, i modified the doc.