### PR TITLE
[ORCA-3475] Allow deleting event orchestration team from an orchestration

### DIFF
--- a/pagerduty/import_pagerduty_event_orchestration_test.go
+++ b/pagerduty/import_pagerduty_event_orchestration_test.go
@@ -44,7 +44,7 @@ func TestAccPagerDutyEventOrchestrationNameOnly_import(t *testing.T) {
 			},
 
 			{
-				ResourceName:      "pagerduty_event_orchestration.nameonly",
+				ResourceName:      "pagerduty_event_orchestration.foo",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},

--- a/pagerduty/resource_pagerduty_event_orchestration.go
+++ b/pagerduty/resource_pagerduty_event_orchestration.go
@@ -89,7 +89,7 @@ func buildEventOrchestrationStruct(d *schema.ResourceData) *pagerduty.EventOrche
 	if attr, ok := d.GetOk("team"); ok {
 		orchestration.Team = expandOrchestrationTeam(attr)
 	} else {
-		var tId *string = nil
+		var tId *string
 		orchestration.Team = &pagerduty.EventOrchestrationObject{
 			ID: tId,
 		}
@@ -176,8 +176,19 @@ func resourcePagerDutyEventOrchestrationUpdate(d *schema.ResourceData, meta inte
 
 	log.Printf("[INFO] Updating PagerDuty Event Orchestration: %s", d.Id())
 
-	if _, _, err := client.EventOrchestrations.Update(d.Id(), orchestration); err != nil {
-		return err
+	retryErr := resource.Retry(10*time.Second, func() *resource.RetryError {
+		if _, _, err := client.EventOrchestrations.Update(d.Id(), orchestration); err != nil {
+			if isErrCode(err, 400) || isErrCode(err, 429) {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if retryErr != nil {
+		return retryErr
 	}
 
 	return nil

--- a/pagerduty/resource_pagerduty_event_orchestration.go
+++ b/pagerduty/resource_pagerduty_event_orchestration.go
@@ -88,6 +88,11 @@ func buildEventOrchestrationStruct(d *schema.ResourceData) *pagerduty.EventOrche
 
 	if attr, ok := d.GetOk("team"); ok {
 		orchestration.Team = expandOrchestrationTeam(attr)
+	} else {
+		var tId *string = nil
+		orchestration.Team = &pagerduty.EventOrchestrationObject{
+			ID: tId,
+		}
 	}
 
 	return orchestration
@@ -97,7 +102,7 @@ func expandOrchestrationTeam(v interface{}) *pagerduty.EventOrchestrationObject 
 	var team *pagerduty.EventOrchestrationObject
 	t := v.([]interface{})[0].(map[string]interface{})
 	team = &pagerduty.EventOrchestrationObject{
-		ID: t["id"].(string),
+		ID: stringTypeToStringPtr(t["id"].(string)),
 	}
 
 	return team

--- a/pagerduty/resource_pagerduty_event_orchestration_test.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_test.go
@@ -62,9 +62,16 @@ func TestAccPagerDutyEventOrchestration_Basic(t *testing.T) {
 			{
 				Config: testAccCheckPagerDutyEventOrchestrationConfigNameOnly(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPagerDutyEventOrchestrationExists("pagerduty_event_orchestration.nameonly"),
+					testAccCheckPagerDutyEventOrchestrationExists("pagerduty_event_orchestration.foo"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_event_orchestration.nameonly", "name", name),
+						"pagerduty_event_orchestration.foo", "name", name,
+					),
+					resource.TestCheckResourceAttr(
+						"pagerduty_event_orchestration.foo", "description", "",
+					),
+					resource.TestCheckResourceAttr(
+						"pagerduty_event_orchestration.foo", "team.#", "0",
+					),
 				),
 			},
 			{
@@ -91,6 +98,21 @@ func TestAccPagerDutyEventOrchestration_Basic(t *testing.T) {
 						"pagerduty_event_orchestration.foo", "description", descriptionUpdated,
 					),
 					testAccCheckPagerDutyEventOrchestrationTeamMatch("pagerduty_event_orchestration.foo", "pagerduty_team.bar"),
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyEventOrchestrationConfigDescriptionTeamDeleted(nameUpdated, team1, team2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyEventOrchestrationExists("pagerduty_event_orchestration.foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_event_orchestration.foo", "name", nameUpdated,
+					),
+					resource.TestCheckResourceAttr(
+						"pagerduty_event_orchestration.foo", "description", "",
+					),
+					resource.TestCheckResourceAttr(
+						"pagerduty_event_orchestration.foo", "team.#", "0",
+					),
 				),
 			},
 		},
@@ -157,6 +179,15 @@ func testAccCheckPagerDutyEventOrchestrationTeamMatch(orchName, teamName string)
 	}
 }
 
+func testAccCheckPagerDutyEventOrchestrationConfigNameOnly(n string) string {
+	return fmt.Sprintf(`
+
+resource "pagerduty_event_orchestration" "foo" {
+	name = "%s"
+}
+`, n)
+}
+
 func testAccCheckPagerDutyEventOrchestrationConfig(name, description, team1, team2 string) string {
 	return fmt.Sprintf(`
 
@@ -176,15 +207,6 @@ resource "pagerduty_event_orchestration" "foo" {
 `, team1, team2, name, description)
 }
 
-func testAccCheckPagerDutyEventOrchestrationConfigNameOnly(n string) string {
-	return fmt.Sprintf(`
-
-resource "pagerduty_event_orchestration" "nameonly" {
-	name = "%s"
-}
-`, n)
-}
-
 func testAccCheckPagerDutyEventOrchestrationConfigUpdated(name, description, team1, team2 string) string {
 	return fmt.Sprintf(`
 
@@ -202,4 +224,19 @@ resource "pagerduty_event_orchestration" "foo" {
 	}
 }
 `, team1, team2, name, description)
+}
+
+func testAccCheckPagerDutyEventOrchestrationConfigDescriptionTeamDeleted(name, team1, team2 string) string {
+	return fmt.Sprintf(`
+
+resource "pagerduty_team" "foo" {
+	name = "%s"
+}
+resource "pagerduty_team" "bar" {
+	name = "%s"
+}
+resource "pagerduty_event_orchestration" "foo" {
+	name = "%s"
+}
+`, team1, team2, name)
 }

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/event_orchestration.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/event_orchestration.go
@@ -10,15 +10,15 @@ type EventOrchestration struct {
 	ID           string                           `json:"id,omitempty"`
 	Name         string                           `json:"name,omitempty"`
 	Description  string                           `json:"description"`
-	Team         *EventOrchestrationObject        `json:"team,omitempty"`
+	Team         *EventOrchestrationObject        `json:"team"`
 	Routes       int                              `json:"routes,omitempty"`
 	Integrations []*EventOrchestrationIntegration `json:"integrations,omitempty"`
 	// TODO: figure out if we need Updater, Creator / updated_by, created_by, updated_at, created_at, version
 }
 
 type EventOrchestrationObject struct {
-	Type string `json:"type,omitempty"`
-	ID   string `json:"id,omitempty"`
+	Type string  `json:"type,omitempty"`
+	ID   *string `json:"id"`
 }
 
 type EventOrchestrationIntegrationParameters struct {


### PR DESCRIPTION
### Changes
- Add support for "unsetting" the team
- Change Event Orchestration tests to have better coverage

### Testing
<img width="1019" alt="image" src="https://user-images.githubusercontent.com/47909261/167526401-c2b05b02-f5e5-428e-9f59-77cb2becf5ce.png">
