### PR TITLE
schedule: Validate daily/weekly restrictions

### DIFF
--- a/pagerduty/resource_pagerduty_schedule.go
+++ b/pagerduty/resource_pagerduty_schedule.go
@@ -25,8 +25,15 @@ func resourcePagerDutySchedule() *schema.Resource {
 				rn := diff.Get(fmt.Sprintf("layer.%d.restriction.#", li)).(int)
 				for ri := 0; ri <= rn; ri++ {
 					t := diff.Get(fmt.Sprintf("layer.%d.restriction.%d.type", li, ri)).(string)
+					d := diff.Get(fmt.Sprintf("layer.%d.restriction.%d.duration_seconds", li, ri)).(int)
 					if t == "daily_restriction" && diff.Get(fmt.Sprintf("layer.%d.restriction.%d.start_day_of_week", li, ri)).(int) != 0 {
 						return fmt.Errorf("start_day_of_week must only be set for a weekly_restriction schedule restriction type")
+					}
+					if t == "weekly_restriction" && d >= int((time.Hour*24*7).Seconds()) {
+						return fmt.Errorf("weekly restriction must be less than a week: %v", (time.Hour * 24 * 7).Seconds())
+					}
+					if t == "daily_restriction" && d >= int((time.Hour*24).Seconds()) {
+						return fmt.Errorf("daily restriction must be less than a day: %v", (time.Hour * 24).Seconds())
 					}
 				}
 			}

--- a/pagerduty/resource_pagerduty_schedule_test.go
+++ b/pagerduty/resource_pagerduty_schedule_test.go
@@ -262,6 +262,11 @@ func TestAccPagerDutySchedule_BasicWeek(t *testing.T) {
 						"pagerduty_schedule.foo", "layer.0.rotation_virtual_start", rotationVirtualStart),
 				),
 			},
+			{
+				Config:      testAccCheckPagerDutyScheduleConfigWeekUpdatedInvalidWeeklyRestrictions(username, email, scheduleUpdated, location, start, rotationVirtualStart),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("weekly restriction must be less than a week"),
+			},
 		},
 	})
 }
@@ -364,6 +369,11 @@ func TestAccPagerDutySchedule_Multi(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "layer.#", "2"),
 				),
+			},
+			{
+				Config:      testAccCheckPagerDutyScheduleConfigInvalidDailyRestriction(username, email, schedule, location, start, rotationVirtualStart),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("daily restriction must be less than a day:"),
 			},
 		},
 	})
@@ -799,4 +809,64 @@ resource "pagerduty_schedule" "foo" {
   }
 }
 `, username, email, team, schedule, location, start, rotationVirtualStart)
+}
+
+func testAccCheckPagerDutyScheduleConfigInvalidDailyRestriction(username, email, schedule, location, start, rotationVirtualStart string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "foo" {
+  name  = "%s"
+  email = "%s"
+}
+
+resource "pagerduty_schedule" "foo" {
+  name = "%s"
+
+  time_zone   = "%s"
+  description = "foo"
+
+  layer {
+    name                         = "foo"
+    start                        = "%s"
+    rotation_virtual_start       = "%s"
+    rotation_turn_length_seconds = 86400
+    users                        = [pagerduty_user.foo.id]
+
+    restriction {
+      type              = "daily_restriction"
+      start_time_of_day = "08:00:00"
+      duration_seconds  = 86400
+    }
+  }
+}
+`, username, email, schedule, location, start, rotationVirtualStart)
+}
+
+func testAccCheckPagerDutyScheduleConfigWeekUpdatedInvalidWeeklyRestrictions(username, email, schedule, location, start, rotationVirtualStart string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "foo" {
+  name        = "%s"
+  email       = "%s"
+}
+
+resource "pagerduty_schedule" "foo" {
+  name = "%s"
+
+  time_zone = "%s"
+
+  layer {
+    name                         = "foo"
+    start                        = "%s"
+    rotation_virtual_start       = "%s"
+    rotation_turn_length_seconds = 86400
+    users                        = [pagerduty_user.foo.id]
+
+		restriction {
+      type              = "weekly_restriction"
+      start_time_of_day = "08:00:00"
+			start_day_of_week = 5
+      duration_seconds  = 604800
+    }
+  }
+}
+`, username, email, schedule, location, start, rotationVirtualStart)
 }


### PR DESCRIPTION
Do not allow a daily restriction that spans a full 24*time.Hour
and similar for weekly restrictions. The PD API rejects 24*time.Hour
and 24*7*time.Hour for the API.