### PR TITLE
Modify resource_pagerduty_schedule.go to send `"end": null` when a layer's end is removed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	cloud.google.com/go v0.71.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.1
-	github.com/heimweh/go-pagerduty v0.0.0-20211210233744-b65de43109c1
+	github.com/heimweh/go-pagerduty v0.0.0-20220208023456-83fe435832fb
 	golang.org/x/tools v0.0.0-20201110124207-079ba7bd75cd // indirect
 	google.golang.org/api v0.35.0 // indirect
 	google.golang.org/genproto v0.0.0-20201109203340-2640f1f9cdfb // indirect

--- a/go.sum
+++ b/go.sum
@@ -282,6 +282,8 @@ github.com/heimweh/go-pagerduty v0.0.0-20211119212911-31ef1eea0d0f h1:/sgh3L7adJ
 github.com/heimweh/go-pagerduty v0.0.0-20211119212911-31ef1eea0d0f/go.mod h1:JtJGtgN0y9KOCaqFMZFaBCWskpO/KK3Ro9TwjP9ss6w=
 github.com/heimweh/go-pagerduty v0.0.0-20211210233744-b65de43109c1 h1:49zl3n/g+ff/7/CpxiuqnenyxId5iAjbhgoE9iDHULc=
 github.com/heimweh/go-pagerduty v0.0.0-20211210233744-b65de43109c1/go.mod h1:JtJGtgN0y9KOCaqFMZFaBCWskpO/KK3Ro9TwjP9ss6w=
