### PR TITLE
Issue 463: Introduce catch_all

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	cloud.google.com/go v0.71.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.1
-	github.com/heimweh/go-pagerduty v0.0.0-20220208023456-83fe435832fb
+	github.com/heimweh/go-pagerduty v0.0.0-20220422231448-43095fe5ba3f
 	golang.org/x/tools v0.0.0-20201110124207-079ba7bd75cd // indirect
 	google.golang.org/api v0.35.0 // indirect
 	google.golang.org/genproto v0.0.0-20201109203340-2640f1f9cdfb // indirect

--- a/go.sum
+++ b/go.sum
@@ -284,6 +284,8 @@ github.com/heimweh/go-pagerduty v0.0.0-20211210233744-b65de43109c1 h1:49zl3n/g+f
 github.com/heimweh/go-pagerduty v0.0.0-20211210233744-b65de43109c1/go.mod h1:JtJGtgN0y9KOCaqFMZFaBCWskpO/KK3Ro9TwjP9ss6w=
 github.com/heimweh/go-pagerduty v0.0.0-20220208023456-83fe435832fb h1:p3faOVCU8L4wab9mpxN9Cm/VNVkPD8GMEfD0sPHw9nY=
 github.com/heimweh/go-pagerduty v0.0.0-20220208023456-83fe435832fb/go.mod h1:JtJGtgN0y9KOCaqFMZFaBCWskpO/KK3Ro9TwjP9ss6w=
