### PR TITLE
Example code update for newer versions of terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 example.tf
 terraform.tfplan
 terraform.tfstate
+.terraform.lock.hcl
 bin/
 dist/
 modules-dev/

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -16,6 +16,14 @@ Use the navigation to the left to read about the available resources.
 
 ```hcl
 # Configure the PagerDuty provider
+terraform {
+  required_providers {
+    pagerduty = {
+      source  = "pagerduty/pagerduty"
+    }
+  }
+}
+
 provider "pagerduty" {
   token = var.pagerduty_token
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -20,6 +20,7 @@ terraform {
   required_providers {
     pagerduty = {
       source  = "pagerduty/pagerduty"
+      version = "2.2.1"
     }
   }
 }


### PR DESCRIPTION
fixes #434 

Updating the sample project to include the `terraform {} ` block which had been required for a while now when using non-HashiCorp providers. Also added `.gitignore` for the terraform lock files that are now generated with any terraform project on initialization.