### PR TITLE
Add pagerduty_response_play datasource

### DIFF
--- a/pagerduty/data_source_pagerduty_response_play.go
+++ b/pagerduty/data_source_pagerduty_response_play.go
@@ -73,7 +73,6 @@ func dataSourcePagerDutyResponsePlayRead(d *schema.ResourceData, meta interface{
 
 		d.SetId(found.ID)
 		d.Set("name", found.Name)
-		d.Set("from", found.FromEmail)
 
 		return nil
 	})

--- a/pagerduty/data_source_pagerduty_response_play.go
+++ b/pagerduty/data_source_pagerduty_response_play.go
@@ -1,0 +1,80 @@
+package pagerduty
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+func dataSourcePagerDutyResponsePlay() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourcePagerDutyResponsePlayRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The name of the response play.",
+			},
+			"from": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "A valid PagerDuty user's email is needed for the response play API ",
+			},
+		},
+	}
+}
+
+func dataSourcePagerDutyResponsePlayRead(d *schema.ResourceData, meta interface{}) error {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] Reading PagerDuty Response Play")
+
+	searchResponsePlay := d.Get("name").(string)
+
+	o := &pagerduty.ListResponsePlayOptions{
+		From: d.Get("from").(string),
+	}
+
+	return resource.Retry(5*time.Minute, func() *resource.RetryError {
+		resp, _, err := client.ResponsePlays.List(o)
+		if err != nil {
+			if isErrCode(err, 429) {
+				// Delaying retry by 30s as recommended by PagerDuty
+				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+				time.Sleep(30 * time.Second)
+				return resource.RetryableError(err)
+			}
+
+			return resource.NonRetryableError(err)
+		}
+
+		var found *pagerduty.ResponsePlay
+
+		for _, play := range resp.ResponsePlays {
+			if play.Name == searchResponsePlay {
+				found = play
+				break
+			}
+		}
+
+		if found == nil {
+			return resource.NonRetryableError(
+				fmt.Errorf("unable to locate any response play with name: %s", searchResponsePlay),
+			)
+		}
+
+		d.SetId(found.ID)
+		d.Set("name", found.Name)
+		d.Set("from", found.FromEmail)
+
+		return nil
+	})
+}

--- a/pagerduty/provider.go
+++ b/pagerduty/provider.go
@@ -60,6 +60,7 @@ func Provider() *schema.Provider {
 			"pagerduty_ruleset":             dataSourcePagerDutyRuleset(),
 			"pagerduty_tag":                 dataSourcePagerDutyTag(),
 			"pagerduty_event_orchestration": dataSourcePagerDutyEventOrchestration(),
+			"pagerduty_response_play":       dataSourcePagerDutyResponsePlay(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/website/docs/d/response_play.html.markdown
+++ b/website/docs/d/response_play.html.markdown
@@ -1,0 +1,38 @@
+---
+layout: "pagerduty"
+page_title: "PagerDuty: pagerduty_response_play"
+sidebar_current: "docs-pagerduty-datasource-response-play"
+description: |-
+  Get information about a response play in PagerDuty.
+---
+
+# pagerduty_response_play
+
+Use this data source to infomation about a specific response play that you can use for other PagerDuty resources.
+
+## Example Usage
+
+```hcl
+resource "pagerduty_user" "example" {
+  name  = "Earline Greenholt"
+  email = "125.greenholt.earline@graham.name"
+}
+
+data "pagerduty_response_play" "example" {
+  name = "My Response Play"
+  from = pagerduty_user.example.email
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+  * `name` - (Required) The name of the response play.
+  * `from` - (Required) The email of the user attributed to the request. Needs to be a valid email address of a user in the PagerDuty account.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+  * `id` - The ID of the response play.


### PR DESCRIPTION
- Add a pagerduty_response_play data source (fixes: #457)

This would be used as follows:

```terraform
data "pagerduty_response_play" "this" {
  name = "Response Play"
  from = data.pagerduty_user.this.email
}
```

Then it'll be possible to reference the response play via `data.pagerduty_response_play.this.id`, which would be needed for response adding a webUI created response play to a service, as some features are webUI only (e.g. Zoom conference bridge).

**Questions:**
- Should the from be on the data source? Or a default added to the provider?

**ToDo**
- [x] Add docs.
- [ ] Add tests.