+github.com/heimweh/go-pagerduty v0.0.0-20220208023456-83fe435832fb h1:p3faOVCU8L4wab9mpxN9Cm/VNVkPD8GMEfD0sPHw9nY=
+github.com/heimweh/go-pagerduty v0.0.0-20220208023456-83fe435832fb/go.mod h1:JtJGtgN0y9KOCaqFMZFaBCWskpO/KK3Ro9TwjP9ss6w=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/pagerduty/resource_pagerduty_schedule.go
+++ b/pagerduty/resource_pagerduty_schedule.go
@@ -415,8 +415,10 @@ func flattenScheduleLayers(v []*pagerduty.ScheduleLayer) ([]map[string]interface
 		// A schedule layer can never be removed but it can be ended.
 		// Here we check each layer and if it has been ended we don't read it back
 		// because it's not relevant anymore.
-		if *sl.End != "" {
-			end, err := timeToUTC(*sl.End)
+		slEnd := schema.TypeString.Zero().(string)
+		if sl.End != nil {
+			slEnd = *sl.End
+			end, err := timeToUTC(slEnd)
 			if err != nil {
 				return nil, err
 			}
@@ -428,7 +430,7 @@ func flattenScheduleLayers(v []*pagerduty.ScheduleLayer) ([]map[string]interface
 		scheduleLayer := map[string]interface{}{
 			"id":                           sl.ID,
 			"name":                         sl.Name,
-			"end":                          *sl.End,
+			"end":                          slEnd,
 			"start":                        sl.Start,
 			"rotation_virtual_start":       sl.RotationVirtualStart,
 			"rotation_turn_length_seconds": sl.RotationTurnLengthSeconds,

--- a/pagerduty/resource_pagerduty_schedule.go
+++ b/pagerduty/resource_pagerduty_schedule.go
@@ -361,19 +361,13 @@ func expandScheduleLayers(v interface{}) ([]*pagerduty.ScheduleLayer, error) {
 			return nil, err
 		}
 
-		// If End is null, it means the layer does not end. The type of layer.*.end is schema.TypeString.
+		// The type of layer.*.end is schema.TypeString. If the end is an empty string, it means the layer does not end.
 		// A client should send a payload including `"end": null` to unset the end of layer.
-		var end *string
-		if rsl["end"].(string) != schema.TypeString.Zero().(string) {
-			e := rsl["end"].(string)
-			end = &e
-		}
-
 		scheduleLayer := &pagerduty.ScheduleLayer{
 			ID:                        rsl["id"].(string),
 			Name:                      rsl["name"].(string),
 			Start:                     rsl["start"].(string),
-			End:                       end,
+			End:                       stringTypeToStringPtr(rsl["end"].(string)),
 			RotationVirtualStart:      rvs.String(),
 			RotationTurnLengthSeconds: rsl["rotation_turn_length_seconds"].(int),
 		}

--- a/pagerduty/resource_pagerduty_schedule.go
+++ b/pagerduty/resource_pagerduty_schedule.go
@@ -420,10 +420,9 @@ func flattenScheduleLayers(v []*pagerduty.ScheduleLayer) ([]map[string]interface
 		// A schedule layer can never be removed but it can be ended.
 		// Here we check each layer and if it has been ended we don't read it back
 		// because it's not relevant anymore.
-		slEnd := schema.TypeString.Zero().(string)
-		if sl.End != nil {
-			slEnd = *sl.End
-			end, err := timeToUTC(slEnd)
+		endStr := stringPtrToStringType(sl.End)
+		if endStr != "" {
+			end, err := timeToUTC(endStr)
 			if err != nil {
 				return nil, err
 			}
@@ -435,7 +434,7 @@ func flattenScheduleLayers(v []*pagerduty.ScheduleLayer) ([]map[string]interface
 		scheduleLayer := map[string]interface{}{
 			"id":                           sl.ID,
 			"name":                         sl.Name,
-			"end":                          slEnd,
+			"end":                          endStr,
 			"start":                        sl.Start,
 			"rotation_virtual_start":       sl.RotationVirtualStart,
 			"rotation_turn_length_seconds": sl.RotationTurnLengthSeconds,

--- a/pagerduty/resource_pagerduty_schedule.go
+++ b/pagerduty/resource_pagerduty_schedule.go
@@ -363,9 +363,8 @@ func expandScheduleLayers(v interface{}) ([]*pagerduty.ScheduleLayer, error) {
 
 		// If End is null, it means the layer does not end. The type of layer.*.end is schema.TypeString.
 		// A client should send a payload including `"end": null` to unset the end of layer.
-		// The condition below uses "" because the zero value of schema.TypeString is an empty string.
 		var end *string
-		if rsl["end"].(string) != "" {
+		if rsl["end"].(string) != schema.TypeString.Zero().(string) {
 			e := rsl["end"].(string)
 			end = &e
 		}

--- a/pagerduty/util.go
+++ b/pagerduty/util.go
@@ -132,3 +132,12 @@ func stringTypeToStringPtr(v string) *string {
 	}
 	return &v
 }
+
+// stringPtrToStringType is a helper that returns the string value passed in
+// or an empty string if the given pointer is nil.
+func stringPtrToStringType(v *string) string {
+	if v == nil {
+		return ""
+	}
+	return *v
+}

--- a/pagerduty/util.go
+++ b/pagerduty/util.go
@@ -123,3 +123,12 @@ func flattenSlice(v []interface{}) interface{} {
 	}
 	return string(b)
 }
+
+// stringTypeToStringPtr is a helper that returns a pointer to
+// the string value passed in or nil if the string is empty.
+func stringTypeToStringPtr(v string) *string {
+	if v == "" {
+		return nil
+	}
+	return &v
+}

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/schedule.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/schedule.go
@@ -58,7 +58,8 @@ type ScheduleLayerEntry struct {
 
 // ScheduleLayer represents a schedule layer in a schedule
 type ScheduleLayer struct {
-	End                        string                  `json:"end,omitempty"`
+	// End should be nullable because if it's null, it means the layer does not end.
+	End                        *string                 `json:"end"`
 	ID                         string                  `json:"id,omitempty"`
 	Name                       string                  `json:"name,omitempty"`
 	RenderedCoveragePercentage float64                 `json:"rendered_coverage_percentage,omitempty"`

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/webhook_subscription.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/webhook_subscription.go
@@ -18,9 +18,15 @@ type WebhookSubscription struct {
 
 // DeliveryMethod represents a webhook delivery method
 type DeliveryMethod struct {
-	TemporarilyDisabled bool   `json:"temporarily_disabled,omitempty"`
-	Type                string `json:"type,omitempty"`
-	URL                 string `json:"url,omitempty"`
+	TemporarilyDisabled bool             `json:"temporarily_disabled,omitempty"`
+	Type                string           `json:"type,omitempty"`
+	URL                 string           `json:"url,omitempty"`
+	CustomHeaders       []*CustomHeaders `json:"custom_headers,omitempty"`
+}
+
+type CustomHeaders struct {
+	Name  string `json:"name,omitempty"`
+	Value string `json:"value,omitempty"`
 }
 
 // Filter represents a webhook subscription filter

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -124,7 +124,7 @@ github.com/hashicorp/terraform-registry-address
 github.com/hashicorp/terraform-svchost
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20211210233744-b65de43109c1
+# github.com/heimweh/go-pagerduty v0.0.0-20220208023456-83fe435832fb
 ## explicit
 github.com/heimweh/go-pagerduty/pagerduty
 # github.com/klauspost/compress v1.11.2


### PR DESCRIPTION
# What

* Update the version of `heimweh/go-pagerduty`
  * Here is the related update: https://github.com/heimweh/go-pagerduty/pull/76
* Modify `pagerduty/resource_pagerduty_schedule.go` to send `"end": null` when a layer's end is removed

# Why

* Fix the following issue
  * https://github.com/PagerDuty/terraform-provider-pagerduty/issues/451