### PR TITLE
Validate time zones

### DIFF
--- a/pagerduty/resource_pagerduty_ruleset_rule.go
+++ b/pagerduty/resource_pagerduty_ruleset_rule.go
@@ -88,6 +88,13 @@ func resourcePagerDutyRulesetRule() *schema.Resource {
 									"timezone": {
 										Type:     schema.TypeString,
 										Optional: true,
+										ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+											_, err := time.LoadLocation(val.(string))
+											if err != nil {
+												errs = append(errs, err)
+											}
+											return
+										},
 									},
 									"start_time": {
 										Type:     schema.TypeInt,

--- a/pagerduty/resource_pagerduty_schedule.go
+++ b/pagerduty/resource_pagerduty_schedule.go
@@ -48,6 +48,13 @@ func resourcePagerDutySchedule() *schema.Resource {
 			"time_zone": {
 				Type:     schema.TypeString,
 				Required: true,
+				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+					_, err := time.LoadLocation(val.(string))
+					if err != nil {
+						errs = append(errs, err)
+					}
+					return
+				},
 			},
 
 			"overflow": {

--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -218,6 +218,13 @@ func resourcePagerDutyService() *schema.Resource {
 						"time_zone": {
 							Type:     schema.TypeString,
 							Optional: true,
+							ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+								_, err := time.LoadLocation(val.(string))
+								if err != nil {
+									errs = append(errs, err)
+								}
+								return
+							},
 						},
 						"start_time": {
 							Type:     schema.TypeString,

--- a/pagerduty/resource_pagerduty_service_event_rule.go
+++ b/pagerduty/resource_pagerduty_service_event_rule.go
@@ -88,6 +88,13 @@ func resourcePagerDutyServiceEventRule() *schema.Resource {
 									"timezone": {
 										Type:     schema.TypeString,
 										Optional: true,
+										ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+											_, err := time.LoadLocation(val.(string))
+											if err != nil {
+												errs = append(errs, err)
+											}
+											return
+										},
 									},
 									"start_time": {
 										Type:     schema.TypeInt,

--- a/pagerduty/resource_pagerduty_user.go
+++ b/pagerduty/resource_pagerduty_user.go
@@ -81,6 +81,13 @@ func resourcePagerDutyUser() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+					_, err := time.LoadLocation(val.(string))
+					if err != nil {
+						errs = append(errs, err)
+					}
+					return
+				},
 			},
 
 			"html_url": {


### PR DESCRIPTION
We can leverage go's time package to validate time zones are valid.

On an invalid time zone the provider will fail with the message:
```
Failed to load location: unknown time zone America/nyc
```