### PR TITLE
Delete and re-create maintenance window if start or end times change

### DIFF
--- a/pagerduty/resource_pagerduty_maintenance_window.go
+++ b/pagerduty/resource_pagerduty_maintenance_window.go
@@ -24,12 +24,14 @@ func resourcePagerDutyMaintenanceWindow() *schema.Resource {
 				Required:         true,
 				ValidateFunc:     validateRFC3339,
 				DiffSuppressFunc: suppressRFC3339Diff,
+				ForceNew:         true,
 			},
 			"end_time": {
 				Type:             schema.TypeString,
 				Required:         true,
 				ValidateFunc:     validateRFC3339,
 				DiffSuppressFunc: suppressRFC3339Diff,
+				ForceNew:         true,
 			},
 
 			"services": {


### PR DESCRIPTION
Proposed solution for the 400 error seen in issue #396, when attempting to update the start and end times of a maintenance window.