### PR TITLE
A pair of minor ACC testing improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.4.2 (Unreleased)
+
+IMPROVEMENTS:
+* Use "@foo.test" email addresses in tests
+
 ## 2.4.1 (April 22, 2022)
 IMPROVEMENTS:
 * `resource/pagerduty_user_notification`: Create user/notification rule: allow using existing ones ([#482](https://github.com/PagerDuty/terraform-provider-pagerduty/pull/482))
@@ -19,7 +24,7 @@ IMPROVEMENTS:
 * `resource/maintenance_window`: Ignore error code 405 on delete ([#466](https://github.com/PagerDuty/terraform-provider-pagerduty/pull/466))
 
 
-## 2.3.0 (February 10, 2022) 
+## 2.3.0 (February 10, 2022)
 IMPROVEMENTS:
 * Updated TF SDK to v2.10.1 and added `depends_on` to eventrule tests ([#446](https://github.com/PagerDuty/terraform-provider-pagerduty/pull/446))
 * `resource/pagerduty_schedule`: Added validation to `duration_seconds` ([#433](https://github.com/PagerDuty/terraform-provider-pagerduty/pull/433))
@@ -198,11 +203,11 @@ IMPROVEMENTS:
 * `data_source_pagerduty_ruleset`: Added `routing_keys` field to the `ruleset` object ([#305](https://github.com/PagerDuty/terraform-provider-pagerduty/pull/305))
 
 ## 1.9.3 (February 11, 2021)
-BUG FIXES: 
+BUG FIXES:
 * `resource/pagerduty_service_event_rule`,`resource/pagerduty_ruleset_rule`: Fixed Bug with Event Rule Suppress Action ([#302](https://github.com/PagerDuty/terraform-provider-pagerduty/pull/302))
 
 ## 1.9.2 (February 10, 2021)
-BUG FIXES: 
+BUG FIXES:
 * `resource/pagerduty_service_event_rule`,`resource/pagerduty_ruleset_rule`: Fixed Bug with Event Rule Positioning ([#301](https://github.com/PagerDuty/terraform-provider-pagerduty/pull/301))
 
 ## 1.9.1 (February 8, 2021)
@@ -268,7 +273,7 @@ FEATURES
 * Implement retry logic on all reads ([#208](https://github.com/PagerDuty/terraform-provider-pagerduty/issues/208))
 * Bump golang to v1.14.1 ([#193](https://github.com/PagerDuty/terraform-provider-pagerduty/issues/193))
 
-BUG FIXES: 
+BUG FIXES:
 * data_source_ruleset: add example of Default Global Ruleset in Docs ([#239](https://github.com/PagerDuty/terraform-provider-pagerduty/issues/239))
 
 ## 1.7.2 (June 01, 2020)
@@ -276,7 +281,7 @@ FEATURES
 * **New Data Source:** `pagerduty_ruleset`  ([#237](https://github.com/PagerDuty/terraform-provider-pagerduty/issues/237))
 * Update docs/tests to TF 0.12 syntax ([#223](https://github.com/PagerDuty/terraform-provider-pagerduty/issues/223))
 
-BUG FIXES: 
+BUG FIXES:
 * testing: update sweepers ([#220](https://github.com/PagerDuty/terraform-provider-pagerduty/issues/220))
 * data_source_priority: adding doc to sidebar nav ([#221](https://github.com/PagerDuty/terraform-provider-pagerduty/issues/221))
 
@@ -363,7 +368,7 @@ BUG FIXES:
 IMPROVEMENTS:
 * Switch to standalone Terraform Plugin SDK: ([#158](https://github.com/PagerDuty/terraform-provider-pagerduty/issues/158))
 
-* Add html_url read-only attribute to resource_pagerduty_service, resource_pagerduty_extension, resource_pagerduty_team ([#162](https://github.com/PagerDuty/terraform-provider-pagerduty/issues/162))  
+* Add html_url read-only attribute to resource_pagerduty_service, resource_pagerduty_extension, resource_pagerduty_team ([#162](https://github.com/PagerDuty/terraform-provider-pagerduty/issues/162))
 
 * resource/pagerduty_event_rule: Documentation for `depends_on` field ([#152](https://github.com/PagerDuty/terraform-provider-pagerduty/issues/152)).
 
@@ -397,9 +402,9 @@ BUG FIXES:
 
 BUG FIXES:
 
-* data-source/pagerduty_team: Fix team search issue [[#110](https://github.com/PagerDuty/terraform-provider-pagerduty/issues/110)] 
+* data-source/pagerduty_team: Fix team search issue [[#110](https://github.com/PagerDuty/terraform-provider-pagerduty/issues/110)]
 * resource/pagerduty_maintenance_window: Suppress spurious diff in `start_time` & `end_time` ([#116](https://github.com/PagerDuty/terraform-provider-pagerduty/issues/116))
-* resource/pagerduty_service: Set invitation_sent [[#127](https://github.com/PagerDuty/terraform-provider-pagerduty/issues/127)] 
+* resource/pagerduty_service: Set invitation_sent [[#127](https://github.com/PagerDuty/terraform-provider-pagerduty/issues/127)]
 * resource/pagerduty_escalation_policy: Correctly set teams ([#129](https://github.com/PagerDuty/terraform-provider-pagerduty/issues/129))
 
 IMPROVEMENTS:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Terraform Provider for PagerDuty
-================================
+# Terraform Provider for PagerDuty
 
 - Website: https://registry.terraform.io/providers/PagerDuty/pagerduty/latest
 - Documentation: https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs
@@ -8,14 +7,12 @@ Terraform Provider for PagerDuty
 
 [PagerDuty](https://www.pagerduty.com/) is an alarm aggregation and dispatching service for system administrators and support teams. It collects alerts from your monitoring tools, gives you an overall view of all of your monitoring alarms, and alerts an on duty engineer if there’s a problem. The Terraform Pagerduty provider is a plugin for Terraform that allows for the management of PagerDuty resources using HCL (HashiCorp Configuration Language).
 
-Requirements
-------------
+## Requirements
 
 -	[Terraform](https://www.terraform.io/downloads.html) 0.12.x
 -	[Go](https://golang.org/doc/install) 1.11 (to build the provider plugin)
 
-Building The Provider
----------------------
+## Building The Provider
 
 Clone repository to: `$GOPATH/src/github.com/terraform-providers/terraform-provider-pagerduty`
 
@@ -31,14 +28,13 @@ $ cd $GOPATH/src/github.com/PagerDuty/terraform-provider-pagerduty
 $ make build
 ```
 
-Using the provider
-----------------------
+## Using the provider
+
 Please refer to https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs for
 examples on how to use the provider and detailed documentation about the
 Resources and Data Sources the provider has.
 
-Developing the Provider
----------------------------
+## Developing the Provider
 
 If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.11+ is *required*). You'll also need to correctly setup a [GOPATH](http://golang.org/doc/code.html#GOPATH), as well as adding `$GOPATH/bin` to your `$PATH`.
 
@@ -50,6 +46,8 @@ $ make build
 $ $GOPATH/bin/terraform-provider-pagerduty
 ...
 ```
+
+### Testing
 
 In order to test the provider, you can simply run `make test`.
 
@@ -66,3 +64,9 @@ $ make testacc
 ```
 
 *Additional Note:* In order for the tests on the Slack Connection resources to pass you will need valid Slack workspace and channel IDs from a [Slack workspace connected to your PagerDuty account](https://support.pagerduty.com/docs/slack-integration-guide#integration-walkthrough).
+
+Run a specific subset of tests by name use the `TESTARGS="-run TestName"` option which will run all test functions with "TestName" in their name.
+
+```sh
+$ make testacc TESTARGS="-run TestAccPagerDutyTeam"
+```

--- a/pagerduty/data_source_pagerduty_escalation_policy_test.go
+++ b/pagerduty/data_source_pagerduty_escalation_policy_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAccDataSourcePagerDutyEscalationPolicy_Basic(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{

--- a/pagerduty/data_source_pagerduty_schedule_test.go
+++ b/pagerduty/data_source_pagerduty_schedule_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestAccDataSourcePagerDutySchedule_Basic(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	schedule := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	location := "Europe/Berlin"
 	start := timeNowInLoc(location).Add(24 * time.Hour).Round(1 * time.Hour).Format(time.RFC3339)

--- a/pagerduty/data_source_pagerduty_service_integration_test.go
+++ b/pagerduty/data_source_pagerduty_service_integration_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAccDataSourcePagerDutyIntegration_Basic(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	serviceIntegration := "Datadog"

--- a/pagerduty/data_source_pagerduty_service_test.go
+++ b/pagerduty/data_source_pagerduty_service_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAccDataSourcePagerDutyService_Basic(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
 

--- a/pagerduty/data_source_pagerduty_user_test.go
+++ b/pagerduty/data_source_pagerduty_user_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAccDataSourcePagerDutyUser_Basic(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },

--- a/pagerduty/import_pagerduty_escalation_policy_test.go
+++ b/pagerduty/import_pagerduty_escalation_policy_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAccPagerDutyEscalationPolicy_import(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{

--- a/pagerduty/import_pagerduty_schedule_test.go
+++ b/pagerduty/import_pagerduty_schedule_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAccPagerDutySchedule_import(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	schedule := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	location := "Europe/Berlin"
 	start := timeNowInLoc(location).Add(24 * time.Hour).Round(1 * time.Hour).Format(time.RFC3339)

--- a/pagerduty/import_pagerduty_service_dependency_test.go
+++ b/pagerduty/import_pagerduty_service_dependency_test.go
@@ -13,7 +13,7 @@ func TestAccPagerDutyServiceDependency_import(t *testing.T) {
 	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	businessService := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{

--- a/pagerduty/import_pagerduty_service_event_rule_test.go
+++ b/pagerduty/import_pagerduty_service_event_rule_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAccPagerDutyServiceEventRule_import(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	rule := fmt.Sprintf("tf-%s", acctest.RandString(5))

--- a/pagerduty/import_pagerduty_service_integration_test.go
+++ b/pagerduty/import_pagerduty_service_integration_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAccPagerDutyServiceIntegration_import(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	serviceIntegration := fmt.Sprintf("tf-%s", acctest.RandString(5))

--- a/pagerduty/import_pagerduty_service_test.go
+++ b/pagerduty/import_pagerduty_service_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAccPagerDutyService_import(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
 
@@ -34,7 +34,7 @@ func TestAccPagerDutyService_import(t *testing.T) {
 
 func TestAccPagerDutyServiceWithIncidentUrgency_import(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
 

--- a/pagerduty/import_pagerduty_slack_connection_test.go
+++ b/pagerduty/import_pagerduty_slack_connection_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAccPagerDutySlackConnection_import(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
 

--- a/pagerduty/import_pagerduty_user_contact_method_test.go
+++ b/pagerduty/import_pagerduty_user_contact_method_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAccPagerDutyUserContactMethod_import(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/pagerduty/import_pagerduty_user_notification_rule_test.go
+++ b/pagerduty/import_pagerduty_user_notification_rule_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAccPagerDutyUserNotificationRule_import(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	contactMethodType := "phone_contact_method"
 
 	resource.Test(t, resource.TestCase{

--- a/pagerduty/import_pagerduty_user_test.go
+++ b/pagerduty/import_pagerduty_user_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAccPagerDutyUser_import(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/pagerduty/import_pagerduty_webhook_subscription_test.go
+++ b/pagerduty/import_pagerduty_webhook_subscription_test.go
@@ -11,7 +11,7 @@ import (
 func TestAccPagerDutyWebhookSubscription_import(t *testing.T) {
 	description := fmt.Sprintf("tf-test-%s", acctest.RandString(5))
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
 

--- a/pagerduty/resource_pagerduty_addon_test.go
+++ b/pagerduty/resource_pagerduty_addon_test.go
@@ -63,7 +63,7 @@ func TestAccPagerDutyAddon_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"pagerduty_addon.foo", "name", addon),
 					resource.TestCheckResourceAttr(
-						"pagerduty_addon.foo", "src", "https://intranet.foo.com/status"),
+						"pagerduty_addon.foo", "src", "https://intranet.foo.test/status"),
 				),
 			},
 			{
@@ -125,7 +125,7 @@ func testAccCheckPagerDutyAddonConfig(addon string) string {
 	return fmt.Sprintf(`
 resource "pagerduty_addon" "foo" {
   name = "%s"
-  src  = "https://intranet.foo.com/status"
+  src  = "https://intranet.foo.test/status"
 }
 `, addon)
 }

--- a/pagerduty/resource_pagerduty_business_service_subscriber_test.go
+++ b/pagerduty/resource_pagerduty_business_service_subscriber_test.go
@@ -13,7 +13,7 @@ import (
 func TestAccPagerDutyBusinessServiceSubscriber_User(t *testing.T) {
 	businessServiceName := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -57,7 +57,7 @@ func TestAccPagerDutyBusinessServiceSubscriber_TeamUser(t *testing.T) {
 	businessServiceName := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	team := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/pagerduty/resource_pagerduty_escalation_policy_test.go
+++ b/pagerduty/resource_pagerduty_escalation_policy_test.go
@@ -52,7 +52,7 @@ func testSweepEscalationPolicy(region string) error {
 
 func TestAccPagerDutyEscalationPolicy_Basic(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	escalationPolicyUpdated := fmt.Sprintf("tf-%s", acctest.RandString(5))
 
@@ -102,7 +102,7 @@ func TestAccPagerDutyEscalationPolicy_Basic(t *testing.T) {
 
 func TestAccPagerDutyEscalationPolicyWithTeams_Basic(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	team := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	escalationPolicyUpdated := fmt.Sprintf("tf-%s", acctest.RandString(5))

--- a/pagerduty/resource_pagerduty_extension_servicenow_test.go
+++ b/pagerduty/resource_pagerduty_extension_servicenow_test.go
@@ -159,7 +159,7 @@ func testAccCheckPagerDutyExtensionServiceNowConfig(name string, extension_name 
 	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
   name        = "%[1]v"
-  email       = "%[1]v@foo.com"
+  email       = "%[1]v@foo.test"
   color       = "green"
   role        = "user"
   job_title   = "foo"

--- a/pagerduty/resource_pagerduty_extension_test.go
+++ b/pagerduty/resource_pagerduty_extension_test.go
@@ -137,7 +137,7 @@ func testAccCheckPagerDutyExtensionConfig(name string, extension_name string, ur
 	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
   name        = "%[1]v"
-  email       = "%[1]v@foo.com"
+  email       = "%[1]v@foo.test"
   color       = "green"
   role        = "user"
   job_title   = "foo"

--- a/pagerduty/resource_pagerduty_maintenance_window_test.go
+++ b/pagerduty/resource_pagerduty_maintenance_window_test.go
@@ -115,7 +115,7 @@ func testAccCheckPagerDutyMaintenanceWindowConfig(desc, start, end string) strin
 	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
   name        = "%[1]v"
-  email       = "%[1]v@foo.com"
+  email       = "%[1]v@foo.test"
   color       = "green"
   role        = "user"
   job_title   = "foo"
@@ -163,7 +163,7 @@ func testAccCheckPagerDutyMaintenanceWindowConfigUpdated(desc, start, end string
 	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
   name        = "%[1]v"
-  email       = "%[1]v@foo.com"
+  email       = "%[1]v@foo.test"
   color       = "green"
   role        = "user"
   job_title   = "foo"

--- a/pagerduty/resource_pagerduty_response_play_test.go
+++ b/pagerduty/resource_pagerduty_response_play_test.go
@@ -24,7 +24,7 @@ func TestAccPagerDutyResponsePlay_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"pagerduty_response_play.foo", "name", name),
 					resource.TestCheckResourceAttr(
-						"pagerduty_response_play.foo", "from", name+"@foo.com"),
+						"pagerduty_response_play.foo", "from", name+"@foo.test"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_response_play.foo", "responder.#", "2"),
 				),
@@ -36,7 +36,7 @@ func TestAccPagerDutyResponsePlay_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"pagerduty_response_play.foo", "name", name),
 					resource.TestCheckResourceAttr(
-						"pagerduty_response_play.foo", "from", name+"@foo.com"),
+						"pagerduty_response_play.foo", "from", name+"@foo.test"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_response_play.foo", "responder.#", "1"),
 					resource.TestCheckResourceAttr(
@@ -96,7 +96,7 @@ func testAccCheckPagerDutyResponsePlayConfig(name string) string {
 	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
   name        = "%[1]v"
-  email       = "%[1]v@foo.com"
+  email       = "%[1]v@foo.test"
   color       = "green"
   role        = "user"
   job_title   = "foo"
@@ -133,7 +133,7 @@ resource "pagerduty_response_play" "foo" {
 	type = "user_reference"
 	id = pagerduty_user.foo.id
   }
-runnability = "services"	
+runnability = "services"
 }
 `, name)
 }
@@ -142,28 +142,28 @@ func testAccCheckPagerDutyResponsePlayConfigUpdated(name string) string {
 	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
 	name        = "%[1]v"
-	email       = "%[1]v@foo.com"
+	email       = "%[1]v@foo.test"
 	color       = "green"
 	role        = "user"
 	job_title   = "foo"
 	description = "foo"
 }
-	
+
 resource "pagerduty_escalation_policy" "foo" {
 	name        = "%[1]v"
 	description = "bar"
 	num_loops   = 2
-	
+
 	rule {
 		escalation_delay_in_minutes = 10
-	
+
 		target {
 			type = "user_reference"
 			id   = pagerduty_user.foo.id
 		}
 	}
 }
-	
+
 resource "pagerduty_response_play" "foo" {
 	name = "%[1]v"
 	from = pagerduty_user.foo.email

--- a/pagerduty/resource_pagerduty_schedule_test.go
+++ b/pagerduty/resource_pagerduty_schedule_test.go
@@ -51,7 +51,7 @@ func testSweepSchedule(region string) error {
 
 func TestAccPagerDutySchedule_Basic(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	schedule := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	scheduleUpdated := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	location := "America/New_York"
@@ -113,7 +113,7 @@ func TestAccPagerDutySchedule_Basic(t *testing.T) {
 
 func TestAccPagerDutyScheduleWithTeams_Basic(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	schedule := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	scheduleUpdated := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	location := "America/New_York"
@@ -176,7 +176,7 @@ func TestAccPagerDutyScheduleWithTeams_Basic(t *testing.T) {
 }
 func TestAccPagerDutyScheduleOverflow_Basic(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	schedule := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	scheduleUpdated := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	location := "America/New_York"
@@ -206,7 +206,7 @@ func TestAccPagerDutyScheduleOverflow_Basic(t *testing.T) {
 
 func TestAccPagerDutySchedule_BasicWeek(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	schedule := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	scheduleUpdated := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	location := "Australia/Melbourne"
@@ -268,7 +268,7 @@ func TestAccPagerDutySchedule_BasicWeek(t *testing.T) {
 
 func TestAccPagerDutySchedule_Multi(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	schedule := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	location := "Europe/Berlin"
 	start := timeNowInLoc(location).Add(24 * time.Hour).Round(1 * time.Hour).Format(time.RFC3339)
@@ -745,7 +745,7 @@ resource "pagerduty_schedule" "foo" {
 
   time_zone   = "%s"
   description = "foo"
-  
+
   teams = [pagerduty_team.foo.id]
 
   layer {
@@ -781,7 +781,7 @@ resource "pagerduty_schedule" "foo" {
 
   time_zone   = "%s"
   description = "Managed by Terraform"
-  
+
   teams = [pagerduty_team.foo.id]
 
   layer {

--- a/pagerduty/resource_pagerduty_service_dependency_test.go
+++ b/pagerduty/resource_pagerduty_service_dependency_test.go
@@ -15,7 +15,7 @@ func TestAccPagerDutyBusinessServiceDependency_Basic(t *testing.T) {
 	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	businessService := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
@@ -152,7 +152,7 @@ func TestAccPagerDutyTechnicalServiceDependency_Basic(t *testing.T) {
 	dependentService := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	supportingService := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{

--- a/pagerduty/resource_pagerduty_service_event_rule_test.go
+++ b/pagerduty/resource_pagerduty_service_event_rule_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAccPagerDutyServiceEventRule_Basic(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	rule := fmt.Sprintf("tf-%s", acctest.RandString(5))
@@ -74,7 +74,7 @@ func TestAccPagerDutyServiceEventRule_Basic(t *testing.T) {
 
 func TestAccPagerDutyServiceEventRule_MultipleRules(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	rule1 := fmt.Sprintf("tf-%s", acctest.RandString(5))

--- a/pagerduty/resource_pagerduty_service_integration_test.go
+++ b/pagerduty/resource_pagerduty_service_integration_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestAccPagerDutyServiceIntegration_Basic(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	serviceIntegration := fmt.Sprintf("tf-%s", acctest.RandString(5))
@@ -56,7 +56,7 @@ func TestAccPagerDutyServiceIntegration_Basic(t *testing.T) {
 
 func TestAccPagerDutyServiceIntegrationGeneric_Basic(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	serviceIntegration := fmt.Sprintf("tf-%s", acctest.RandString(5))
@@ -115,7 +115,7 @@ func TestAccPagerDutyServiceIntegrationGeneric_Basic(t *testing.T) {
 }
 func TestAccPagerDutyServiceIntegrationEmail_Filters(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	serviceIntegration := fmt.Sprintf("tf-%s", acctest.RandString(5))
@@ -146,7 +146,7 @@ func TestAccPagerDutyServiceIntegrationEmail_Filters(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"pagerduty_service_integration.foo", "email_filter.0.from_email_mode", "match"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_service_integration.foo", "email_filter.0.from_email_regex", "(@foo.com*)"),
+						"pagerduty_service_integration.foo", "email_filter.0.from_email_regex", "(@foo.test*)"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service_integration.foo", "email_filter.0.subject_mode", "match"),
 					resource.TestCheckResourceAttr(
@@ -262,7 +262,7 @@ func TestAccPagerDutyServiceIntegrationEmail_Filters(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"pagerduty_service_integration.foo", "email_filter.0.from_email_mode", "match"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_service_integration.foo", "email_filter.0.from_email_regex", "(@foo.com*)"),
+						"pagerduty_service_integration.foo", "email_filter.0.from_email_regex", "(@foo.test*)"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service_integration.foo", "email_filter.0.subject_mode", "match"),
 					resource.TestCheckResourceAttr(
@@ -746,7 +746,7 @@ resource "pagerduty_service_integration" "foo" {
     body_mode        = "always"
     body_regex       = null
     from_email_mode  = "match"
-    from_email_regex = "(@foo.com*)"
+    from_email_regex = "(@foo.test*)"
     subject_mode     = "match"
     subject_regex    = "(CRITICAL*)"
   }
@@ -872,7 +872,7 @@ resource "pagerduty_service_integration" "foo" {
     body_mode        = "always"
     body_regex       = null
     from_email_mode  = "match"
-    from_email_regex = "(@foo.com*)"
+    from_email_regex = "(@foo.test*)"
     subject_mode     = "match"
     subject_regex    = "(CRITICAL*)"
   }

--- a/pagerduty/resource_pagerduty_service_test.go
+++ b/pagerduty/resource_pagerduty_service_test.go
@@ -50,7 +50,7 @@ func testSweepService(region string) error {
 
 func TestAccPagerDutyService_Basic(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	serviceUpdated := fmt.Sprintf("tf-%s", acctest.RandString(5))
@@ -132,7 +132,7 @@ func TestAccPagerDutyService_Basic(t *testing.T) {
 
 func TestAccPagerDutyService_AlertGrouping(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
 
@@ -199,7 +199,7 @@ func TestAccPagerDutyService_AlertGrouping(t *testing.T) {
 
 func TestAccPagerDutyService_AlertContentGrouping(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
 
@@ -244,7 +244,7 @@ func TestAccPagerDutyService_AlertContentGrouping(t *testing.T) {
 
 func TestAccPagerDutyService_BasicWithIncidentUrgencyRules(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	serviceUpdated := fmt.Sprintf("tf-%s", acctest.RandString(5))
@@ -446,7 +446,7 @@ func TestAccPagerDutyService_BasicWithIncidentUrgencyRules(t *testing.T) {
 
 func TestAccPagerDutyService_FromBasicToCustomIncidentUrgencyRules(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	serviceUpdated := fmt.Sprintf("tf-%s", acctest.RandString(5))
@@ -548,7 +548,7 @@ func TestAccPagerDutyService_FromBasicToCustomIncidentUrgencyRules(t *testing.T)
 
 func TestAccPagerDutyService_SupportHoursChange(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	service_id := ""
@@ -759,9 +759,9 @@ resource "pagerduty_service" "foo" {
 	acknowledgement_timeout = 1800
 	escalation_policy       = pagerduty_escalation_policy.foo.id
 	alert_creation          = "create_alerts_and_incidents"
-	alert_grouping_parameters { 
+	alert_grouping_parameters {
         type = "content_based"
-        config { 
+        config {
             aggregate = "all"
             fields = ["custom_details.field1"]
         }

--- a/pagerduty/resource_pagerduty_slack_connection_test.go
+++ b/pagerduty/resource_pagerduty_slack_connection_test.go
@@ -22,7 +22,7 @@ var (
 
 func TestAccPagerDutySlackConnection_Basic(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
 
@@ -165,32 +165,32 @@ func testAccCheckPagerDutySlackConnectionExists(n string) resource.TestCheckFunc
 func testAccCheckPagerDutySlackConnectionConfig(username, useremail, escalationPolicy, service, workspaceID, channelID string) string {
 	return fmt.Sprintf(`
 	resource "pagerduty_user" "foo" {
-		name        = "%s"  
+		name        = "%s"
 		email       = "%s"
 	}
-	
+
 	resource "pagerduty_escalation_policy" "foo" {
 		name        = "%s"
 		description = "foo"
 		num_loops   = 1
-		
+
 		rule {
 			escalation_delay_in_minutes = 10
-		
+
 			target {
 				type = "user_reference"
 				id   = pagerduty_user.foo.id
 			}
 		}
 	}
-	
+
 	resource "pagerduty_service" "foo" {
 		name                    = "%s"
 		description             = "foo"
 		auto_resolve_timeout    = 1800
 		acknowledgement_timeout = 1800
 		escalation_policy       = pagerduty_escalation_policy.foo.id
-		
+
 		incident_urgency_rule {
 			type = "constant"
 			urgency = "high"
@@ -219,7 +219,7 @@ func testAccCheckPagerDutySlackConnectionConfig(username, useremail, escalationP
 				"incident.responder.added",
 				"incident.responder.replied",
 				"incident.status_update_published",
-				"incident.reopened"		  
+				"incident.reopened"
 			]
 			priorities = [data.pagerduty_priority.p1.id]
 			urgency = "high"
@@ -231,32 +231,32 @@ func testAccCheckPagerDutySlackConnectionConfig(username, useremail, escalationP
 func testAccCheckPagerDutySlackConnectionConfigUpdated(username, email, escalationPolicy, service, workspaceID, channelID string) string {
 	return fmt.Sprintf(`
 	resource "pagerduty_user" "foo" {
-		name        = "%s"  
+		name        = "%s"
 		email       = "%s"
 	}
-	
+
 	resource "pagerduty_escalation_policy" "foo" {
 		name        = "%s"
 		description = "foo"
 		num_loops   = 1
-		
+
 		rule {
 			escalation_delay_in_minutes = 10
-		
+
 			target {
 				type = "user_reference"
 				id   = pagerduty_user.foo.id
 			}
 		}
 	}
-	
+
 	resource "pagerduty_service" "foo" {
 		name                    = "%s"
 		description             = "foo"
 		auto_resolve_timeout    = 1800
 		acknowledgement_timeout = 1800
 		escalation_policy       = pagerduty_escalation_policy.foo.id
-		
+
 		incident_urgency_rule {
 			type = "constant"
 			urgency = "high"
@@ -285,7 +285,7 @@ func testAccCheckPagerDutySlackConnectionConfigUpdated(username, email, escalati
 				"incident.responder.added",
 				"incident.responder.replied",
 				"incident.status_update_published",
-				"incident.reopened"		  
+				"incident.reopened"
 			]
 			priorities = [data.pagerduty_priority.p1.id]
 		}
@@ -318,7 +318,7 @@ func testAccCheckPagerDutySlackConnectionConfigTeam(team, workspaceID, channelID
 					"incident.responder.added",
 					"incident.responder.replied",
 					"incident.status_update_published",
-					"incident.reopened"		  
+					"incident.reopened"
 				]
 			}
 		}
@@ -349,7 +349,7 @@ func testAccCheckPagerDutySlackConnectionConfigTeamUpdated(team, workspaceID, ch
 					"incident.responder.added",
 					"incident.responder.replied",
 					"incident.status_update_published",
-					"incident.reopened"		  
+					"incident.reopened"
 				]
 				urgency = "low"
 			}
@@ -381,7 +381,7 @@ func testAccCheckPagerDutySlackConnectionConfigEnvar(team, channelID string) str
 					"incident.responder.added",
 					"incident.responder.replied",
 					"incident.status_update_published",
-					"incident.reopened"		  
+					"incident.reopened"
 				]
 				urgency = "low"
 			}

--- a/pagerduty/resource_pagerduty_tag_assignment_test.go
+++ b/pagerduty/resource_pagerduty_tag_assignment_test.go
@@ -13,7 +13,7 @@ import (
 func TestAccPagerDutyTagAssignment_User(t *testing.T) {
 	tagLabel := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -61,7 +61,7 @@ func TestAccPagerDutyTagAssignment_EP(t *testing.T) {
 	tagLabel := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	ep := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -184,15 +184,15 @@ resource "pagerduty_user" "foo" {
 	name        = "%s"
 	email       = "%s"
 }
-  
+
 resource "pagerduty_escalation_policy" "foo" {
 	name        = "%s"
 	description = "foo"
 	num_loops   = 1
-  
+
 	rule {
 	  escalation_delay_in_minutes = 10
-  
+
 	  target {
 		type = "user_reference"
 		id   = pagerduty_user.foo.id

--- a/pagerduty/resource_pagerduty_team_membership_test.go
+++ b/pagerduty/resource_pagerduty_team_membership_test.go
@@ -114,7 +114,7 @@ func testAccCheckPagerDutyTeamMembershipConfig(user, team string) string {
 	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
   name = "%[1]v"
-  email = "%[1]v@foo.com"
+  email = "%[1]v@foo.test"
 }
 
 resource "pagerduty_team" "foo" {
@@ -133,7 +133,7 @@ func testAccCheckPagerDutyTeamMembershipWithRoleConfig(user, team, role string) 
 	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
   name = "%[1]v"
-  email = "%[1]v@foo.com"
+  email = "%[1]v@foo.test"
 }
 
 resource "pagerduty_team" "foo" {

--- a/pagerduty/resource_pagerduty_user_contact_method_test.go
+++ b/pagerduty/resource_pagerduty_user_contact_method_test.go
@@ -13,8 +13,8 @@ import (
 func TestAccPagerDutyUserContactMethodEmail_Basic(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	usernameUpdated := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
-	emailUpdated := fmt.Sprintf("%s@foo.com", usernameUpdated)
+	email := fmt.Sprintf("%s@foo.test", username)
+	emailUpdated := fmt.Sprintf("%s@foo.test", usernameUpdated)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -40,8 +40,8 @@ func TestAccPagerDutyUserContactMethodEmail_Basic(t *testing.T) {
 func TestAccPagerDutyUserContactMethodPhone_Basic(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	usernameUpdated := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
-	emailUpdated := fmt.Sprintf("%s@foo.com", usernameUpdated)
+	email := fmt.Sprintf("%s@foo.test", username)
+	emailUpdated := fmt.Sprintf("%s@foo.test", usernameUpdated)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -71,8 +71,8 @@ func TestAccPagerDutyUserContactMethodPhone_Basic(t *testing.T) {
 func TestAccPagerDutyUserContactMethodSMS_Basic(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	usernameUpdated := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
-	emailUpdated := fmt.Sprintf("%s@foo.com", usernameUpdated)
+	email := fmt.Sprintf("%s@foo.test", username)
+	emailUpdated := fmt.Sprintf("%s@foo.test", usernameUpdated)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/pagerduty/resource_pagerduty_user_notification_rule_test.go
+++ b/pagerduty/resource_pagerduty_user_notification_rule_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestAccPagerDutyUserNotificationRuleContactMethod_Basic(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	contactMethodType1 := "email_contact_method"
 	contactMethodType2 := "phone_contact_method"
 	contactMethodType3 := "sms_contact_method"
@@ -46,7 +46,7 @@ func TestAccPagerDutyUserNotificationRuleContactMethod_Basic(t *testing.T) {
 
 func TestAccPagerDutyUserNotificationRuleContactMethod_Invalid(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -63,7 +63,7 @@ func TestAccPagerDutyUserNotificationRuleContactMethod_Invalid(t *testing.T) {
 
 func TestAccPagerDutyUserNotificationRuleContactMethod_Missing_id(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -80,7 +80,7 @@ func TestAccPagerDutyUserNotificationRuleContactMethod_Missing_id(t *testing.T) 
 
 func TestAccPagerDutyUserNotificationRuleContactMethod_Missing_type(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -97,7 +97,7 @@ func TestAccPagerDutyUserNotificationRuleContactMethod_Missing_type(t *testing.T
 
 func TestAccPagerDutyUserNotificationRuleContactMethod_Unknown_key(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/pagerduty/resource_pagerduty_user_test.go
+++ b/pagerduty/resource_pagerduty_user_test.go
@@ -56,8 +56,8 @@ func TestAccPagerDutyUser_Basic(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	usernameSpaces := " " + username + " "
 	usernameUpdated := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@Foo.com", username)
-	emailUpdated := fmt.Sprintf("%s@foo.com", usernameUpdated)
+	email := fmt.Sprintf("%s@foo.test", username)
+	emailUpdated := fmt.Sprintf("%s@foo.test", usernameUpdated)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -108,7 +108,7 @@ func TestAccPagerDutyUser_Basic(t *testing.T) {
 
 func TestAccPagerDutyUserWithTeams_Basic(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	team1 := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	team2 := fmt.Sprintf("tf-%s", acctest.RandString(5))
 

--- a/pagerduty/resource_pagerduty_webhook_subscription_test.go
+++ b/pagerduty/resource_pagerduty_webhook_subscription_test.go
@@ -48,7 +48,7 @@ func testSweepWebhookSubscription(region string) error {
 func TestAccPagerDutyWebhookSubscription_Basic(t *testing.T) {
 	description := fmt.Sprintf("tf-test-%s", acctest.RandString(5))
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
 
@@ -109,38 +109,38 @@ func testAccCheckPagerDutyWebhookSubscriptionExists(n string) resource.TestCheck
 func testAccCheckPagerDutyWebhookSubscriptionConfig(username, useremail, escalationPolicy, service, description string) string {
 	return fmt.Sprintf(`
 	resource "pagerduty_user" "foo" {
-		name        = "%s"  
+		name        = "%s"
 		email       = "%s"
 	}
-	
+
 	resource "pagerduty_escalation_policy" "foo" {
 		name        = "%s"
 		description = "foo"
 		num_loops   = 1
-		
+
 		rule {
 			escalation_delay_in_minutes = 10
-		
+
 			target {
 				type = "user_reference"
 				id   = pagerduty_user.foo.id
 			}
 		}
 	}
-	
+
 	resource "pagerduty_service" "foo" {
 		name                    = "%s"
 		description             = "foo"
 		auto_resolve_timeout    = 1800
 		acknowledgement_timeout = 1800
 		escalation_policy       = pagerduty_escalation_policy.foo.id
-		
+
 		incident_urgency_rule {
 			type = "constant"
 			urgency = "high"
 		}
 	}
-	
+
 	resource "pagerduty_webhook_subscription" "foo" {
 		delivery_method {
 			type = "http_delivery_method"

--- a/vendor/go.mongodb.org/mongo-driver/mongo/options/datakeyoptions.go
+++ b/vendor/go.mongodb.org/mongo-driver/mongo/options/datakeyoptions.go
@@ -22,7 +22,7 @@ func DataKey() *DataKeyOptions {
 // If being used with a local KMS provider, this option is not applicable and should not be specified.
 //
 // For the AWS, Azure, and GCP KMS providers, this option is required and must be a document. For each, the value of the
-// "endpoint" or "keyVaultEndpoint" must be a host name with an optional port number (e.g. "foo.com" or "foo.com:443").
+// "endpoint" or "keyVaultEndpoint" must be a host name with an optional port number (e.g. "foo.test" or "foo.test:443").
 //
 // When using AWS, the document must have the format:
 // {

--- a/website/docs/r/service_integration.html.markdown
+++ b/website/docs/r/service_integration.html.markdown
@@ -96,7 +96,7 @@ resource "pagerduty_service_integration" "email" {
     body_mode        = "always"
     body_regex       = null
     from_email_mode  = "match"
-    from_email_regex = "(@foo.com*)"
+    from_email_regex = "(@foo.test*)"
     subject_mode     = "match"
     subject_regex    = "(CRITICAL*)"
   }
@@ -201,7 +201,7 @@ The following arguments are supported:
   * `type` - (Required) Can be `between`, `entire` or `regex`.
   * `part` - (Required) Can be `subject` or `body`.
   * `value_name` - (Required) First value extractor should have name `incident_key` other value extractors should contain custom names.
-  * `ends_before` - (Optional) 
+  * `ends_before` - (Optional)
   * `starts_after` - (Optional)
   * `regex` - (Optional) If `type` has value `regex` this value should contain valid regex.
 


### PR DESCRIPTION
1. Add instructions to the README about running a small number of test
2. Switch tests to use `@foo.test` email addresses instead of `@foo.com` addresses. The goal of this change is to be certain that PagerDuty never sends a real email to a random domain when the acceptance tests run. This relies on the fact that [the .test TLD](https://en.wikipedia.org/wiki/.test) will never be publicly addressable.

I updated the CHANGELOG but marked the new version as unreleased because I don't think these changes warrant an actual release.