### PR TITLE
Fixes constant diff in value_extractor

### DIFF
--- a/pagerduty/resource_pagerduty_service_integration.go
+++ b/pagerduty/resource_pagerduty_service_integration.go
@@ -523,6 +523,7 @@ func flattenEmailParsers(v []*pagerduty.EmailParser) []map[string]interface{} {
 				"type":         ve.Type,
 				"value_name":   ve.ValueName,
 				"part":         ve.Part,
+				"regex":        ve.Regex,
 				"starts_after": ve.StartsAfter,
 				"ends_before":  ve.EndsBefore,
 			}


### PR DESCRIPTION
The feature branch missed the `regex` field in `value_extractor` block,
showing a constant drift whenever a plan was run. This fixes the drift.