### PR TITLE
Update Links to PD API Docs

### DIFF
--- a/website/docs/d/escalation_policy.html.markdown
+++ b/website/docs/d/escalation_policy.html.markdown
@@ -37,4 +37,4 @@ The following arguments are supported:
 * `id` - The ID of the found escalation policy.
 * `name` - The short name of the found escalation policy.
 
-[1]: https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1escalation_policies/get
+[1]: https://developer.pagerduty.com/api-reference/b3A6Mjc0ODEyNA-list-escalation-policies

--- a/website/docs/d/extension_schema.html.markdown
+++ b/website/docs/d/extension_schema.html.markdown
@@ -64,4 +64,4 @@ The following arguments are supported:
 * `name` - The short name of the found extension vendor.
 * `type` - The generic service type for this extension vendor.
 
-[1]: https://v2.developer.pagerduty.com/v2/page/api-reference#!/Extension_Schemas/get_extension_schemas
+[1]: https://developer.pagerduty.com/api-reference/b3A6Mjc0ODEzMA-list-extension-schemas

--- a/website/docs/d/priority.html.markdown
+++ b/website/docs/d/priority.html.markdown
@@ -69,4 +69,4 @@ The following arguments are supported:
 * `name` - The name of the found priority.
 * `description` - A description of the found priority.
 
-[1]: https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1priorities/get
+[1]: https://developer.pagerduty.com/api-reference/b3A6Mjc0ODE2NA-list-priorities

--- a/website/docs/d/ruleset.html.markdown
+++ b/website/docs/d/ruleset.html.markdown
@@ -67,5 +67,5 @@ The following arguments are supported:
 * `routing_keys` - Routing keys routed to this ruleset.
 
 
-[1]: https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1rulesets/get
-[2]: https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1rulesets~1%7Bid%7D~1rules/get
+[1]: https://developer.pagerduty.com/api-reference/b3A6Mjc0ODE3MQ-list-rulesets
+[2]: https://developer.pagerduty.com/api-reference/b3A6Mjc0ODE3Ng-list-event-rules

--- a/website/docs/d/schedule.html.markdown
+++ b/website/docs/d/schedule.html.markdown
@@ -45,4 +45,4 @@ The following arguments are supported:
 * `id` - The ID of the found schedule.
 * `name` - The short name of the found schedule.
 
-[1]: https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1schedules~1%7Bid%7D/get
+[1]: https://developer.pagerduty.com/api-reference/b3A6Mjc0ODE4MQ-list-schedules

--- a/website/docs/d/team.html.markdown
+++ b/website/docs/d/team.html.markdown
@@ -50,4 +50,4 @@ The following arguments are supported:
 * `description` - A description of the found team.
 * `parent` - ID of the parent team. This is available to accounts with the Team Hierarchy feature enabled. Please contact your account manager for more information.
 
-[1]: https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1teams/get
+[1]: https://developer.pagerduty.com/api-reference/b3A6Mjc0ODIyMw-list-teams

--- a/website/docs/d/user.html.markdown
+++ b/website/docs/d/user.html.markdown
@@ -42,4 +42,4 @@ The following arguments are supported:
 * `id` - The ID of the found user.
 * `name` - The short name of the found user.
 
-[1]: https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1users/get
+[1]: https://developer.pagerduty.com/api-reference/b3A6Mjc0ODIzMw-list-users

--- a/website/docs/d/user_contact_method.html.markdown
+++ b/website/docs/d/user_contact_method.html.markdown
@@ -55,5 +55,5 @@ The following arguments are supported:
   * `enabled` - If true, this phone is capable of receiving SMS messages. (Phone and SMS contact methods only.)
   * `device_type` - Either `ios` or `android`, depending on the type of the device receiving notifications. (Push notification contact method only.)
 
-[1]: https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1users~1%7Bid%7D~1contact_methods~1%7Bcontact_method_id%7D/get
-[2]: https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1users~1%7Bid%7D/get
+[1]: https://developer.pagerduty.com/api-reference/b3A6Mjc0ODIzOQ-list-a-user-s-contact-methods
+[2]: https://developer.pagerduty.com/api-reference/b3A6Mjc0ODIzMw-list-users

