### PR TITLE
Phone numbers starting with a 0 are not supported

### DIFF
--- a/pagerduty/resource_pagerduty_user_contact_method.go
+++ b/pagerduty/resource_pagerduty_user_contact_method.go
@@ -1,6 +1,8 @@
 package pagerduty
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -19,6 +21,14 @@ func resourcePagerDutyUserContactMethod() *schema.Resource {
 		Delete: resourcePagerDutyUserContactMethodDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourcePagerDutyUserContactMethodImport,
+		},
+		CustomizeDiff: func(context context.Context, diff *schema.ResourceDiff, i interface{}) error {
+			a := diff.Get("address").(string)
+			t := diff.Get("type").(string)
+			if t == "sms_contact_method" || t == "phone_contact_method" && strings.HasPrefix(a, "0") {
+				return errors.New("phone numbers starting with a 0 are not supported")
+			}
+			return nil
 		},
 		Schema: map[string]*schema.Schema{
 			"user_id": {

--- a/pagerduty/resource_pagerduty_user_contact_method.go
+++ b/pagerduty/resource_pagerduty_user_contact_method.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 	"time"
 
@@ -25,8 +26,13 @@ func resourcePagerDutyUserContactMethod() *schema.Resource {
 		CustomizeDiff: func(context context.Context, diff *schema.ResourceDiff, i interface{}) error {
 			a := diff.Get("address").(string)
 			t := diff.Get("type").(string)
-			if t == "sms_contact_method" || t == "phone_contact_method" && strings.HasPrefix(a, "0") {
-				return errors.New("phone numbers starting with a 0 are not supported")
+			if t == "sms_contact_method" || t == "phone_contact_method" {
+				if strings.HasPrefix(a, "0") {
+					return errors.New("phone numbers starting with a 0 are not supported")
+				}
+				if _, err := strconv.Atoi(a); err != nil {
+					return errors.New("phone numbers should only contain digits")
+				}
 			}
 			return nil
 		},

--- a/pagerduty/resource_pagerduty_user_contact_method_test.go
+++ b/pagerduty/resource_pagerduty_user_contact_method_test.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -52,6 +53,10 @@ func TestAccPagerDutyUserContactMethodPhone_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyUserContactMethodExists("pagerduty_user_contact_method.foo"),
 				),
+			},
+			{
+				Config:      testAccCheckPagerDutyUserContactMethodPhoneConfig(username, email, "04153013250"),
+				ExpectError: regexp.MustCompile("phone numbers starting with a 0 are not supported"),
 			},
 			{
 				Config: testAccCheckPagerDutyUserContactMethodPhoneConfig(usernameUpdated, emailUpdated, "8019351337"),


### PR DESCRIPTION
There are still a lot of phone numbers not supported by PagerDuty, a particularly large set of them is numbers starting with 0, particularly common in UK and Australia. There is currently no timeline when this might be fixed. Until the numbers are enabled, we should validate them at the provider level.

In addition to leading zero, we know only the digits-only format is supported