+github.com/heimweh/go-pagerduty v0.0.0-20220422231448-43095fe5ba3f h1:NLk7iDq85F2lz0q1gY32vZR506aYiNcgvV+Us1rX1q4=
+github.com/heimweh/go-pagerduty v0.0.0-20220422231448-43095fe5ba3f/go.mod h1:JtJGtgN0y9KOCaqFMZFaBCWskpO/KK3Ro9TwjP9ss6w=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/pagerduty/resource_pagerduty_ruleset_rule.go
+++ b/pagerduty/resource_pagerduty_ruleset_rule.go
@@ -907,6 +907,7 @@ func resourcePagerDutyRulesetRuleDelete(d *schema.ResourceData, meta interface{}
 		rule.Actions.Priority = nil
 		rule.Actions.Route = nil
 		rule.Actions.Severity = nil
+		rule.Actions.Suppress = new(pagerduty.RuleActionSuppress)
 		rule.Actions.Suppress.Value = true
 		rule.Actions.Suspend = nil
 

--- a/pagerduty/resource_pagerduty_ruleset_rule.go
+++ b/pagerduty/resource_pagerduty_ruleset_rule.go
@@ -900,8 +900,15 @@ func resourcePagerDutyRulesetRuleDelete(d *schema.ResourceData, meta interface{}
 			return err
 		}
 
-		rule.Actions = nil
-		rule.TimeFrame = nil
+		// Reset all available actions back to the default state of the catch_all rule
+		rule.Actions.Annotate = nil
+		rule.Actions.EventAction = nil
+		rule.Actions.Extractions = nil
+		rule.Actions.Priority = nil
+		rule.Actions.Route = nil
+		rule.Actions.Severity = nil
+		rule.Actions.Suppress.Value = true
+		rule.Actions.Suspend = nil
 
 		if err := performRulesetRuleUpdate(rulesetID, d.Id(), rule, client); err != nil {
 			return err

--- a/pagerduty/resource_pagerduty_ruleset_rule.go
+++ b/pagerduty/resource_pagerduty_ruleset_rule.go
@@ -868,7 +868,7 @@ func performRulesetRuleUpdate(rulesetID string, id string, rule *pagerduty.Rules
 	retryErr := resource.Retry(30*time.Second, func() *resource.RetryError {
 		if updatedRule, _, err := client.Rulesets.UpdateRule(rulesetID, id, rule); err != nil {
 			return resource.RetryableError(err)
-		} else if rule.Position != nil && *updatedRule.Position != *rule.Position {
+		} else if rule.Position != nil && *updatedRule.Position != *rule.Position && rule.CatchAll != true {
 			log.Printf("[INFO] PagerDuty ruleset rule %s position %d needs to be %d", updatedRule.ID, *updatedRule.Position, *rule.Position)
 			return resource.RetryableError(fmt.Errorf("Error updating ruleset rule %s position %d needs to be %d", updatedRule.ID, *updatedRule.Position, *rule.Position))
 		}

--- a/pagerduty/resource_pagerduty_ruleset_rule_test.go
+++ b/pagerduty/resource_pagerduty_ruleset_rule_test.go
@@ -165,6 +165,56 @@ func TestAccPagerDutyRulesetRule_CatchAllRule(t *testing.T) {
 	})
 }
 
+func TestAccPagerDutyRulesetRule_CatchAllRuleRoute(t *testing.T) {
+	ruleset := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	team := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	rule1 := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	catch_all_rule := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyRulesetRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyRulesetRuleConfigCatchAllRuleRoute(team, ruleset, rule1, catch_all_rule),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyRulesetRuleExists("pagerduty_ruleset_rule.foo"),
+					testAccCheckPagerDutyRulesetRuleExists("pagerduty_ruleset_rule.catch_all"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_ruleset_rule.foo", "position", "0"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_ruleset_rule.catch_all", "position", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_ruleset_rule.foo", "disabled", "false"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_ruleset_rule.foo", "conditions.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_ruleset_rule.foo", "conditions.0.operator", "and"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_ruleset_rule.foo", "conditions.0.subconditions.0.operator", "contains"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_ruleset_rule.foo", "conditions.0.subconditions.0.parameter.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_ruleset_rule.foo", "conditions.0.subconditions.0.parameter.0.value", "disk space"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_ruleset_rule.foo", "actions.0.annotate.0.value", rule1),
+					resource.TestCheckResourceAttr(
+						"pagerduty_ruleset_rule.catch_all", "catch_all", "true"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_ruleset_rule.catch_all", "actions.0.annotate.0.value", catch_all_rule),
+					resource.TestCheckResourceAttr(
+						"pagerduty_ruleset_rule.catch_all", "actions.0.suppress.0.value", "false"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_ruleset_rule.catch_all", "actions.0.route.0.value", "P5DTL0K"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_ruleset_rule.catch_all", "actions.0.severity.0.value", "info"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckPagerDutyRulesetRuleDestroy(s *terraform.State) error {
 	client, _ := testAccProvider.Meta().(*Config).Client()
 	for _, r := range s.RootModule().Resources {
@@ -503,6 +553,80 @@ resource "pagerduty_ruleset_rule" "catch_all" {
 		}
 		suppress {
 			value = true
+		}
+	}
+}
+`, team, ruleset, rule1, catch_all_rule)
+}
+
+func testAccCheckPagerDutyRulesetRuleConfigCatchAllRuleRoute(team, ruleset, rule1, catch_all_rule string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_team" "foo" {
+	name = "%s"
+}
+
+resource "pagerduty_ruleset" "foo" {
+	name = "%s"
+	team {
+		id = pagerduty_team.foo.id
+	}
+}
+resource "pagerduty_ruleset_rule" "foo" {
+	ruleset = pagerduty_ruleset.foo.id
+	position = 0
+	disabled = false
+	time_frame {
+		scheduled_weekly {
+			weekdays = [3,7]
+			timezone = "America/Los_Angeles"
+			start_time = "1000000"
+			duration = "3600000"
+
+		}
+	}
+	conditions {
+		operator = "and"
+		subconditions {
+			operator = "contains"
+			parameter {
+				value = "disk space"
+				path = "summary"
+			}
+		}
+	}
+	actions {
+		route {
+			value = "P5DTL0K"
+		}
+		severity  {
+			value = "warning"
+		}
+		annotate {
+			value = "%s"
+		}
+		extractions {
+			target = "dedup_key"
+			source = "source"
+			regex = "(.*)"
+		}
+	}
+}
+resource "pagerduty_ruleset_rule" "catch_all" {
+	ruleset = pagerduty_ruleset.foo.id
+	position = 1
+	catch_all = true
+	actions {
+		annotate {
+			value = "%s"
+		}
+		suppress {
+			value = false
+		}
+		route {
+			value = "P5DTL0K"
+		}
+		severity  {
+			value = "info"
 		}
 	}
 }

--- a/pagerduty/resource_pagerduty_ruleset_rule_test.go
+++ b/pagerduty/resource_pagerduty_ruleset_rule_test.go
@@ -118,6 +118,53 @@ func TestAccPagerDutyRulesetRule_MultipleRules(t *testing.T) {
 		},
 	})
 }
+
+func TestAccPagerDutyRulesetRule_CatchAllRule(t *testing.T) {
+	ruleset := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	team := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	rule1 := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	catch_all_rule := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyRulesetRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyRulesetRuleConfigCatchAllRule(team, ruleset, rule1, catch_all_rule),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyRulesetRuleExists("pagerduty_ruleset_rule.foo"),
+					testAccCheckPagerDutyRulesetRuleExists("pagerduty_ruleset_rule.catch_all"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_ruleset_rule.foo", "position", "0"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_ruleset_rule.catch_all", "position", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_ruleset_rule.foo", "disabled", "false"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_ruleset_rule.foo", "conditions.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_ruleset_rule.foo", "conditions.0.operator", "and"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_ruleset_rule.foo", "conditions.0.subconditions.0.operator", "contains"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_ruleset_rule.foo", "conditions.0.subconditions.0.parameter.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_ruleset_rule.foo", "conditions.0.subconditions.0.parameter.0.value", "disk space"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_ruleset_rule.foo", "actions.0.annotate.0.value", rule1),
+					resource.TestCheckResourceAttr(
+						"pagerduty_ruleset_rule.catch_all", "catch_all", "true"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_ruleset_rule.catch_all", "actions.0.annotate.0.value", catch_all_rule),
+					resource.TestCheckResourceAttr(
+						"pagerduty_ruleset_rule.catch_all", "actions.0.suppress.0.value", "true"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckPagerDutyRulesetRuleDestroy(s *terraform.State) error {
 	client, _ := testAccProvider.Meta().(*Config).Client()
 	for _, r := range s.RootModule().Resources {
@@ -392,4 +439,72 @@ resource "pagerduty_ruleset_rule" "baz" {
 	}
 }
 `, team, ruleset, rule1, rule2, rule3)
+}
+
+func testAccCheckPagerDutyRulesetRuleConfigCatchAllRule(team, ruleset, rule1, catch_all_rule string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_team" "foo" {
+	name = "%s"
+}
+
+resource "pagerduty_ruleset" "foo" {
+	name = "%s"
+	team { 
+		id = pagerduty_team.foo.id
+	}
+}
+resource "pagerduty_ruleset_rule" "foo" {
+	ruleset = pagerduty_ruleset.foo.id
+	position = 0
+	disabled = false
+	time_frame {
+		scheduled_weekly {
+			weekdays = [3,7]
+			timezone = "America/Los_Angeles"
+			start_time = "1000000"
+			duration = "3600000"
+
+		}
+	}
+	conditions {
+		operator = "and"
+		subconditions {
+			operator = "contains"
+			parameter {
+				value = "disk space"
+				path = "summary"
+			}
+		}
+	}
+	actions {
+		route {
+			value = "P5DTL0K"
+		}
+		severity  {
+			value = "warning"
+		}
+		annotate {
+			value = "%s"
+		}
+		extractions {
+			target = "dedup_key"
+			source = "source"
+			regex = "(.*)"
+		}
+	}
+}
+resource "pagerduty_ruleset_rule" "catch_all" {
+	ruleset = pagerduty_ruleset.foo.id
+	position = 1
+	catch_all = true
+	actions {
+		annotate {
+			value = "%s"
+		}
+		suppress {
+			value = true
+		}
+	}
+}
+`, team, ruleset, rule1, catch_all_rule)
 }

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/ruleset.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/ruleset.go
@@ -120,14 +120,14 @@ type ListRulesetRulesResponse struct {
 
 // RuleActions represents a rule action
 type RuleActions struct {
-	Suppress    *RuleActionSuppress     `json:"suppress,omitempty"`
-	Annotate    *RuleActionParameter    `json:"annotate,omitempty"`
-	Severity    *RuleActionParameter    `json:"severity,omitempty"`
-	Priority    *RuleActionParameter    `json:"priority,omitempty"`
-	Route       *RuleActionParameter    `json:"route,omitempty"`
-	EventAction *RuleActionParameter    `json:"event_action,omitempty"`
+	Suppress    *RuleActionSuppress     `json:"suppress"`
+	Annotate    *RuleActionParameter    `json:"annotate"`
+	Severity    *RuleActionParameter    `json:"severity"`
+	Priority    *RuleActionParameter    `json:"priority"`
+	Route       *RuleActionParameter    `json:"route"`
+	EventAction *RuleActionParameter    `json:"event_action"`
 	Extractions []*RuleActionExtraction `json:"extractions,omitempty"`
-	Suspend     *RuleActionIntParameter `json:"suspend,omitempty"`
+	Suspend     *RuleActionIntParameter `json:"suspend"`
 }
 
 // RuleActionParameter represents a string parameter object on a rule action

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/webhook_subscription.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/webhook_subscription.go
@@ -21,7 +21,7 @@ type DeliveryMethod struct {
 	TemporarilyDisabled bool             `json:"temporarily_disabled,omitempty"`
 	Type                string           `json:"type,omitempty"`
 	URL                 string           `json:"url,omitempty"`
-	CustomHeaders       []*CustomHeaders `json:"custom_headers,omitempty"`
+	CustomHeaders       []*CustomHeaders `json:"custom_headers"`
 }
 
 type CustomHeaders struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -124,7 +124,7 @@ github.com/hashicorp/terraform-registry-address
 github.com/hashicorp/terraform-svchost
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20220208023456-83fe435832fb
+# github.com/heimweh/go-pagerduty v0.0.0-20220422231448-43095fe5ba3f
 ## explicit
 github.com/heimweh/go-pagerduty/pagerduty
 # github.com/klauspost/compress v1.11.2

--- a/website/docs/r/ruleset_rule.html.markdown
+++ b/website/docs/r/ruleset_rule.html.markdown
@@ -95,6 +95,20 @@ resource "pagerduty_ruleset_rule" "foo" {
     }
   }
 }
+
+resource "pagerduty_ruleset_rule" "catch_all" {
+  ruleset  = pagerduty_ruleset.foo.id
+  position = 1
+  catch_all = true
+  actions {
+    annotate {
+      value = "From Terraform"
+    }
+    suppress {
+      value = true
+    }
+  }
+}
 ```
 
 ## Argument Reference
@@ -104,6 +118,7 @@ The following arguments are supported:
 * `ruleset` - (Required) The ID of the ruleset that the rule belongs to.
 * `conditions` - (Required) Conditions evaluated to check if an event matches this event rule. Is always empty for the catch-all rule, though.
 * `position` - (Optional) Position/index of the rule within the ruleset.
+* `catch_all` - (Optional) Indicates whether the Event Rule is the last Event Rule of the Ruleset that serves as a catch-all. It has limited functionality compared to other rules and always matches.
 * `disabled` - (Optional) Indicates whether the rule is disabled and would therefore not be evaluated.
 * `time_frame` - (Optional) Settings for [scheduling the rule](https://support.pagerduty.com/docs/rulesets#section-scheduled-event-rules).
 * `actions` - (Optional) Actions to apply to an event if the conditions match.


### PR DESCRIPTION
Reference: https://github.com/PagerDuty/terraform-provider-pagerduty/issues/463

Proposal is to introduce `catch_all` parameter as parameter to reflect what is in the API.

Then if `catch_all` is present, as catch-all rule is created at Ruleset creation, an update is performed instead of a  create (PUT instead of POST)

Concerning the delete, I am skipping it but maybe it could be better to do another update to reset the catch-all rule (to be discussed in this thread)

Concerning the the `conditions` as mentioned, it is optional. So in case of `catch_all` it must be removed