--- a/website/docs/d/vendor.html.markdown
+++ b/website/docs/d/vendor.html.markdown
@@ -63,4 +63,4 @@ The following arguments are supported:
 * `name` - The short name of the found vendor.
 * `type` - The generic service type for this vendor.
 
-[1]: https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1vendors/get
+[1]: https://developer.pagerduty.com/api-reference/b3A6Mjc0ODI1OQ-list-vendors

--- a/website/docs/r/addon.html.markdown
+++ b/website/docs/r/addon.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # pagerduty\_addon
 
-With [add-ons](https://v2.developer.pagerduty.com/v2/page/api-reference#!/Add-ons/get_addons), third-party developers can write their own add-ons to PagerDuty's UI. Given a configuration containing a src parameter, that URL will be embedded in an iframe on a page that's available to users from a drop-down menu.
+With [add-ons](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODEwNQ-install-an-add-on), third-party developers can write their own add-ons to PagerDuty's UI. Given a configuration containing a src parameter, that URL will be embedded in an iframe on a page that's available to users from a drop-down menu.
 
 ## Example Usage
 

--- a/website/docs/r/business_service.html.markdown
+++ b/website/docs/r/business_service.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # pagerduty\_business\_service
 
-A [business service](https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1business_services/get) allows you to model capabilities that span multiple technical services and that may be owned by several different teams. 
+A [business service](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODExNg-create-a-business-service) allows you to model capabilities that span multiple technical services and that may be owned by several different teams. 
 
 
 ## Example Usage

--- a/website/docs/r/escalation_policy.html.markdown
+++ b/website/docs/r/escalation_policy.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # pagerduty\_escalation_policy
 
-An [escalation policy](https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1escalation_policies/get) determines what user or schedule will be notified first, second, and so on when an incident is triggered. Escalation policies are used by one or more services.
+An [escalation policy](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODEyNQ-create-an-escalation-policy) determines what user or schedule will be notified first, second, and so on when an incident is triggered. Escalation policies are used by one or more services.
 
 
 ## Example Usage

--- a/website/docs/r/extension.html.markdown
+++ b/website/docs/r/extension.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # pagerduty\_extension
 
-An [extension](https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1extensions/post) can be associated with a service.
+An [extension](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODEzMw-create-an-extension) can be associated with a service.
 
 ## Example Usage
 

--- a/website/docs/r/extension_servicenow.html.markdown
+++ b/website/docs/r/extension_servicenow.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # pagerduty\_extension\_servicenow
 
-A special case for [extension](https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1extensions/post) for ServiceNow.
+A special case for [extension](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODEzMw-create-an-extension) for ServiceNow.
 
 ## Example Usage
 

--- a/website/docs/r/maintenance_window.html.markdown
+++ b/website/docs/r/maintenance_window.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # pagerduty_maintenance_window
 
-A [maintenance window](https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1maintenance_windows/get) is used to temporarily disable one or more services for a set period of time. No incidents will be triggered and no notifications will be received while a service is disabled by a maintenance window.
+A [maintenance window](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODE1OA-create-a-maintenance-window) is used to temporarily disable one or more services for a set period of time. No incidents will be triggered and no notifications will be received while a service is disabled by a maintenance window.
 
 Maintenance windows are specified to start at a certain time and end after they have begun. Once started, a maintenance window cannot be deleted; it can only be ended immediately to re-enable the service.
 

--- a/website/docs/r/response_play.html.markdown
+++ b/website/docs/r/response_play.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # pagerduty_response_play
 
-A [response play](https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1response_plays/get) allows you to create packages of Incident Actions that can be applied during an Incident's life cycle.
+A [response play](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODE2Ng-create-a-response-play) allows you to create packages of Incident Actions that can be applied during an Incident's life cycle.
 
 
 ## Example Usage

--- a/website/docs/r/schedule.html.markdown
+++ b/website/docs/r/schedule.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # pagerduty\_schedule
 
-A [schedule](https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1schedules~1%7Bid%7D~1users/get) determines the time periods that users are on call. Only on-call users are eligible to receive notifications from incidents.
+A [schedule](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODE4Mg-create-a-schedule) determines the time periods that users are on call. Only on-call users are eligible to receive notifications from incidents.
 
 
 ## Example Usage

--- a/website/docs/r/service.html.markdown
+++ b/website/docs/r/service.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # pagerduty\_service
 
-A [service](https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1services/get) represents something you monitor (like a web service, email service, or database service). It is a container for related incidents that associates them with escalation policies.
+A [service](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODE5Nw-create-a-service) represents something you monitor (like a web service, email service, or database service). It is a container for related incidents that associates them with escalation policies.
 
 
 ## Example Usage

--- a/website/docs/r/service_dependency.html.markdown
+++ b/website/docs/r/service_dependency.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # pagerduty\_service\_dependency
 
-A [service dependency](https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1service_dependencies~1associate/post) is a relationship between two services that this service uses, or that are used by this service, and are critical for successful operation.
+A [service dependency](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODE5Mg-associate-service-dependencies) is a relationship between two services that this service uses, or that are used by this service, and are critical for successful operation.
 
 
 ## Example Usage

--- a/website/docs/r/tag.html.markdown
+++ b/website/docs/r/tag.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # pagerduty\_tag
 
-A [tag](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODIxNw-list-tags) is applied to Escalation Policies, Teams or Users and can be used to filter them.
+A [tag](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODIxOA-create-a-tag) is applied to Escalation Policies, Teams or Users and can be used to filter them.
 
 ## Example Usage
 

--- a/website/docs/r/tag_assignment.html.markdown
+++ b/website/docs/r/tag_assignment.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # pagerduty\_tag\_assignment
 
-A [tag](https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1tags/get) is applied to Escalation Policies, Teams or Users and can be used to filter them.
+A [tag](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODEwMA-assign-tags) is applied to Escalation Policies, Teams or Users and can be used to filter them.
 
 ## Example Usage
 

--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # pagerduty\_team
 
-A [team](https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1teams/get) is a collection of users and escalation policies that represent a group of people within an organization.
+A [team](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODIyMg-create-a-team) is a collection of users and escalation policies that represent a group of people within an organization.
 
 The account must have the `teams` ability to use the following resource.
 

--- a/website/docs/r/team_membership.html.markdown
+++ b/website/docs/r/team_membership.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # pagerduty_team_membership
 
-A [team membership](https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1teams~1%7Bid%7D~1users~1%7Buser_id%7D/put) manages memberships within a team.
+A [team membership](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODIzMg-add-a-user-to-a-team) manages memberships within a team.
 
 ## Example Usage
 

--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # pagerduty\_user
 
-A [user](https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1users/get) is a member of a PagerDuty account that have the ability to interact with incidents and other data on the account.
+A [user](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODIzNA-create-a-user) is a member of a PagerDuty account that have the ability to interact with incidents and other data on the account.
 
 
 ## Example Usage

--- a/website/docs/r/user_contact_method.html.markdown
+++ b/website/docs/r/user_contact_method.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # pagerduty_user_contact_method
 
-A [contact method](https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1users~1%7Bid%7D~1contact_methods/get) is a contact method for a PagerDuty user (email, phone or SMS).
+A [contact method](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODI0MA-create-a-user-contact-method) is a contact method for a PagerDuty user (email, phone or SMS).
 
 
 ## Example Usage

--- a/website/docs/r/user_notification_rule.html.markdown
+++ b/website/docs/r/user_notification_rule.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # pagerduty_user_notification_rule
 
-A [notification rule](https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1users~1%7Bid%7D~1notification_rules~1%7Bnotification_rule_id%7D/get) configures where and when a PagerDuty user is notified when a triggered incident is assigned to them. Unique notification rules can be created for both high and low-urgency incidents.
+A [notification rule](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODI0NQ-create-a-user-notification-rule) configures where and when a PagerDuty user is notified when a triggered incident is assigned to them. Unique notification rules can be created for both high and low-urgency incidents.
 
 ## Example Usage
 


### PR DESCRIPTION
This updates all the broken links to the PagerDuty API docs in the Provider documentation.