### PR TITLE
Validate user and schedule reference in escalation policy targets

### DIFF
--- a/pagerduty/resource_pagerduty_escalation_policy.go
+++ b/pagerduty/resource_pagerduty_escalation_policy.go
@@ -66,6 +66,10 @@ func resourcePagerDutyEscalationPolicy() *schema.Resource {
 										Type:     schema.TypeString,
 										Optional: true,
 										Default:  "user_reference",
+										ValidateFunc: validateValueFunc([]string{
+											"user_reference",
+											"schedule_reference",
+										}),
 									},
 									"id": {
 										Type:     schema.TypeString,

--- a/website/docs/r/escalation_policy.html.markdown
+++ b/website/docs/r/escalation_policy.html.markdown
@@ -64,7 +64,7 @@ Escalation rules (`rule`) supports the following:
 
 Targets (`target`) supports the following:
 
-  * `type` - (Optional) Can be `user`, `schedule`, `user_reference` or `schedule_reference`. Defaults to `user_reference`. For multiple users as example, repeat the target.
+  * `type` - (Optional) Can be `user_reference` or `schedule_reference`. Defaults to `user_reference`. For multiple users as example, repeat the target.
   * `id` - (Required) A target ID
 
 ## Attributes Reference

--- a/website/docs/r/response_play.html.markdown
+++ b/website/docs/r/response_play.html.markdown
@@ -91,7 +91,7 @@ The following arguments are supported:
 * `escalation_rule` - The escalation rules
   * `escalation_delay_in_minutes` - The number of minutes before an unacknowledged incident escalates away from this rule.
   * `target` - The targets an incident should be assigned to upon reaching this rule.
-    * `type` - Type of object of the target. Supported types are `user`, `schedule`, `user_reference`, `schedule_reference`.
+    * `type` - Type of object of the target. Supported types are `user_reference`, `schedule_reference`.
 * `service` - There can be multiple services associated with a policy.
 * `team` - (Optional) Teams associated with the policy. Account must have the `teams` ability to use this parameter. There can be multiple teams associated with a policy.
 


### PR DESCRIPTION
This prevents a use of "user" and "schedule" types in escalation policy target as well as other invalid values.

Notably a "user" type is being returned as "user_reference" by the PagerDuty API, so it is causing a perma-diff in terraform plan like below:

```
      ~ rule {
            id                          = "PD..."
            # (1 unchanged attribute hidden)

          ~ target {
                id   = "PH..."
              ~ type = "user_reference" -> "user"
            }
        }

```