### PR TITLE
Safer HTTP client initialization and usage.

### DIFF
--- a/pagerduty/data_source_pagerduty_business_service.go
+++ b/pagerduty/data_source_pagerduty_business_service.go
@@ -28,7 +28,10 @@ func dataSourcePagerDutyBusinessService() *schema.Resource {
 }
 
 func dataSourcePagerDutyBusinessServiceRead(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Reading PagerDuty business service")
 

--- a/pagerduty/data_source_pagerduty_escalation_policy.go
+++ b/pagerduty/data_source_pagerduty_escalation_policy.go
@@ -24,7 +24,10 @@ func dataSourcePagerDutyEscalationPolicy() *schema.Resource {
 }
 
 func dataSourcePagerDutyEscalationPolicyRead(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Reading PagerDuty escalation policy")
 

--- a/pagerduty/data_source_pagerduty_extension_schema.go
+++ b/pagerduty/data_source_pagerduty_extension_schema.go
@@ -29,7 +29,10 @@ func dataSourcePagerDutyExtensionSchema() *schema.Resource {
 }
 
 func dataSourcePagerDutyExtensionSchemaRead(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Reading PagerDuty Extension Schema")
 

--- a/pagerduty/data_source_pagerduty_priority.go
+++ b/pagerduty/data_source_pagerduty_priority.go
@@ -30,7 +30,10 @@ func dataSourcePagerDutyPriority() *schema.Resource {
 }
 
 func dataSourcePagerDutyPriorityRead(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Reading PagerDuty priority")
 

--- a/pagerduty/data_source_pagerduty_ruleset.go
+++ b/pagerduty/data_source_pagerduty_ruleset.go
@@ -31,7 +31,10 @@ func dataSourcePagerDutyRuleset() *schema.Resource {
 }
 
 func dataSourcePagerDutyRulesetRead(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Reading PagerDuty ruleset")
 

--- a/pagerduty/data_source_pagerduty_schedule.go
+++ b/pagerduty/data_source_pagerduty_schedule.go
@@ -24,7 +24,10 @@ func dataSourcePagerDutySchedule() *schema.Resource {
 }
 
 func dataSourcePagerDutyScheduleRead(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Reading PagerDuty schedule")
 

--- a/pagerduty/data_source_pagerduty_service.go
+++ b/pagerduty/data_source_pagerduty_service.go
@@ -28,7 +28,10 @@ func dataSourcePagerDutyService() *schema.Resource {
 }
 
 func dataSourcePagerDutyServiceRead(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Reading PagerDuty service")
 

--- a/pagerduty/data_source_pagerduty_service_integration.go
+++ b/pagerduty/data_source_pagerduty_service_integration.go
@@ -36,7 +36,10 @@ func dataSourcePagerDutyServiceIntegration() *schema.Resource {
 }
 
 func dataSourcePagerDutyServiceIntegrationRead(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Reading PagerDuty service")
 

--- a/pagerduty/data_source_pagerduty_tag.go
+++ b/pagerduty/data_source_pagerduty_tag.go
@@ -25,7 +25,10 @@ func dataSourcePagerDutyTag() *schema.Resource {
 }
 
 func dataSourcePagerDutyTagRead(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Reading PagerDuty tag")
 

--- a/pagerduty/data_source_pagerduty_team.go
+++ b/pagerduty/data_source_pagerduty_team.go
@@ -33,7 +33,10 @@ func dataSourcePagerDutyTeam() *schema.Resource {
 }
 
 func dataSourcePagerDutyTeamRead(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Reading PagerDuty team")
 

--- a/pagerduty/data_source_pagerduty_user.go
+++ b/pagerduty/data_source_pagerduty_user.go
@@ -28,7 +28,10 @@ func dataSourcePagerDutyUser() *schema.Resource {
 }
 
 func dataSourcePagerDutyUserRead(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Reading PagerDuty user")
 

--- a/pagerduty/data_source_pagerduty_user_contact_method.go
+++ b/pagerduty/data_source_pagerduty_user_contact_method.go
@@ -59,7 +59,10 @@ func dataSourcePagerDutyUserContactMethod() *schema.Resource {
 }
 
 func dataSourcePagerDutyUserContactMethodRead(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Reading PagerDuty user's contact method")
 

--- a/pagerduty/data_source_pagerduty_vendor.go
+++ b/pagerduty/data_source_pagerduty_vendor.go
@@ -30,7 +30,10 @@ func dataSourcePagerDutyVendor() *schema.Resource {
 }
 
 func dataSourcePagerDutyVendorRead(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Reading PagerDuty vendor")
 

--- a/pagerduty/resource_pagerduty_addon.go
+++ b/pagerduty/resource_pagerduty_addon.go
@@ -42,7 +42,11 @@ func buildAddonStruct(d *schema.ResourceData) *pagerduty.Addon {
 }
 
 func fetchPagerDutyAddon(d *schema.ResourceData, meta interface{}, errCallback func(error, *schema.ResourceData) error) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
+
 	return resource.Retry(2*time.Minute, func() *resource.RetryError {
 		addon, _, err := client.Addons.Get(d.Id())
 		if err != nil {
@@ -64,13 +68,16 @@ func fetchPagerDutyAddon(d *schema.ResourceData, meta interface{}, errCallback f
 }
 
 func resourcePagerDutyAddonCreate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	addon := buildAddonStruct(d)
 
 	log.Printf("[INFO] Creating PagerDuty add-on %s", addon.Name)
 
-	addon, _, err := client.Addons.Install(addon)
+	addon, _, err = client.Addons.Install(addon)
 	if err != nil {
 		return err
 	}
@@ -86,7 +93,10 @@ func resourcePagerDutyAddonRead(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourcePagerDutyAddonUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	addon := buildAddonStruct(d)
 
@@ -100,7 +110,10 @@ func resourcePagerDutyAddonUpdate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourcePagerDutyAddonDelete(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Deleting PagerDuty add-on %s", d.Id())
 

--- a/pagerduty/resource_pagerduty_business_service.go
+++ b/pagerduty/resource_pagerduty_business_service.go
@@ -93,7 +93,10 @@ func buildBusinessServiceStruct(d *schema.ResourceData) (*pagerduty.BusinessServ
 }
 
 func resourcePagerDutyBusinessServiceCreate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 
@@ -118,7 +121,10 @@ func resourcePagerDutyBusinessServiceCreate(d *schema.ResourceData, meta interfa
 }
 
 func resourcePagerDutyBusinessServiceRead(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Reading PagerDuty business service %s", d.Id())
 
@@ -149,7 +155,10 @@ func resourcePagerDutyBusinessServiceRead(d *schema.ResourceData, meta interface
 }
 
 func resourcePagerDutyBusinessServiceUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	businessService, err := buildBusinessServiceStruct(d)
 	if err != nil {
@@ -168,7 +177,10 @@ func resourcePagerDutyBusinessServiceUpdate(d *schema.ResourceData, meta interfa
 }
 
 func resourcePagerDutyBusinessServiceDelete(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Deleting PagerDuty business service %s", d.Id())
 

--- a/pagerduty/resource_pagerduty_business_service_subscriber.go
+++ b/pagerduty/resource_pagerduty_business_service_subscriber.go
@@ -53,7 +53,11 @@ func buildBusinessServiceSubscriberStruct(d *schema.ResourceData) (*pagerduty.Bu
 }
 
 func resourcePagerDutyBusinessServiceSubscriberCreate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
+
 	businessServiceId := d.Get("business_service_id").(string)
 
 	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
@@ -82,7 +86,10 @@ func resourcePagerDutyBusinessServiceSubscriberCreate(d *schema.ResourceData, me
 }
 
 func resourcePagerDutyBusinessServiceSubscriberRead(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	businessServiceId := d.Get("business_service_id").(string)
 	businessServiceSubscriber, _ := buildBusinessServiceSubscriberStruct(d)
@@ -113,7 +120,10 @@ func resourcePagerDutyBusinessServiceSubscriberRead(d *schema.ResourceData, meta
 }
 
 func resourcePagerDutyBusinessServiceSubscriberDelete(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	businessServiceId := d.Get("business_service_id").(string)
 	businessServiceSubscriber, _ := buildBusinessServiceSubscriberStruct(d)
@@ -135,7 +145,10 @@ func createSubscriberID(businessServiceId string, subscriberType string, subscri
 
 func resourcePagerDutyBusinessServiceSubscriberImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	ids := strings.Split(d.Id(), ".")
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
 
 	if len(ids) != 3 {
 		return []*schema.ResourceData{}, fmt.Errorf("error importing pagerduty_business_service_subscriber. Expecting an importation ID formed as '<business_service_id>.<subscriber_type>.<subscriber_id>'")

--- a/pagerduty/resource_pagerduty_escalation_policy.go
+++ b/pagerduty/resource_pagerduty_escalation_policy.go
@@ -106,13 +106,16 @@ func buildEscalationPolicyStruct(d *schema.ResourceData) *pagerduty.EscalationPo
 }
 
 func resourcePagerDutyEscalationPolicyCreate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	escalationPolicy := buildEscalationPolicyStruct(d)
 
 	log.Printf("[INFO] Creating PagerDuty escalation policy: %s", escalationPolicy.Name)
 
-	escalationPolicy, _, err := client.EscalationPolicies.Create(escalationPolicy)
+	escalationPolicy, _, err = client.EscalationPolicies.Create(escalationPolicy)
 	if err != nil {
 		return err
 	}
@@ -123,7 +126,10 @@ func resourcePagerDutyEscalationPolicyCreate(d *schema.ResourceData, meta interf
 }
 
 func resourcePagerDutyEscalationPolicyRead(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Reading PagerDuty escalation policy: %s", d.Id())
 
@@ -153,7 +159,10 @@ func resourcePagerDutyEscalationPolicyRead(d *schema.ResourceData, meta interfac
 }
 
 func resourcePagerDutyEscalationPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	escalationPolicy := buildEscalationPolicyStruct(d)
 
@@ -174,7 +183,10 @@ func resourcePagerDutyEscalationPolicyUpdate(d *schema.ResourceData, meta interf
 }
 
 func resourcePagerDutyEscalationPolicyDelete(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Deleting PagerDuty escalation policy: %s", d.Id())
 

--- a/pagerduty/resource_pagerduty_event_rule.go
+++ b/pagerduty/resource_pagerduty_event_rule.go
@@ -57,7 +57,10 @@ func buildEventRuleStruct(d *schema.ResourceData) *pagerduty.EventRule {
 }
 
 func resourcePagerDutyEventRuleCreate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	eventRule := buildEventRuleStruct(d)
 
@@ -79,7 +82,10 @@ func resourcePagerDutyEventRuleCreate(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourcePagerDutyEventRuleRead(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Reading PagerDuty event rule: %s", d.Id())
 
@@ -114,7 +120,10 @@ func resourcePagerDutyEventRuleRead(d *schema.ResourceData, meta interface{}) er
 	})
 }
 func resourcePagerDutyEventRuleUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	eventRule := buildEventRuleStruct(d)
 
@@ -128,7 +137,10 @@ func resourcePagerDutyEventRuleUpdate(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourcePagerDutyEventRuleDelete(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Deleting PagerDuty event rule: %s", d.Id())
 

--- a/pagerduty/resource_pagerduty_extension.go
+++ b/pagerduty/resource_pagerduty_extension.go
@@ -87,7 +87,11 @@ func buildExtensionStruct(d *schema.ResourceData) *pagerduty.Extension {
 }
 
 func fetchPagerDutyExtension(d *schema.ResourceData, meta interface{}, errCallback func(error, *schema.ResourceData) error) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
+
 	return resource.Retry(2*time.Minute, func() *resource.RetryError {
 		extension, _, err := client.Extensions.Get(d.Id())
 		if err != nil {
@@ -118,13 +122,16 @@ func fetchPagerDutyExtension(d *schema.ResourceData, meta interface{}, errCallba
 }
 
 func resourcePagerDutyExtensionCreate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	extension := buildExtensionStruct(d)
 
 	log.Printf("[INFO] Creating PagerDuty extension %s", extension.Name)
 
-	extension, _, err := client.Extensions.Create(extension)
+	extension, _, err = client.Extensions.Create(extension)
 	if err != nil {
 		return err
 	}
@@ -140,7 +147,10 @@ func resourcePagerDutyExtensionRead(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourcePagerDutyExtensionUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	extension := buildExtensionStruct(d)
 
@@ -154,7 +164,10 @@ func resourcePagerDutyExtensionUpdate(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourcePagerDutyExtensionDelete(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Deleting PagerDuty extension %s", d.Id())
 
@@ -172,7 +185,10 @@ func resourcePagerDutyExtensionDelete(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourcePagerDutyExtensionImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
 
 	extension, _, err := client.Extensions.Get(d.Id())
 

--- a/pagerduty/resource_pagerduty_extension_servicenow.go
+++ b/pagerduty/resource_pagerduty_extension_servicenow.go
@@ -122,7 +122,11 @@ func buildExtensionServiceNowStruct(d *schema.ResourceData) *pagerduty.Extension
 }
 
 func fetchPagerDutyExtensionServiceNowCreate(d *schema.ResourceData, meta interface{}, errCallback func(error, *schema.ResourceData) error) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
+
 	return resource.Retry(2*time.Minute, func() *resource.RetryError {
 		extension, _, err := client.Extensions.Get(d.Id())
 		if err != nil {
@@ -159,13 +163,16 @@ func fetchPagerDutyExtensionServiceNowCreate(d *schema.ResourceData, meta interf
 }
 
 func resourcePagerDutyExtensionServiceNowCreate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	extension := buildExtensionServiceNowStruct(d)
 
 	log.Printf("[INFO] Creating PagerDuty extension %s", extension.Name)
 
-	extension, _, err := client.Extensions.Create(extension)
+	extension, _, err = client.Extensions.Create(extension)
 	if err != nil {
 		return err
 	}
@@ -180,7 +187,10 @@ func resourcePagerDutyExtensionServiceNowRead(d *schema.ResourceData, meta inter
 }
 
 func resourcePagerDutyExtensionServiceNowUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	extension := buildExtensionServiceNowStruct(d)
 
@@ -194,7 +204,10 @@ func resourcePagerDutyExtensionServiceNowUpdate(d *schema.ResourceData, meta int
 }
 
 func resourcePagerDutyExtensionServiceNowDelete(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Deleting PagerDuty extension %s", d.Id())
 
@@ -212,7 +225,10 @@ func resourcePagerDutyExtensionServiceNowDelete(d *schema.ResourceData, meta int
 }
 
 func resourcePagerDutyExtensionServiceNowImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
 
 	extension, _, err := client.Extensions.Get(d.Id())
 

--- a/pagerduty/resource_pagerduty_maintenance_window.go
+++ b/pagerduty/resource_pagerduty_maintenance_window.go
@@ -63,13 +63,16 @@ func buildMaintenanceWindowStruct(d *schema.ResourceData) *pagerduty.Maintenance
 }
 
 func resourcePagerDutyMaintenanceWindowCreate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	window := buildMaintenanceWindowStruct(d)
 
 	log.Printf("[INFO] Creating PagerDuty maintenance window")
 
-	window, _, err := client.MaintenanceWindows.Create(window)
+	window, _, err = client.MaintenanceWindows.Create(window)
 	if err != nil {
 		return err
 	}
@@ -80,7 +83,10 @@ func resourcePagerDutyMaintenanceWindowCreate(d *schema.ResourceData, meta inter
 }
 
 func resourcePagerDutyMaintenanceWindowRead(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Reading PagerDuty maintenance window %s", d.Id())
 
@@ -109,7 +115,10 @@ func resourcePagerDutyMaintenanceWindowRead(d *schema.ResourceData, meta interfa
 }
 
 func resourcePagerDutyMaintenanceWindowUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	window := buildMaintenanceWindowStruct(d)
 
@@ -123,7 +132,10 @@ func resourcePagerDutyMaintenanceWindowUpdate(d *schema.ResourceData, meta inter
 }
 
 func resourcePagerDutyMaintenanceWindowDelete(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Deleting PagerDuty maintenance window %s", d.Id())
 

--- a/pagerduty/resource_pagerduty_response_play.go
+++ b/pagerduty/resource_pagerduty_response_play.go
@@ -227,7 +227,10 @@ func buildResponsePlayStruct(d *schema.ResourceData) *pagerduty.ResponsePlay {
 }
 
 func resourcePagerDutyResponsePlayCreate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	responsePlay := buildResponsePlayStruct(d)
 
@@ -251,7 +254,10 @@ func resourcePagerDutyResponsePlayCreate(d *schema.ResourceData, meta interface{
 }
 
 func resourcePagerDutyResponsePlayRead(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	from := d.Get("from").(string)
 	log.Printf("[INFO] Reading PagerDuty response play: %s (from: %s)", d.Id(), from)
@@ -288,7 +294,10 @@ func resourcePagerDutyResponsePlayRead(d *schema.ResourceData, meta interface{})
 }
 
 func resourcePagerDutyResponsePlayUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	responsePlay := buildResponsePlayStruct(d)
 
@@ -308,7 +317,10 @@ func resourcePagerDutyResponsePlayUpdate(d *schema.ResourceData, meta interface{
 }
 
 func resourcePagerDutyResponsePlayDelete(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Deleting PagerDuty response play: %s", d.Id())
 	from := d.Get("from").(string)
@@ -461,7 +473,10 @@ func flattenRSTeams(teams []*pagerduty.TeamReference) []interface{} {
 }
 
 func resourcePagerDutyResponsePlayImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
 
 	ids := strings.SplitN(d.Id(), ".", 2)
 
@@ -471,7 +486,7 @@ func resourcePagerDutyResponsePlayImport(d *schema.ResourceData, meta interface{
 	rid, from := ids[0], ids[1]
 	log.Printf("[INFO] Importing PagerDuty response play: %s (From: %s)", rid, from)
 
-	_, _, err := client.ResponsePlays.Get(rid, from)
+	_, _, err = client.ResponsePlays.Get(rid, from)
 	if err != nil {
 		return []*schema.ResourceData{}, err
 	}

--- a/pagerduty/resource_pagerduty_ruleset.go
+++ b/pagerduty/resource_pagerduty_ruleset.go
@@ -101,7 +101,11 @@ func flattenTeam(v *pagerduty.RulesetObject) []interface{} {
 }
 
 func fetchPagerDutyRuleset(d *schema.ResourceData, meta interface{}, errCallback func(error, *schema.ResourceData) error) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
+
 	return resource.Retry(2*time.Minute, func() *resource.RetryError {
 		ruleset, _, err := client.Rulesets.Get(d.Id())
 		if err != nil {
@@ -127,7 +131,10 @@ func fetchPagerDutyRuleset(d *schema.ResourceData, meta interface{}, errCallback
 }
 
 func resourcePagerDutyRulesetCreate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	ruleset := buildRulesetStruct(d)
 
@@ -158,7 +165,10 @@ func resourcePagerDutyRulesetRead(d *schema.ResourceData, meta interface{}) erro
 
 }
 func resourcePagerDutyRulesetUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	ruleset := buildRulesetStruct(d)
 
@@ -172,7 +182,10 @@ func resourcePagerDutyRulesetUpdate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourcePagerDutyRulesetDelete(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Deleting PagerDuty ruleset: %s", d.Id())
 

--- a/pagerduty/resource_pagerduty_ruleset_rule.go
+++ b/pagerduty/resource_pagerduty_ruleset_rule.go
@@ -729,7 +729,10 @@ func flattenActiveBetween(ab *pagerduty.ActiveBetween) []interface{} {
 }
 
 func resourcePagerDutyRulesetRuleCreate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	rule := buildRulesetRuleStruct(d)
 
@@ -758,7 +761,10 @@ func resourcePagerDutyRulesetRuleCreate(d *schema.ResourceData, meta interface{}
 }
 
 func resourcePagerDutyRulesetRuleRead(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Reading PagerDuty ruleset rule: %s", d.Id())
 	rulesetID := d.Get("ruleset").(string)
@@ -789,7 +795,10 @@ func resourcePagerDutyRulesetRuleRead(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourcePagerDutyRulesetRuleUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	rule := buildRulesetRuleStruct(d)
 
@@ -813,7 +822,10 @@ func resourcePagerDutyRulesetRuleUpdate(d *schema.ResourceData, meta interface{}
 }
 
 func resourcePagerDutyRulesetRuleDelete(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Deleting PagerDuty ruleset rule: %s", d.Id())
 	rulesetID := d.Get("ruleset").(string)
@@ -834,7 +846,10 @@ func resourcePagerDutyRulesetRuleDelete(d *schema.ResourceData, meta interface{}
 }
 
 func resourcePagerDutyRulesetRuleImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
 
 	ids := strings.Split(d.Id(), ".")
 
@@ -843,7 +858,7 @@ func resourcePagerDutyRulesetRuleImport(d *schema.ResourceData, meta interface{}
 	}
 	rulesetID, ruleID := ids[0], ids[1]
 
-	_, _, err := client.Rulesets.GetRule(rulesetID, ruleID)
+	_, _, err = client.Rulesets.GetRule(rulesetID, ruleID)
 	if err != nil {
 		return []*schema.ResourceData{}, err
 	}

--- a/pagerduty/resource_pagerduty_schedule.go
+++ b/pagerduty/resource_pagerduty_schedule.go
@@ -185,7 +185,10 @@ func buildScheduleStruct(d *schema.ResourceData) (*pagerduty.Schedule, error) {
 }
 
 func resourcePagerDutyScheduleCreate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	schedule, err := buildScheduleStruct(d)
 	if err != nil {
@@ -211,7 +214,10 @@ func resourcePagerDutyScheduleCreate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourcePagerDutyScheduleRead(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Reading PagerDuty schedule: %s", d.Id())
 
@@ -249,7 +255,10 @@ func resourcePagerDutyScheduleRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourcePagerDutyScheduleUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	schedule, err := buildScheduleStruct(d)
 	if err != nil {
@@ -318,7 +327,10 @@ func resourcePagerDutyScheduleUpdate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourcePagerDutyScheduleDelete(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Deleting PagerDuty schedule: %s", d.Id())
 

--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -355,7 +355,11 @@ func buildServiceStruct(d *schema.ResourceData) (*pagerduty.Service, error) {
 }
 
 func fetchService(d *schema.ResourceData, meta interface{}, errCallback func(error, *schema.ResourceData) error) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
+
 	return resource.Retry(2*time.Minute, func() *resource.RetryError {
 		service, _, err := client.Services.Get(d.Id(), &pagerduty.GetServiceOptions{})
 		if err != nil {
@@ -378,7 +382,10 @@ func fetchService(d *schema.ResourceData, meta interface{}, errCallback func(err
 }
 
 func resourcePagerDutyServiceCreate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	service, err := buildServiceStruct(d)
 	if err != nil {
@@ -403,7 +410,10 @@ func resourcePagerDutyServiceRead(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourcePagerDutyServiceUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	service, err := buildServiceStruct(d)
 	if err != nil {
@@ -421,7 +431,10 @@ func resourcePagerDutyServiceUpdate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourcePagerDutyServiceDelete(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Deleting PagerDuty service %s", d.Id())
 

--- a/pagerduty/resource_pagerduty_service_dependency.go
+++ b/pagerduty/resource_pagerduty_service_dependency.go
@@ -112,7 +112,10 @@ func expandService(v interface{}) *pagerduty.ServiceObj {
 	return so
 }
 func resourcePagerDutyServiceDependencyAssociate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	serviceDependency, err := buildServiceDependencyStruct(d)
 	if err != nil {
@@ -151,7 +154,10 @@ func resourcePagerDutyServiceDependencyAssociate(d *schema.ResourceData, meta in
 }
 
 func resourcePagerDutyServiceDependencyDisassociate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	dependency, err := buildServiceDependencyStruct(d)
 	if err != nil {
@@ -260,7 +266,10 @@ func convertType(s string) string {
 }
 
 func findDependencySetState(depID, serviceID, serviceType string, d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	// Pausing to let the PD API sync.
 	time.Sleep(1 * time.Second)

--- a/pagerduty/resource_pagerduty_service_event_rule.go
+++ b/pagerduty/resource_pagerduty_service_event_rule.go
@@ -323,7 +323,10 @@ func buildServiceEventRuleStruct(d *schema.ResourceData) *pagerduty.ServiceEvent
 	return rule
 }
 func resourcePagerDutyServiceEventRuleCreate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	rule := buildServiceEventRuleStruct(d)
 
@@ -352,7 +355,10 @@ func resourcePagerDutyServiceEventRuleCreate(d *schema.ResourceData, meta interf
 }
 
 func resourcePagerDutyServiceEventRuleRead(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Reading PagerDuty service event rule: %s", d.Id())
 	serviceID := d.Get("service").(string)
@@ -383,7 +389,10 @@ func resourcePagerDutyServiceEventRuleRead(d *schema.ResourceData, meta interfac
 }
 
 func resourcePagerDutyServiceEventRuleUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	rule := buildServiceEventRuleStruct(d)
 
@@ -408,7 +417,10 @@ func resourcePagerDutyServiceEventRuleUpdate(d *schema.ResourceData, meta interf
 }
 
 func resourcePagerDutyServiceEventRuleDelete(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Deleting PagerDuty service event rule: %s", d.Id())
 	serviceID := d.Get("service").(string)
@@ -429,7 +441,10 @@ func resourcePagerDutyServiceEventRuleDelete(d *schema.ResourceData, meta interf
 }
 
 func resourcePagerDutyServiceEventRuleImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
 
 	ids := strings.Split(d.Id(), ".")
 
@@ -438,7 +453,7 @@ func resourcePagerDutyServiceEventRuleImport(d *schema.ResourceData, meta interf
 	}
 	serviceID, ruleID := ids[0], ids[1]
 
-	_, _, err := client.Services.GetEventRule(serviceID, ruleID)
+	_, _, err = client.Services.GetEventRule(serviceID, ruleID)
 	if err != nil {
 		return []*schema.ResourceData{}, err
 	}

--- a/pagerduty/resource_pagerduty_service_integration.go
+++ b/pagerduty/resource_pagerduty_service_integration.go
@@ -124,7 +124,11 @@ func buildServiceIntegrationStruct(d *schema.ResourceData) (*pagerduty.Integrati
 }
 
 func fetchPagerDutyServiceIntegration(d *schema.ResourceData, meta interface{}, errCallback func(error, *schema.ResourceData) error) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
+
 	service := d.Get("service").(string)
 
 	o := &pagerduty.GetIntegrationOptions{}
@@ -170,7 +174,10 @@ func fetchPagerDutyServiceIntegration(d *schema.ResourceData, meta interface{}, 
 }
 
 func resourcePagerDutyServiceIntegrationCreate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	serviceIntegration, err := buildServiceIntegrationStruct(d)
 	if err != nil {
@@ -208,7 +215,10 @@ func resourcePagerDutyServiceIntegrationRead(d *schema.ResourceData, meta interf
 }
 
 func resourcePagerDutyServiceIntegrationUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	serviceIntegration, err := buildServiceIntegrationStruct(d)
 	if err != nil {
@@ -227,7 +237,10 @@ func resourcePagerDutyServiceIntegrationUpdate(d *schema.ResourceData, meta inte
 }
 
 func resourcePagerDutyServiceIntegrationDelete(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	service := d.Get("service").(string)
 
@@ -243,7 +256,10 @@ func resourcePagerDutyServiceIntegrationDelete(d *schema.ResourceData, meta inte
 }
 
 func resourcePagerDutyServiceIntegrationImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
 
 	ids := strings.Split(d.Id(), ".")
 
@@ -252,7 +268,7 @@ func resourcePagerDutyServiceIntegrationImport(d *schema.ResourceData, meta inte
 	}
 	sid, id := ids[0], ids[1]
 
-	_, _, err := client.Services.GetIntegration(sid, id, nil)
+	_, _, err = client.Services.GetIntegration(sid, id, nil)
 	if err != nil {
 		return []*schema.ResourceData{}, err
 	}

--- a/pagerduty/resource_pagerduty_tag.go
+++ b/pagerduty/resource_pagerduty_tag.go
@@ -49,7 +49,10 @@ func buildTagStruct(d *schema.ResourceData) *pagerduty.Tag {
 }
 
 func resourcePagerDutyTagCreate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	tag := buildTagStruct(d)
 
@@ -77,7 +80,10 @@ func resourcePagerDutyTagCreate(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourcePagerDutyTagRead(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Reading PagerDuty tag %s", d.Id())
 
@@ -96,7 +102,10 @@ func resourcePagerDutyTagRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourcePagerDutyTagDelete(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Deleting PagerDuty tag %s", d.Id())
 

--- a/pagerduty/resource_pagerduty_tag_assignment.go
+++ b/pagerduty/resource_pagerduty_tag_assignment.go
@@ -60,7 +60,10 @@ func buildTagAssignmentStruct(d *schema.ResourceData) *pagerduty.TagAssignment {
 }
 
 func resourcePagerDutyTagAssignmentCreate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	assignment := buildTagAssignmentStruct(d)
 	assignments := &pagerduty.TagAssignments{
@@ -94,7 +97,10 @@ func resourcePagerDutyTagAssignmentCreate(d *schema.ResourceData, meta interface
 }
 
 func resourcePagerDutyTagAssignmentRead(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	assignment := buildTagAssignmentStruct(d)
 
@@ -124,7 +130,10 @@ func resourcePagerDutyTagAssignmentRead(d *schema.ResourceData, meta interface{}
 }
 
 func resourcePagerDutyTagAssignmentDelete(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	assignment := buildTagAssignmentStruct(d)
 	assignments := &pagerduty.TagAssignments{
@@ -158,7 +167,12 @@ func resourcePagerDutyTagAssignmentImport(d *schema.ResourceData, meta interface
 		return []*schema.ResourceData{}, fmt.Errorf("Error importing pagerduty_tag_assignment. Expecting an importation ID formed as '<entity_type>.<entity_id>.<tag_id>'")
 	}
 	entityType, entityID, tagID := ids[0], ids[1], ids[2]
-	client, _ := meta.(*Config).Client()
+
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+
 	// give PagerDuty 2 seconds to save the assignment correctly
 	time.Sleep(2 * time.Second)
 	tagResponse, _, err := client.Tags.ListTagsForEntity(entityType, entityID)

--- a/pagerduty/resource_pagerduty_team.go
+++ b/pagerduty/resource_pagerduty_team.go
@@ -58,7 +58,10 @@ func buildTeamStruct(d *schema.ResourceData) *pagerduty.Team {
 }
 
 func resourcePagerDutyTeamCreate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	team := buildTeamStruct(d)
 
@@ -82,7 +85,10 @@ func resourcePagerDutyTeamCreate(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourcePagerDutyTeamRead(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Reading PagerDuty team %s", d.Id())
 
@@ -100,7 +106,10 @@ func resourcePagerDutyTeamRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourcePagerDutyTeamUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	team := buildTeamStruct(d)
 
@@ -120,7 +129,10 @@ func resourcePagerDutyTeamUpdate(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourcePagerDutyTeamDelete(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Deleting PagerDuty team %s", d.Id())
 

--- a/pagerduty/resource_pagerduty_team_membership.go
+++ b/pagerduty/resource_pagerduty_team_membership.go
@@ -46,7 +46,11 @@ func resourcePagerDutyTeamMembership() *schema.Resource {
 }
 
 func fetchPagerDutyTeamMembership(d *schema.ResourceData, meta interface{}, errCallback func(error, *schema.ResourceData) error) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
+
 	userID, teamID := resourcePagerDutyTeamMembershipParseID(d.Id())
 	log.Printf("[DEBUG] Reading user: %s from team: %s", userID, teamID)
 	return resource.Retry(2*time.Minute, func() *resource.RetryError {
@@ -78,7 +82,10 @@ func fetchPagerDutyTeamMembership(d *schema.ResourceData, meta interface{}, errC
 	})
 }
 func resourcePagerDutyTeamMembershipCreate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	userID := d.Get("user_id").(string)
 	teamID := d.Get("team_id").(string)
@@ -111,7 +118,10 @@ func resourcePagerDutyTeamMembershipRead(d *schema.ResourceData, meta interface{
 }
 
 func resourcePagerDutyTeamMembershipUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	userID := d.Get("user_id").(string)
 	teamID := d.Get("team_id").(string)
@@ -141,7 +151,10 @@ func resourcePagerDutyTeamMembershipUpdate(d *schema.ResourceData, meta interfac
 }
 
 func resourcePagerDutyTeamMembershipDelete(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	userID, teamID := resourcePagerDutyTeamMembershipParseID(d.Id())
 

--- a/pagerduty/resource_pagerduty_user.go
+++ b/pagerduty/resource_pagerduty_user.go
@@ -132,13 +132,16 @@ func buildUserStruct(d *schema.ResourceData) *pagerduty.User {
 }
 
 func resourcePagerDutyUserCreate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	user := buildUserStruct(d)
 
 	log.Printf("[INFO] Creating PagerDuty user %s", user.Name)
 
-	user, _, err := client.Users.Create(user)
+	user, _, err = client.Users.Create(user)
 	if err != nil {
 		return err
 	}
@@ -149,7 +152,10 @@ func resourcePagerDutyUserCreate(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourcePagerDutyUserRead(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] pooh Reading PagerDuty user %s", d.Id())
 
@@ -188,7 +194,10 @@ func resourcePagerDutyUserRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourcePagerDutyUserUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	user := buildUserStruct(d)
 
@@ -254,7 +263,10 @@ func resourcePagerDutyUserUpdate(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourcePagerDutyUserDelete(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Deleting PagerDuty user %s", d.Id())
 

--- a/pagerduty/resource_pagerduty_user_contact_method.go
+++ b/pagerduty/resource_pagerduty_user_contact_method.go
@@ -94,7 +94,11 @@ func buildUserContactMethodStruct(d *schema.ResourceData) *pagerduty.ContactMeth
 }
 
 func fetchPagerDutyUserContactMethod(d *schema.ResourceData, meta interface{}, errCallback func(error, *schema.ResourceData) error) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
+
 	userID := d.Get("user_id").(string)
 
 	return resource.Retry(2*time.Minute, func() *resource.RetryError {
@@ -122,7 +126,10 @@ func fetchPagerDutyUserContactMethod(d *schema.ResourceData, meta interface{}, e
 }
 
 func resourcePagerDutyUserContactMethodCreate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	userID := d.Get("user_id").(string)
 
@@ -143,7 +150,10 @@ func resourcePagerDutyUserContactMethodRead(d *schema.ResourceData, meta interfa
 }
 
 func resourcePagerDutyUserContactMethodUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	contactMethod := buildUserContactMethodStruct(d)
 
@@ -159,7 +169,10 @@ func resourcePagerDutyUserContactMethodUpdate(d *schema.ResourceData, meta inter
 }
 
 func resourcePagerDutyUserContactMethodDelete(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Deleting PagerDuty user contact method %s", d.Id())
 
@@ -175,7 +188,10 @@ func resourcePagerDutyUserContactMethodDelete(d *schema.ResourceData, meta inter
 }
 
 func resourcePagerDutyUserContactMethodImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
 
 	ids := strings.Split(d.Id(), ":")
 
@@ -184,7 +200,7 @@ func resourcePagerDutyUserContactMethodImport(d *schema.ResourceData, meta inter
 	}
 	uid, id := ids[0], ids[1]
 
-	_, _, err := client.Users.GetContactMethod(uid, id)
+	_, _, err = client.Users.GetContactMethod(uid, id)
 	if err != nil {
 		return []*schema.ResourceData{}, err
 	}

--- a/pagerduty/resource_pagerduty_user_notification_rule.go
+++ b/pagerduty/resource_pagerduty_user_notification_rule.go
@@ -72,7 +72,11 @@ func buildUserNotificationRuleStruct(d *schema.ResourceData) (*pagerduty.Notific
 }
 
 func fetchPagerDutyUserNotificationRule(d *schema.ResourceData, meta interface{}, errCallback func(error, *schema.ResourceData) error) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
+
 	userID := d.Get("user_id").(string)
 
 	return resource.Retry(2*time.Minute, func() *resource.RetryError {
@@ -96,7 +100,10 @@ func fetchPagerDutyUserNotificationRule(d *schema.ResourceData, meta interface{}
 }
 
 func resourcePagerDutyUserNotificationRuleCreate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	userID := d.Get("user_id").(string)
 
@@ -120,7 +127,10 @@ func resourcePagerDutyUserNotificationRuleRead(d *schema.ResourceData, meta inte
 }
 
 func resourcePagerDutyUserNotificationRuleUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	notificationRule, err := buildUserNotificationRuleStruct(d)
 	if err != nil {
@@ -139,7 +149,10 @@ func resourcePagerDutyUserNotificationRuleUpdate(d *schema.ResourceData, meta in
 }
 
 func resourcePagerDutyUserNotificationRuleDelete(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Deleting PagerDuty user notification rule %s", d.Id())
 
@@ -155,7 +168,10 @@ func resourcePagerDutyUserNotificationRuleDelete(d *schema.ResourceData, meta in
 }
 
 func resourcePagerDutyUserNotificationRuleImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
 
 	ids := strings.Split(d.Id(), ":")
 
@@ -164,7 +180,7 @@ func resourcePagerDutyUserNotificationRuleImport(d *schema.ResourceData, meta in
 	}
 	uid, id := ids[0], ids[1]
 
-	_, _, err := client.Users.GetNotificationRule(uid, id)
+	_, _, err = client.Users.GetNotificationRule(uid, id)
 	if err != nil {
 		return []*schema.ResourceData{}, err
 	}

--- a/pagerduty/resource_pagerduty_webhook_subscription.go
+++ b/pagerduty/resource_pagerduty_webhook_subscription.go
@@ -106,7 +106,10 @@ func buildWebhookSubscriptionStruct(d *schema.ResourceData) *pagerduty.WebhookSu
 }
 
 func resourcePagerDutyWebhookSubscriptionCreate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	webhook := buildWebhookSubscriptionStruct(d)
 
@@ -134,7 +137,10 @@ func resourcePagerDutyWebhookSubscriptionCreate(d *schema.ResourceData, meta int
 }
 
 func resourcePagerDutyWebhookSubscriptionRead(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Reading PagerDuty webhook subscription %s", d.Id())
 
@@ -149,7 +155,10 @@ func resourcePagerDutyWebhookSubscriptionRead(d *schema.ResourceData, meta inter
 	})
 }
 func resourcePagerDutyWebhookSubscriptionUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Updating PagerDuty webhook subscription %s", d.Id())
 	whStruct := buildWebhookSubscriptionStruct(d)
@@ -165,7 +174,10 @@ func resourcePagerDutyWebhookSubscriptionUpdate(d *schema.ResourceData, meta int
 }
 
 func resourcePagerDutyWebhookSubscriptionDelete(d *schema.ResourceData, meta interface{}) error {
-	client, _ := meta.(*Config).Client()
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Deleting PagerDuty webhook subscription %s", d.Id())
 


### PR DESCRIPTION
This PR has two major components (corresponding to the two commits):

- Updating API client creation to only initialize once rather than every time a client is referenced.
- Surfacing client errors whenever an API client is retrieved from the config.

By exposing new errors this change may break some expectations around what errors might be returned by the provider, but hopefully in a way that's useful (i.e. before it would segfault, now it'll hopefully return something more informative).

The one gotcha would be if client re-initialization was intentional, but hopefully that isn't the case. And one optimization might be to explicitly initialize the client at config time, after which we don't need error handling around `Client()` calls.

This PR likely addresses the segfaults mentioned in issues:

- #394 
- #421 
- #440 
- #447
- #453