### PR TITLE
Include timezdata build tag into the goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,6 +6,8 @@ builds:
     - -trimpath
   ldflags:
     - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+  tags:
+    - timetzdata
   goos:
     - freebsd
     - windows


### PR DESCRIPTION
fixes #484 

Following up on #478 as the time zone data should be included in the released binary. The #478 only included it in the GNUmakefile, which appears to be ignored in the release build process.