### PR TITLE
pagerduty_service_integration: support emails that are only known after apply

### DIFF
--- a/pagerduty/resource_pagerduty_service_integration.go
+++ b/pagerduty/resource_pagerduty_service_integration.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -12,6 +13,10 @@ import (
 	"github.com/heimweh/go-pagerduty/pagerduty"
 )
 
+const (
+	errEmailIntegrationMustHaveEmail = "integration_email attribute must be set for an integration type generic_email_inbound_integration"
+)
+
 func resourcePagerDutyServiceIntegration() *schema.Resource {
 	return &schema.Resource{
 		Create: resourcePagerDutyServiceIntegrationCreate,
@@ -20,8 +25,8 @@ func resourcePagerDutyServiceIntegration() *schema.Resource {
 		Delete: resourcePagerDutyServiceIntegrationDelete,
 		CustomizeDiff: func(context context.Context, diff *schema.ResourceDiff, i interface{}) error {
 			t := diff.Get("type").(string)
-			if t == "generic_email_inbound_integration" && diff.Get("integration_email").(string) == "" {
-				return fmt.Errorf("integration_email attribute must be set for an integration type generic_email_inbound_integration")
+			if t == "generic_email_inbound_integration" && diff.Get("integration_email").(string) == "" && diff.NewValueKnown("integration_email") {
+				return errors.New(errEmailIntegrationMustHaveEmail)
 			}
 			return nil
 		},
@@ -82,7 +87,7 @@ func resourcePagerDutyServiceIntegration() *schema.Resource {
 	}
 }
 
-func buildServiceIntegrationStruct(d *schema.ResourceData) *pagerduty.Integration {
+func buildServiceIntegrationStruct(d *schema.ResourceData) (*pagerduty.Integration, error) {
 	serviceIntegration := &pagerduty.Integration{
 		Name: d.Get("name").(string),
 		Type: "service_integration",
@@ -111,13 +116,20 @@ func buildServiceIntegrationStruct(d *schema.ResourceData) *pagerduty.Integratio
 		}
 	}
 
-	return serviceIntegration
+	if serviceIntegration.IntegrationEmail == "" {
+		return nil, errors.New(errEmailIntegrationMustHaveEmail)
+	}
+
+	return serviceIntegration, nil
 }
 
 func resourcePagerDutyServiceIntegrationCreate(d *schema.ResourceData, meta interface{}) error {
 	client, _ := meta.(*Config).Client()
 
-	serviceIntegration := buildServiceIntegrationStruct(d)
+	serviceIntegration, err := buildServiceIntegrationStruct(d)
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Creating PagerDuty service integration %s", serviceIntegration.Name)
 
@@ -196,7 +208,10 @@ func resourcePagerDutyServiceIntegrationRead(d *schema.ResourceData, meta interf
 func resourcePagerDutyServiceIntegrationUpdate(d *schema.ResourceData, meta interface{}) error {
 	client, _ := meta.(*Config).Client()
 
-	serviceIntegration := buildServiceIntegrationStruct(d)
+	serviceIntegration, err := buildServiceIntegrationStruct(d)
+	if err != nil {
+		return err
+	}
 
 	service := d.Get("service").(string)
 


### PR DESCRIPTION
This change allows to use outputs from other resources (e.g. `random_id`) in
the `integration_email` field.

Example usage:

```terraform
resource "random_id" "foo" {
  keepers = {
    prefix = "foo"
  }

  byte_length = 8
}

resource "pagerduty_service_integration" "foo" {
  name = "email"

  service = pagerduty_service.foo.id

  type              = "generic_email_inbound_integration"
  integration_email = "${random_id.foo.keepers.prefix}-${random_id.foo.hex}@domain.pagerduty.com"
}
```