### PR TITLE
Embed time zone data into the provider's binary

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -6,7 +6,7 @@ PKG_NAME=pagerduty
 default: build
 
 build: fmtcheck
-	go install
+	go install -tags timetzdata
 
 test: fmtcheck
 	go test -i $(TEST) || exit 1


### PR DESCRIPTION
fixes #477 

To address the issue of running the provider in environments without time zone data installed, we can build in time zone data. The binary will still check OS hosted time zone data as a fallback.

Ref:
https://pkg.go.dev/time/tzdata
https://wawand.co/blog/posts/timezonedata-go115-7c2a25e7-dbdd-4b6b-8092-51cc2d0241ce/



