### PR TITLE
Validate "duration_seconds" for a layer restriction

### DIFF
--- a/pagerduty/resource_pagerduty_schedule.go
+++ b/pagerduty/resource_pagerduty_schedule.go
@@ -28,6 +28,10 @@ func resourcePagerDutySchedule() *schema.Resource {
 					if t == "daily_restriction" && diff.Get(fmt.Sprintf("layer.%d.restriction.%d.start_day_of_week", li, ri)).(int) != 0 {
 						return fmt.Errorf("start_day_of_week must only be set for a weekly_restriction schedule restriction type")
 					}
+					ds := diff.Get(fmt.Sprintf("layer.%d.restriction.%d.duration_seconds", li, ri)).(int)
+					if t == "daily_restriction" && ds >= 3600*24 {
+						return fmt.Errorf("duration_seconds for a daily_restriction schedule restriction type must be shorter than a day")
+					}
 				}
 			}
 			return nil
@@ -136,8 +140,9 @@ func resourcePagerDutySchedule() *schema.Resource {
 									},
 
 									"duration_seconds": {
-										Type:     schema.TypeInt,
-										Required: true,
+										Type:         schema.TypeInt,
+										Required:     true,
+										ValidateFunc: validation.IntBetween(1, 7*24*3600-1),
 									},
 								},
 							},


### PR DESCRIPTION
Just a small validation addition for a common confusion of daily restriction being understood as "restrict a for a full day". 