### PR TITLE
[ORCA-3465] - Event Orchestration Service path resource

### DIFF
--- a/pagerduty/event_orchestration_path_util.go
+++ b/pagerduty/event_orchestration_path_util.go
@@ -1,7 +1,10 @@
 package pagerduty
 
 import (
+	"context"
+	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/heimweh/go-pagerduty/pagerduty"
 )
 
 var PagerDutyEventOrchestrationPathParent = map[string]*schema.Schema{
@@ -24,4 +27,106 @@ var PagerDutyEventOrchestrationPathConditions = map[string]*schema.Schema{
 		Type:     schema.TypeString,
 		Required: true,
 	},
+}
+
+func checkExtractions(context context.Context, diff *schema.ResourceDiff, i interface{}) error {
+	sn := diff.Get("sets.#").(int)
+
+	for si := 0; si < sn; si++ {
+		rn := diff.Get(fmt.Sprintf("sets.%d.rules.#", si)).(int)
+		for ri := 0; ri < rn; ri++ {
+			res := checkExtractionAttributes(diff, fmt.Sprintf("sets.%d.rules.%d.actions.0.extractions", si, ri))
+			if res != nil {
+				return res
+			}
+		}
+	}
+	return checkExtractionAttributes(diff, "catch_all.0.actions.0.extractions")
+}
+
+func checkExtractionAttributes(diff *schema.ResourceDiff, loc string) error {
+	num := diff.Get(fmt.Sprintf("%s.#", loc)).(int)
+	for i := 0; i < num; i++ {
+		prefix := fmt.Sprintf("%s.%d", loc, i)
+		r := diff.Get(fmt.Sprintf("%s.regex", prefix)).(string)
+		t := diff.Get(fmt.Sprintf("%s.template", prefix)).(string)
+
+		if r == "" && t == "" {
+			return fmt.Errorf("Invalid configuration in %s: regex and template cannot both be null", prefix)
+		}
+		if r != "" && t != "" {
+			return fmt.Errorf("Invalid configuration in %s: regex and template cannot both have values", prefix)
+		}
+
+		s := diff.Get(fmt.Sprintf("%s.source", prefix)).(string)
+		if r != "" && s == "" {
+			return fmt.Errorf("Invalid configuration in %s: source can't be blank", prefix)
+		}
+	}
+	return nil
+}
+
+func expandEventOrchestrationPathVariables(v interface{}) []*pagerduty.EventOrchestrationPathActionVariables {
+	res := []*pagerduty.EventOrchestrationPathActionVariables{}
+
+	for _, er := range v.([]interface{}) {
+		rer := er.(map[string]interface{})
+
+		av := &pagerduty.EventOrchestrationPathActionVariables{
+			Name:  rer["name"].(string),
+			Path:  rer["path"].(string),
+			Type:  rer["type"].(string),
+			Value: rer["value"].(string),
+		}
+
+		res = append(res, av)
+	}
+
+	return res
+}
+
+func flattenEventOrchestrationPathVariables(v []*pagerduty.EventOrchestrationPathActionVariables) []interface{} {
+	var res []interface{}
+
+	for _, s := range v {
+		fv := map[string]interface{}{
+			"name":  s.Name,
+			"path":  s.Path,
+			"type":  s.Type,
+			"value": s.Value,
+		}
+		res = append(res, fv)
+	}
+	return res
+}
+
+func expandEventOrchestrationPathExtractions(v interface{}) []*pagerduty.EventOrchestrationPathActionExtractions {
+	res := []*pagerduty.EventOrchestrationPathActionExtractions{}
+
+	for _, eai := range v.([]interface{}) {
+		ea := eai.(map[string]interface{})
+		ext := &pagerduty.EventOrchestrationPathActionExtractions{
+			Target:   ea["target"].(string),
+			Regex:    ea["regex"].(string),
+			Template: ea["template"].(string),
+			Source:   ea["source"].(string),
+		}
+		res = append(res, ext)
+	}
+	return res
+}
+
+func flattenEventOrchestrationPathExtractions(e []*pagerduty.EventOrchestrationPathActionExtractions) []interface{} {
+	var res []interface{}
+
+	for _, s := range e {
+		e := map[string]interface{}{
+			"target":   s.Target,
+			"regex":    s.Regex,
+			"template": s.Template,
+			"source":   s.Source,
+		}
+		res = append(res, e)
+	}
+	return res
 }

--- a/pagerduty/import_pagerduty_event_orchestration_path_service_test.go
+++ b/pagerduty/import_pagerduty_event_orchestration_path_service_test.go
@@ -1,0 +1,36 @@
+package pagerduty
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccPagerDutyEventOrchestrationPathService_import(t *testing.T) {
+	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyEventOrchestrationServicePathDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyEventOrchestrationPathServiceAutomationActionsConfig(escalationPolicy, service),
+			},
+			{
+				ResourceName:      "pagerduty_event_orchestration_service.serviceA",
+				ImportStateIdFunc: testAccCheckPagerDutyEventOrchestrationPathServiceID,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckPagerDutyEventOrchestrationPathServiceID(s *terraform.State) (string, error) {
+	return s.RootModule().Resources["pagerduty_service.bar"].Primary.ID, nil
+}

--- a/pagerduty/provider.go
+++ b/pagerduty/provider.go
@@ -90,7 +90,9 @@ func Provider() *schema.Provider {
 			"pagerduty_webhook_subscription":         resourcePagerDutyWebhookSubscription(),
 			"pagerduty_event_orchestration":          resourcePagerDutyEventOrchestration(),
 			"pagerduty_event_orchestration_router":   resourcePagerDutyEventOrchestrationPathRouter(),
-			"pagerduty_event_orchestration_unrouted": resourcePagerDutyEventOrchestrationPathUnrouted()},
+			"pagerduty_event_orchestration_unrouted": resourcePagerDutyEventOrchestrationPathUnrouted(),
+			"pagerduty_event_orchestration_service":  resourcePagerDutyEventOrchestrationPathService(),
+		},
 	}
 
 	p.ConfigureFunc = func(d *schema.ResourceData) (interface{}, error) {

--- a/pagerduty/resource_pagerduty_event_orchestration_path_service.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_service.go
@@ -243,7 +243,6 @@ func resourcePagerDutyEventOrchestrationPathServiceRead(d *schema.ResourceData, 
 }
 
 func resourcePagerDutyEventOrchestrationPathServiceDelete(d *schema.ResourceData, meta interface{}) error {
-	// TODO: figure out what to do here
 	d.SetId("")
 	return nil
 }
@@ -303,6 +302,9 @@ func expandServicePathActions(v interface{}) *pagerduty.EventOrchestrationPathRu
 	var actions = new(pagerduty.EventOrchestrationPathRuleActions)
 
 	for _, i := range v.([]interface{}) {
+		if i == nil {
+			continue
+		}
 		a := i.(map[string]interface{})
 		// TODO:
 		actions.RouteTo = a["route_to"].(string)

--- a/pagerduty/resource_pagerduty_event_orchestration_path_service.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_service.go
@@ -1,0 +1,480 @@
+package pagerduty
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/heimweh/go-pagerduty/pagerduty"
+	"log"
+	"time"
+)
+
+var eventOrchestrationAutomationActionObject = map[string]*schema.Schema{
+	"key": {
+		Type:     schema.TypeString,
+		Required: true,
+	},
+	"value": {
+		Type:     schema.TypeString,
+		Required: true,
+	},
+}
+
+var eventOrchestrationPathServiceCatchAllActions = map[string]*schema.Schema{
+	// suppress
+	// suspend
+	// priority
+	// annotate
+	"pagerduty_automation_actions": {
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"action_id": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			},
+		},
+	},
+	"automation_actions": {
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"name": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"url": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"auto_send": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				"headers": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: eventOrchestrationAutomationActionObject,
+					},
+				},
+				"parameters": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: eventOrchestrationAutomationActionObject,
+					},
+				},
+			},
+		},
+	},
+	// severity
+	// event_action
+	// variables
+	// extractions
+}
+
+var eventOrchestrationPathServiceRuleActions = buildEventOrchestrationPathServiceRuleActions()
+
+func buildEventOrchestrationPathServiceRuleActions() map[string]*schema.Schema {
+	a := eventOrchestrationPathServiceCatchAllActions
+	a["route_to"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Required: true,
+	}
+
+	return a
+}
+
+func resourcePagerDutyEventOrchestrationPathService() *schema.Resource {
+	return &schema.Resource{
+		Read:   nil,
+		Create: resourcePagerDutyEventOrchestrationPathServiceCreate,
+		Update: resourcePagerDutyEventOrchestrationPathServiceUpdate,
+		Delete: resourcePagerDutyEventOrchestrationPathServiceDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough, //TODO: resourcePagerDutyEventOrchestrationPathServiceImport
+		},
+		Schema: map[string]*schema.Schema{
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"parent": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				// TODO: use PagerDutyEventOrchestrationPathParent
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"self": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"sets": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"rules": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"label": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									// "conditions": {
+									// 	Type:     schema.TypeList,
+									// 	Optional: true,
+									// 	Elem: &schema.Resource{
+									// 		Schema: PagerDutyEventOrchestrationPathConditions,
+									// 	},
+									// },
+									"actions": {
+										Type:     schema.TypeList,
+										Required: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: eventOrchestrationPathServiceRuleActions,
+										},
+									},
+									"disabled": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			// "catch_all": {
+			// 	Type:     schema.TypeList,
+			// 	MaxItems: 1,
+			// 	Required: true, // TODO: figure out how to make this optional with a default value
+			// 	Elem: &schema.Resource{
+			// 		Schema: eventOrchestrationPathServiceCatchAllActions,
+			// 	},
+			// },
+		},
+	}
+}
+
+func resourcePagerDutyEventOrchestrationPathServiceCreate(d *schema.ResourceData, meta interface{}) error {
+	return resourcePagerDutyEventOrchestrationPathServiceUpdate(d, meta)
+}
+
+func resourcePagerDutyEventOrchestrationPathServiceUpdate(d *schema.ResourceData, meta interface{}) error {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
+
+	payload := buildServicePathStruct(d)
+	var servicePath *pagerduty.EventOrchestrationPath
+
+	log.Printf("[INFO] Creating PagerDuty Event Orchestration Service Path: %s", payload.Parent.ID)
+
+	retryErr := resource.Retry(30*time.Second, func() *resource.RetryError {
+		if path, _, err := client.EventOrchestrationPaths.Update(payload.Parent.ID, "service", payload); err != nil {
+			return resource.RetryableError(err)
+		} else if path != nil {
+			d.SetId(path.Parent.ID)
+			servicePath = path
+		}
+		return nil
+	})
+
+	if retryErr != nil {
+		return retryErr
+	}
+
+	setEventOrchestrationPathServiceProps(d, servicePath)
+
+	return nil
+}
+
+func resourcePagerDutyEventOrchestrationPathServiceRead(d *schema.ResourceData, meta interface{}) error {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
+
+	return resource.Retry(2*time.Minute, func() *resource.RetryError {
+		id := d.Id()
+		log.Printf("[INFO] Reading PagerDuty Event Orchestration Path of type %s for orchestration: %s", "router", id)
+
+		if path, _, err := client.EventOrchestrationPaths.Get(d.Id(), "router"); err != nil {
+			time.Sleep(2 * time.Second)
+			return resource.RetryableError(err)
+		} else if path != nil {
+			setEventOrchestrationPathServiceProps(d, path)
+		}
+		return nil
+	})
+
+}
+
+func resourcePagerDutyEventOrchestrationPathServiceDelete(d *schema.ResourceData, meta interface{}) error {
+	// TODO: figure out what to do here
+	d.SetId("")
+	return nil
+}
+
+func buildServicePathStruct(d *schema.ResourceData) *pagerduty.EventOrchestrationPath {
+	return &pagerduty.EventOrchestrationPath{
+		// TODO: use shared method
+		Parent: &pagerduty.EventOrchestrationPathReference{
+			ID: d.Get("parent.0.id").(string),
+		},
+		Sets: expandServicePathSets(d.Get("sets")),
+	}
+}
+
+// TODO: see if we can reuse expand functions for all orch path sets.
+// Maybe pass in the rule actions and catch-all rule actions expanding function?
+func expandServicePathSets(v interface{}) []*pagerduty.EventOrchestrationPathSet {
+	var result []*pagerduty.EventOrchestrationPathSet
+
+	for _, i := range v.([]interface{}) {
+		s := i.(map[string]interface{})
+		set := &pagerduty.EventOrchestrationPathSet{
+			ID:    s["id"].(string),
+			Rules: expandServicePathRules(s["rules"]),
+		}
+
+		result = append(result, set)
+	}
+
+	return result
+}
+
+func expandServicePathRules(v interface{}) []*pagerduty.EventOrchestrationPathRule {
+	var result []*pagerduty.EventOrchestrationPathRule
+
+	for _, i := range v.([]interface{}) {
+		r := i.(map[string]interface{})
+		rule := &pagerduty.EventOrchestrationPathRule{
+			Actions: expandServicePathActions(r["actions"]),
+		}
+
+		if r["label"] != nil {
+			rule.Label = r["label"].(string)
+		}
+
+		if r["disabled"] != nil {
+			rule.Disabled = r["disabled"].(bool)
+		}
+
+		result = append(result, rule)
+	}
+
+	return result
+}
+
+func expandServicePathActions(v interface{}) *pagerduty.EventOrchestrationPathRuleActions {
+	var actions = new(pagerduty.EventOrchestrationPathRuleActions)
+
+	for _, i := range v.([]interface{}) {
+		a := i.(map[string]interface{})
+		// TODO:
+		actions.RouteTo = a["route_to"].(string)
+		// suppress
+		// suspend
+		// priority
+		// annotate
+		actions.PagerdutyAutomationActions = expandServicePathPagerDutyAutomationActions(a["pagerduty_automation_actions"])
+		actions.AutomationActions = expandServicePathAutomationActions(a["automation_actions"])
+		// severity
+		// event_action
+		// variables
+		// extractions
+	}
+
+	return actions
+}
+
+func expandServicePathPagerDutyAutomationActions(v interface{}) []*pagerduty.EventOrchestrationPathPagerdutyAutomationAction {
+	var result []*pagerduty.EventOrchestrationPathPagerdutyAutomationAction
+
+	for _, i := range v.([]interface{}) {
+		a := i.(map[string]interface{})
+		pdaa := &pagerduty.EventOrchestrationPathPagerdutyAutomationAction{
+			ActionId: a["action_id"].(string),
+		}
+
+		result = append(result, pdaa)
+	}
+
+	return result
+}
+
+func expandServicePathAutomationActions(v interface{}) []*pagerduty.EventOrchestrationPathAutomationAction {
+	var result []*pagerduty.EventOrchestrationPathAutomationAction
+
+	for _, i := range v.([]interface{}) {
+		a := i.(map[string]interface{})
+		aa := &pagerduty.EventOrchestrationPathAutomationAction{
+			Name:       a["name"].(string),
+			Url:        a["url"].(string),
+			AutoSend:   a["auto_send"].(bool),
+			Headers:    expandEventOrchestrationAutomationActionObjects(a["headers"]),
+			Parameters: expandEventOrchestrationAutomationActionObjects(a["parameters"]),
+		}
+
+		result = append(result, aa)
+	}
+
+	return result
+}
+
+func expandEventOrchestrationAutomationActionObjects(v interface{}) []*pagerduty.EventOrchestrationPathAutomationActionObject {
+	var result []*pagerduty.EventOrchestrationPathAutomationActionObject
+
+	for _, i := range v.([]interface{}) {
+		o := i.(map[string]interface{})
+		obj := &pagerduty.EventOrchestrationPathAutomationActionObject{
+			Key:   o["key"].(string),
+			Value: o["value"].(string),
+		}
+
+		result = append(result, obj)
+	}
+
+	return result
+}
+
+func setEventOrchestrationPathServiceProps(d *schema.ResourceData, p *pagerduty.EventOrchestrationPath) error {
+	d.SetId(p.Parent.ID)
+	d.Set("parent", flattenServicePathParent(p.Parent))
+	// TODO: see if we can reuse expand functions for all orch path sets.
+	// Maybe pass in the rule actions and catch-all rule actions expanding function?
+	d.Set("sets", nil)
+	return nil
+}
+
+func flattenServicePathParent(p *pagerduty.EventOrchestrationPathReference) []interface{} {
+	var parent = map[string]interface{}{
+		"id":   p.ID,
+		"type": p.Type,
+		"self": p.Self,
+	}
+
+	return []interface{}{parent}
+}
+
+func flattenServicePathSets(orchPathSets []*pagerduty.EventOrchestrationPathSet) []interface{} {
+	var flattenedSets []interface{}
+
+	for _, set := range orchPathSets {
+		flattenedSet := map[string]interface{}{
+			"id":    set.ID,
+			"rules": flattenServicePathRules(set.Rules),
+		}
+		flattenedSets = append(flattenedSets, flattenedSet)
+	}
+	return flattenedSets
+}
+
+func flattenServicePathRules(rules []*pagerduty.EventOrchestrationPathRule) []interface{} {
+	var flattenedRules []interface{}
+
+	for _, rule := range rules {
+		flattenedRule := map[string]interface{}{
+			"id":       rule.ID,
+			"label":    rule.Label,
+			"disabled": rule.Disabled,
+			// TODO:
+			// "conditions": flattenServicePathConditions(rule.Conditions),
+			"actions": flattenServicePathActions(rule.Actions),
+		}
+		flattenedRules = append(flattenedRules, flattenedRule)
+	}
+
+	return flattenedRules
+}
+
+func flattenServicePathActions(actions *pagerduty.EventOrchestrationPathRuleActions) []map[string]interface{} {
+	var actionsMap []map[string]interface{}
+
+	am := make(map[string]interface{})
+	am["route_to"] = actions.RouteTo
+	am["pagerduty_automation_actions"] = flattenServicePathPagerDutyAutomationActions(actions.PagerdutyAutomationActions)
+	am["automation_actions"] = nil
+	actionsMap = append(actionsMap, am)
+
+	return actionsMap
+}
+
+func flattenServicePathPagerDutyAutomationActions(v []*pagerduty.EventOrchestrationPathPagerdutyAutomationAction) []interface{} {
+	var result []interface{}
+
+	for _, i := range v {
+		pdaa := map[string]string{
+			"action_id": i.ActionId,
+		}
+
+		result = append(result, pdaa)
+	}
+
+	return result
+}
+
+func flattenServicePathAutomationActions(v []*pagerduty.EventOrchestrationPathAutomationAction) []interface{} {
+	var result []interface{}
+
+	for _, i := range v {
+		pdaa := map[string]interface{}{
+			"name":       i.Name,
+			"url":        i.Url,
+			"auto_send":  i.AutoSend,
+			"headers":    flattenServicePathAutomationActionObjects(i.Headers),
+			"parameters": flattenServicePathAutomationActionObjects(i.Parameters),
+		}
+
+		result = append(result, pdaa)
+	}
+
+	return result
+}
+
+func flattenServicePathAutomationActionObjects(v []*pagerduty.EventOrchestrationPathAutomationActionObject) []interface{} {
+	var result []interface{}
+
+	for _, i := range v {
+		pdaa := map[string]interface{}{
+			"key":   i.Key,
+			"value": i.Value,
+		}
+
+		result = append(result, pdaa)
+	}
+
+	return result
+}

--- a/pagerduty/resource_pagerduty_event_orchestration_path_service.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_service.go
@@ -234,14 +234,23 @@ func resourcePagerDutyEventOrchestrationPathService() *schema.Resource {
 					},
 				},
 			},
-			// "catch_all": {
-			// 	Type:     schema.TypeList,
-			// 	MaxItems: 1,
-			// 	Required: true, // TODO: figure out how to make this optional with a default value
-			// 	Elem: &schema.Resource{
-			// 		Schema: eventOrchestrationPathServiceCatchAllActions,
-			// 	},
-			// },
+			"catch_all": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"actions": {
+							Type:     schema.TypeList,
+							Required: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: eventOrchestrationPathServiceRuleActions,
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 }

--- a/pagerduty/resource_pagerduty_event_orchestration_path_service.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_service.go
@@ -1,11 +1,12 @@
 package pagerduty
 
 import (
+	"log"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/heimweh/go-pagerduty/pagerduty"
-	"log"
-	"time"
 )
 
 var eventOrchestrationAutomationActionObject = map[string]*schema.Schema{
@@ -308,7 +309,6 @@ func resourcePagerDutyEventOrchestrationPathServiceDelete(d *schema.ResourceData
 
 func buildServicePathStruct(d *schema.ResourceData) *pagerduty.EventOrchestrationPath {
 	return &pagerduty.EventOrchestrationPath{
-		// TODO: use shared method
 		Parent: &pagerduty.EventOrchestrationPathReference{
 			ID: d.Get("parent.0.id").(string),
 		},
@@ -369,9 +369,10 @@ func expandServicePathActions(v interface{}) *pagerduty.EventOrchestrationPathRu
 			continue
 		}
 		a := i.(map[string]interface{})
+
 		actions.RouteTo = a["route_to"].(string)
 		actions.Suppress = a["suppress"].(bool)
-		actions.Suspend = a["suspend"].(int)
+		actions.Suspend = intTypeToIntPtr(a["suspend"].(int))
 		actions.Priority = a["priority"].(string)
 		actions.Annotate = a["annotate"].(string)
 		actions.Severity = a["severity"].(string)

--- a/pagerduty/resource_pagerduty_event_orchestration_path_service.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_service.go
@@ -358,8 +358,10 @@ func expandServicePathRules(v interface{}) []*pagerduty.EventOrchestrationPathRu
 
 func expandServicePathActions(v interface{}) *pagerduty.EventOrchestrationPathRuleActions {
 	var actions = &pagerduty.EventOrchestrationPathRuleActions{
-		Variables:   []*pagerduty.EventOrchestrationPathActionVariables{},
-		Extractions: []*pagerduty.EventOrchestrationPathActionExtractions{},
+		AutomationActions:          []*pagerduty.EventOrchestrationPathAutomationAction{},
+		PagerdutyAutomationActions: []*pagerduty.EventOrchestrationPathPagerdutyAutomationAction{},
+		Variables:                  []*pagerduty.EventOrchestrationPathActionVariables{},
+		Extractions:                []*pagerduty.EventOrchestrationPathActionExtractions{},
 	}
 
 	for _, i := range v.([]interface{}) {
@@ -385,7 +387,7 @@ func expandServicePathActions(v interface{}) *pagerduty.EventOrchestrationPathRu
 }
 
 func expandServicePathPagerDutyAutomationActions(v interface{}) []*pagerduty.EventOrchestrationPathPagerdutyAutomationAction {
-	var result []*pagerduty.EventOrchestrationPathPagerdutyAutomationAction
+	result := []*pagerduty.EventOrchestrationPathPagerdutyAutomationAction{}
 
 	for _, i := range v.([]interface{}) {
 		a := i.(map[string]interface{})
@@ -400,7 +402,7 @@ func expandServicePathPagerDutyAutomationActions(v interface{}) []*pagerduty.Eve
 }
 
 func expandServicePathAutomationActions(v interface{}) []*pagerduty.EventOrchestrationPathAutomationAction {
-	var result []*pagerduty.EventOrchestrationPathAutomationAction
+	result := []*pagerduty.EventOrchestrationPathAutomationAction{}
 
 	for _, i := range v.([]interface{}) {
 		a := i.(map[string]interface{})
@@ -419,7 +421,7 @@ func expandServicePathAutomationActions(v interface{}) []*pagerduty.EventOrchest
 }
 
 func expandEventOrchestrationAutomationActionObjects(v interface{}) []*pagerduty.EventOrchestrationPathAutomationActionObject {
-	var result []*pagerduty.EventOrchestrationPathAutomationActionObject
+	result := []*pagerduty.EventOrchestrationPathAutomationActionObject{}
 
 	for _, i := range v.([]interface{}) {
 		o := i.(map[string]interface{})
@@ -492,10 +494,10 @@ func flattenServicePathActions(actions *pagerduty.EventOrchestrationPathRuleActi
 		"route_to":     actions.RouteTo,
 		"severity":     actions.Severity,
 		"event_action": actions.EventAction,
-		// suppress
-		// suspend
-		// priority
-		// annotate
+		"suppress":     actions.Suppress,
+		"suspend":      actions.Suspend,
+		"priority":     actions.Priority,
+		"annotate":     actions.Annotate,
 	}
 
 	// TODO: use shared code

--- a/pagerduty/resource_pagerduty_event_orchestration_path_service.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_service.go
@@ -561,7 +561,6 @@ func flattenServicePathActions(actions *pagerduty.EventOrchestrationPathRuleActi
 		flattenedAction["extractions"] = flattenEventOrchestrationPathExtractions(actions.Extractions)
 	}
 	if actions.PagerdutyAutomationActions != nil {
-
 		flattenedAction["pagerduty_automation_actions"] = flattenServicePathPagerDutyAutomationActions(actions.PagerdutyAutomationActions)
 	}
 	if actions.AutomationActions != nil {

--- a/pagerduty/resource_pagerduty_event_orchestration_path_service_test.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_service_test.go
@@ -36,7 +36,19 @@ func TestAccPagerDutyEventOrchestrationPathService_Basic(t *testing.T) {
 		// CheckDestroy: testAccCheckPagerDutyEventOrchestrationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckPagerDutyEventOrchestrationServiceConfig(service),
+				Config: testAccCheckPagerDutyEventOrchestrationServiceRequiredFieldsConfig(service),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyEventOrchestrationServiceExists("pagerduty_event_orchestration_service.serviceA"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_event_orchestration_service.serviceA", "sets.#", "1",
+					),
+					resource.TestCheckResourceAttr(
+						"pagerduty_event_orchestration.foo", "sets.0.rules.#", "0",
+					),
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyEventOrchestrationServiceAllFieldsConfig(service),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyEventOrchestrationServiceExists("pagerduty_event_orchestration_service.serviceA"),
 				),
@@ -68,7 +80,22 @@ func testAccCheckPagerDutyEventOrchestrationServiceExists(rn string) resource.Te
 	}
 }
 
-func testAccCheckPagerDutyEventOrchestrationServiceConfig(sId string) string {
+func testAccCheckPagerDutyEventOrchestrationServiceRequiredFieldsConfig(sId string) string {
+	return fmt.Sprintf(`
+
+resource "pagerduty_event_orchestration_service" "serviceA" {
+	parent {
+		id = "%s"
+	}
+
+	sets {
+		id = "start"
+	}
+}
+`, sId)
+}
+
+func testAccCheckPagerDutyEventOrchestrationServiceAllFieldsConfig(sId string) string {
 	return fmt.Sprintf(`
 
 resource "pagerduty_event_orchestration_service" "serviceA" {
@@ -88,6 +115,24 @@ resource "pagerduty_event_orchestration_service" "serviceA" {
 						name = "Reboot me"
 						url = "https://test.com"
 						auto_send = true
+						
+						headers {
+							key = "foo"
+							value = "bar"
+						}
+						headers {
+							key = "baz"
+							value = "buz"
+						}
+
+						parameters {
+							key = "source"
+							value = "orch_rule"
+						}
+						parameters {
+							key = "region"
+							value = "us"
+						}
 					}
 			}
 		}

--- a/pagerduty/resource_pagerduty_event_orchestration_path_service_test.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_service_test.go
@@ -2,14 +2,14 @@ package pagerduty
 
 import (
 	"fmt"
-	"log"
+	// "log"
 	// "strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	// "github.com/heimweh/go-pagerduty/pagerduty"
+	"github.com/heimweh/go-pagerduty/pagerduty"
 )
 
 func init() {
@@ -57,12 +57,30 @@ func TestAccPagerDutyEventOrchestrationPathService_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						resourceName, "sets.0.rules.#", "1",
 					),
-					testAccCheckPagerDutyEventOrchestrationServiceRuleActions(resourceName, "sets.0.rules.0.actions.0", map[string]interface{}{
-						"pagerduty_automation_actions": map[string]interface{}{"action_id": "SOME_ACTION_ID"},
+					testAccCheckPagerDutyEventOrchestrationServiceRuleActions(resourceName, "sets.0.rules.0", &pagerduty.EventOrchestrationPathRuleActions{
+						PagerdutyAutomationActions: []*pagerduty.EventOrchestrationPathPagerdutyAutomationAction{
+							&pagerduty.EventOrchestrationPathPagerdutyAutomationAction{ActionId: "SOME_ACTION_ID"},
+						},
+						AutomationActions: []*pagerduty.EventOrchestrationPathAutomationAction{
+							&pagerduty.EventOrchestrationPathAutomationAction{
+								Name:     "test",
+								Url:      "https://test.com",
+								AutoSend: true,
+								Headers: []*pagerduty.EventOrchestrationPathAutomationActionObject{
+									&pagerduty.EventOrchestrationPathAutomationActionObject{Key: "foo", Value: "bar"},
+									&pagerduty.EventOrchestrationPathAutomationActionObject{Key: "baz", Value: "buz"},
+								},
+								Parameters: []*pagerduty.EventOrchestrationPathAutomationActionObject{
+									&pagerduty.EventOrchestrationPathAutomationActionObject{Key: "source", Value: "orch"},
+									&pagerduty.EventOrchestrationPathAutomationActionObject{Key: "region", Value: "us"},
+								},
+							},
+						},
 					}),
 				),
 			},
 			// update all fields
+			// reset headers/params
 			// reset rule action items -> should be default
 			// reset rule actions -> should be []
 			// reset rule conditions -> should be []
@@ -94,17 +112,63 @@ func testAccCheckPagerDutyEventOrchestrationServiceExists(rn string) resource.Te
 	}
 }
 
-func testAccCheckPagerDutyEventOrchestrationServiceRuleActions(rn, path string, a map[string]interface{}) resource.TestCheckFunc {
+func testAccCheckPagerDutyEventOrchestrationServiceRuleActions(rn, rloc string, a *pagerduty.EventOrchestrationPathRuleActions) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		r, ok := s.RootModule().Resources[rn]
 		if !ok {
 			return fmt.Errorf("Not found: %s", rn)
 		}
 
-		attr := r.Primary.Attributes[path]
+		attr := r.Primary.Attributes
+		path := fmt.Sprintf("%s.actions.0", rloc) // "sets.0.rules.0" + ".actions.0"
 
-		log.Printf(">>> attr: %v", attr)
-		log.Printf(">>> a: %v", a)
+		// route_to
+		// suppress
+		// suspend
+		// priority
+		// annotate
+		// pagerduty_automation_actions
+		if attr[fmt.Sprintf("%s.pagerduty_automation_actions.0.action_id", path)] != a.PagerdutyAutomationActions[0].ActionId {
+			return fmt.Errorf("pagerduty_automation_actions not matching for %s", rn)
+		}
+
+		// automation_actions
+		if attr[fmt.Sprintf("%s.automation_actions.0.name", path)] != a.AutomationActions[0].Name {
+			return fmt.Errorf("automation_actions.0.name not matching for %s", rn)
+		}
+		if attr[fmt.Sprintf("%s.automation_actions.0.url", path)] != a.AutomationActions[0].Url {
+			return fmt.Errorf("automation_actions.0.url not matching for %s", rn)
+		}
+		// if attr[fmt.Sprintf("%s.automation_actions.0.auto_send", path)] != a.AutomationActions[0].AutoSend {
+		// 	return fmt.Errorf("automation_actions.0.auto_send not matching for %s", rn)
+		// }
+
+		objCheckFn := func(prop string, obj []*pagerduty.EventOrchestrationPathAutomationActionObject) error {
+			for i, h := range obj {
+				kPath := fmt.Sprintf("%s.automation_actions.0.%s.%d.key", path, prop, i)
+				vPath := fmt.Sprintf("%s.automation_actions.0.%s.%d.value", path, prop, i)
+				if k := attr[kPath]; k != h.Key {
+					return fmt.Errorf("%s not matching for %s", kPath, rn)
+				}
+				if v := attr[vPath]; v != h.Value {
+					return fmt.Errorf("%s not matching for %s", kPath, rn)
+				}
+			}
+
+			return nil
+		}
+
+		objCheckFn("headers", a.AutomationActions[0].Headers)
+		objCheckFn("parameters", a.AutomationActions[0].Parameters)
+
+		// severity
+		// event_action
+		// variables
+		// extractions
+
+		// log.Printf(">>> attr path: %v", fmt.Sprintf("%s.pagerduty_automation_actions.0.action_id", path))
+		// log.Printf(">>> attr: %v", attr[fmt.Sprintf("%s.pagerduty_automation_actions.0.action_id", path)])
+		// log.Printf(">>> a: %v", a.PagerdutyAutomationActions[0].ActionId)
 
 		return nil
 	}
@@ -177,7 +241,7 @@ func testAccCheckPagerDutyEventOrchestrationServiceAllFieldsConfig(ep, s string)
 								action_id = "SOME_ACTION_ID"
 							}
 							automation_actions {
-								name = "Reboot me"
+								name = "test"
 								url = "https://test.com"
 								auto_send = true
 		
@@ -192,7 +256,7 @@ func testAccCheckPagerDutyEventOrchestrationServiceAllFieldsConfig(ep, s string)
 		
 								parameters {
 									key = "source"
-									value = "orch_rule"
+									value = "orch"
 								}
 								parameters {
 									key = "region"

--- a/pagerduty/resource_pagerduty_event_orchestration_path_service_test.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_service_test.go
@@ -1,0 +1,97 @@
+package pagerduty
+
+import (
+	"fmt"
+	// "log"
+	// "strings"
+	"testing"
+
+	// "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func init() {
+	resource.AddTestSweepers("pagerduty_event_orchestration_service", &resource.Sweeper{
+		Name: "pagerduty_event_orchestration_service",
+		Dependencies: []string{
+			"pagerduty_service",
+			// TODO: EP, Schedule, user
+		},
+	})
+}
+
+func TestAccPagerDutyEventOrchestrationPathService_Basic(t *testing.T) {
+	//name := fmt.Sprintf("tf-name-%s", acctest.RandString(5))
+	// description := fmt.Sprintf("tf-description-%s", acctest.RandString(5))
+	// nameUpdated := fmt.Sprintf("tf-name-%s", acctest.RandString(5))
+	// descriptionUpdated := fmt.Sprintf("tf-description-%s", acctest.RandString(5))
+	// team1 := fmt.Sprintf("tf-team-%s", acctest.RandString(5))
+	// team2 := fmt.Sprintf("tf-team-%s", acctest.RandString(5))
+	service := "PZ73WUB"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		// CheckDestroy: testAccCheckPagerDutyEventOrchestrationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyEventOrchestrationServiceConfig(service),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyEventOrchestrationServiceExists("pagerduty_event_orchestration_service.serviceA"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckPagerDutyEventOrchestrationServiceExists(rn string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		orch, ok := s.RootModule().Resources[rn]
+		if !ok {
+			return fmt.Errorf("Not found: %s", rn)
+		}
+		if orch.Primary.ID == "" {
+			return fmt.Errorf("No Event Orchestration Service ID is set")
+		}
+
+		client, _ := testAccProvider.Meta().(*Config).Client()
+		found, _, err := client.EventOrchestrationPaths.Get(orch.Primary.ID, "service")
+		if err != nil {
+			return err
+		}
+		if found.Parent.ID != orch.Primary.ID {
+			return fmt.Errorf("Event Orchrestration Service not found: %v - %v", orch.Primary.ID, found)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckPagerDutyEventOrchestrationServiceConfig(sId string) string {
+	return fmt.Sprintf(`
+
+resource "pagerduty_event_orchestration_service" "serviceA" {
+	parent {
+		id = "%s"
+	}
+
+	sets {
+		id = "start"
+		rules {
+			label = "rule 1"
+			actions {
+					pagerduty_automation_actions {
+						action_id = "SOME_ACTION_ID"
+					}
+					automation_actions {
+						name = "Reboot me"
+						url = "https://test.com"
+						auto_send = true
+					}
+			}
+		}
+	}
+}
+`, sId)
+}

--- a/pagerduty/resource_pagerduty_event_orchestration_path_service_test.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_service_test.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"fmt"
+	"strconv"
 	// "log"
 	// "strings"
 	"testing"
@@ -47,6 +48,7 @@ func TestAccPagerDutyEventOrchestrationPathService_Basic(t *testing.T) {
 					),
 				),
 			},
+			// set adding/editing/deleting props in a single rule
 			{
 				Config: testAccCheckPagerDutyEventOrchestrationServiceAllFieldsConfig(escalationPolicy, service),
 				Check: resource.ComposeTestCheckFunc(
@@ -120,7 +122,7 @@ func testAccCheckPagerDutyEventOrchestrationServiceRuleActions(rn, rloc string, 
 		}
 
 		attr := r.Primary.Attributes
-		path := fmt.Sprintf("%s.actions.0", rloc) // "sets.0.rules.0" + ".actions.0"
+		path := fmt.Sprintf("%s.actions.0", rloc) // "sets.0.rules.0.actions.0"
 
 		// route_to
 		// suppress
@@ -139,9 +141,9 @@ func testAccCheckPagerDutyEventOrchestrationServiceRuleActions(rn, rloc string, 
 		if attr[fmt.Sprintf("%s.automation_actions.0.url", path)] != a.AutomationActions[0].Url {
 			return fmt.Errorf("automation_actions.0.url not matching for %s", rn)
 		}
-		// if attr[fmt.Sprintf("%s.automation_actions.0.auto_send", path)] != a.AutomationActions[0].AutoSend {
-		// 	return fmt.Errorf("automation_actions.0.auto_send not matching for %s", rn)
-		// }
+		if attr[fmt.Sprintf("%s.automation_actions.0.auto_send", path)] != strconv.FormatBool(a.AutomationActions[0].AutoSend) {
+			return fmt.Errorf("automation_actions.0.auto_send not matching for %s", rn)
+		}
 
 		objCheckFn := func(prop string, obj []*pagerduty.EventOrchestrationPathAutomationActionObject) error {
 			for i, h := range obj {

--- a/pagerduty/resource_pagerduty_event_orchestration_path_service_test.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_service_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	// "strconv"
 	// "log"
-	// "strings"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -15,6 +15,7 @@ import (
 func init() {
 	resource.AddTestSweepers("pagerduty_event_orchestration_service", &resource.Sweeper{
 		Name: "pagerduty_event_orchestration_service",
+		F:    testSweepEventOrchestration,
 		Dependencies: []string{
 			"pagerduty_user",
 			"pagerduty_escalation_policy",
@@ -38,70 +39,80 @@ func TestAccPagerDutyEventOrchestrationPathService_Basic(t *testing.T) {
 			{
 				Config: testAccCheckPagerDutyEventOrchestrationServiceRequiredFieldsConfig(escalationPolicy, service),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPagerDutyEventOrchestrationServiceExists(resourceName),
-					resource.TestCheckResourceAttr(
-						resourceName, "sets.#", "1",
-					),
-					resource.TestCheckResourceAttr(
-						resourceName, "sets.0.rules.#", "0",
-					),
+					testAccCheckPagerDutyEventOrchestrationServicePathExists(resourceName),
+					testAccCheckPagerDutyEventOrchestrationServicePathParent(resourceName, "pagerduty_service.bar"),
 					resource.TestCheckResourceAttr(
 						resourceName, "type", "service",
 					),
 				),
 			},
-			// Test setting/resetting Automation Actions properties
+			// Test adding/updating/deleting automation_actions properties
 			{
 				Config: testAccCheckPagerDutyEventOrchestrationServiceAutomationActionsConfig(escalationPolicy, service),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPagerDutyEventOrchestrationServiceExists(resourceName),
-					resource.TestCheckResourceAttr(
-						resourceName, "sets.#", "1",
-					),
-					resource.TestCheckResourceAttr(
-						resourceName, "sets.0.rules.#", "1",
-					),
+					testAccCheckPagerDutyEventOrchestrationServicePathExists(resourceName),
+					testAccCheckPagerDutyEventOrchestrationServicePathParent(resourceName, "pagerduty_service.bar"),
 					resource.TestCheckResourceAttrSet(
 						resourceName, "sets.0.rules.0.id",
 					),
 				),
 			},
 			{
-				Config: testAccCheckPagerDutyEventOrchestrationServiceAutomationActionsResetConfig(escalationPolicy, service),
+				Config: testAccCheckPagerDutyEventOrchestrationServiceAutomationActionsParamsUpdateConfig(escalationPolicy, service),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPagerDutyEventOrchestrationServiceExists(resourceName),
+					testAccCheckPagerDutyEventOrchestrationServicePathExists(resourceName),
+					testAccCheckPagerDutyEventOrchestrationServicePathParent(resourceName, "pagerduty_service.bar"),
 					resource.TestCheckResourceAttr(
-						resourceName, "sets.#", "1",
-					),
-					resource.TestCheckResourceAttr(
-						resourceName, "sets.0.rules.#", "1",
+						resourceName, "sets.0.rules.0.actions.0.automation_actions.0.auto_send", "false",
 					),
 				),
 			},
 			{
-				Config: testAccCheckPagerDutyEventOrchestrationServicePDAutomationActionsConfig(escalationPolicy, service),
+				Config: testAccCheckPagerDutyEventOrchestrationServiceAutomationActionsParamsDeleteConfig(escalationPolicy, service),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPagerDutyEventOrchestrationServiceExists(resourceName),
-					resource.TestCheckResourceAttr(
-						resourceName, "sets.#", "1",
-					),
-					resource.TestCheckResourceAttr(
-						resourceName, "sets.0.rules.#", "1",
-					),
+					testAccCheckPagerDutyEventOrchestrationServicePathExists(resourceName),
+					testAccCheckPagerDutyEventOrchestrationServicePathParent(resourceName, "pagerduty_service.bar"),
 				),
 			},
-			// update all fields
-			// route_to
-			// suppress
-			// suspend
-			// priority
-			// annotate
-			// pagerduty_automation_actions
-			// severity
-			// event_action
-			// variables
-			// extractions
-			// reset headers/params
+			// Test adding/updating extractions/variables
+			{
+				Config: testAccCheckPagerDutyEventOrchestrationServiceExtractionsVariablesConfig(escalationPolicy, service),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyEventOrchestrationServicePathExists(resourceName),
+					testAccCheckPagerDutyEventOrchestrationServicePathParent(resourceName, "pagerduty_service.bar"),
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyEventOrchestrationServiceExtractionsVariablesUpdatedConfig(escalationPolicy, service),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyEventOrchestrationServicePathExists(resourceName),
+					testAccCheckPagerDutyEventOrchestrationServicePathParent(resourceName, "pagerduty_service.bar"),
+				),
+			},
+			// Test adding/updating/deleting all actions
+			{
+				Config: testAccCheckPagerDutyEventOrchestrationServiceAllActionsConfig(escalationPolicy, service),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyEventOrchestrationServicePathExists(resourceName),
+					testAccCheckPagerDutyEventOrchestrationServicePathParent(resourceName, "pagerduty_service.bar"),
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyEventOrchestrationServiceAllActionsUpdateConfig(escalationPolicy, service),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyEventOrchestrationServicePathExists(resourceName),
+					testAccCheckPagerDutyEventOrchestrationServicePathParent(resourceName, "pagerduty_service.bar"),
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyEventOrchestrationServiceAllActionsDeleteConfig(escalationPolicy, service),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyEventOrchestrationServicePathExists(resourceName),
+					testAccCheckPagerDutyEventOrchestrationServicePathParent(resourceName, "pagerduty_service.bar"),
+				),
+			},
+
+			// test route to
 			// reset rule action items -> should be default
 			// reset rule actions -> should be []
 			// reset rule conditions -> should be []
@@ -110,7 +121,7 @@ func TestAccPagerDutyEventOrchestrationPathService_Basic(t *testing.T) {
 	})
 }
 
-func testAccCheckPagerDutyEventOrchestrationServiceExists(rn string) resource.TestCheckFunc {
+func testAccCheckPagerDutyEventOrchestrationServicePathExists(rn string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		orch, ok := s.RootModule().Resources[rn]
 		if !ok {
@@ -127,6 +138,37 @@ func testAccCheckPagerDutyEventOrchestrationServiceExists(rn string) resource.Te
 		}
 		if found.Parent.ID != orch.Primary.ID {
 			return fmt.Errorf("Event Orchrestration Service not found: %v - %v", orch.Primary.ID, found)
+		}
+
+		// return fmt.Errorf(">>> attr: %v", orch.Primary.Attributes)
+
+		return nil
+	}
+}
+
+func testAccCheckPagerDutyEventOrchestrationServicePathParent(rn, sn string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		p, _ := s.RootModule().Resources[rn]
+		srv, ok := s.RootModule().Resources[sn]
+
+		if !ok {
+			return fmt.Errorf("Service not found: %s", sn)
+		}
+
+		var pId = p.Primary.Attributes["parent.0.id"]
+		var sId = srv.Primary.Attributes["id"]
+		if pId != sId {
+			return fmt.Errorf("Event Orchestration Service path parent ID (%v) not matching provided service ID: %v", pId, sId)
+		}
+
+		var t = p.Primary.Attributes["parent.0.type"]
+		if t != "service_reference" {
+			return fmt.Errorf("Event Orchestration Service path parent type (%v) not matching expected type: 'service_reference'", t)
+		}
+
+		var self = p.Primary.Attributes["parent.0.self"]
+		if !strings.HasSuffix(self, sId) {
+			return fmt.Errorf("Event Orchestration Service path parent self URL (%v) not containing expected service ID", self)
 		}
 
 		return nil
@@ -174,7 +216,7 @@ func testAccCheckPagerDutyEventOrchestrationServiceRequiredFieldsConfig(ep, s st
 	return fmt.Sprintf("%s%s", createBaseServicePathConfig(ep, s),
 		`resource "pagerduty_event_orchestration_service" "serviceA" {
 			parent {
-				id = "pagerduty_service.bar.id"
+				id = pagerduty_service.bar.id
 			}
 		
 			sets {
@@ -184,14 +226,11 @@ func testAccCheckPagerDutyEventOrchestrationServiceRequiredFieldsConfig(ep, s st
 	`)
 }
 
-// pagerduty_automation_actions {
-// 	action_id = "SOME_ACTION_ID"
-// }
 func testAccCheckPagerDutyEventOrchestrationServiceAutomationActionsConfig(ep, s string) string {
 	return fmt.Sprintf("%s%s", createBaseServicePathConfig(ep, s),
 		`resource "pagerduty_event_orchestration_service" "serviceA" {
 			parent {
-				id = "pagerduty_service.bar.id"
+				id = pagerduty_service.bar.id
 			}
 		
 			sets {
@@ -229,11 +268,43 @@ func testAccCheckPagerDutyEventOrchestrationServiceAutomationActionsConfig(ep, s
 	`)
 }
 
-func testAccCheckPagerDutyEventOrchestrationServiceAutomationActionsResetConfig(ep, s string) string {
+func testAccCheckPagerDutyEventOrchestrationServiceAutomationActionsParamsUpdateConfig(ep, s string) string {
 	return fmt.Sprintf("%s%s", createBaseServicePathConfig(ep, s),
 		`resource "pagerduty_event_orchestration_service" "serviceA" {
 			parent {
-				id = "pagerduty_service.bar.id"
+				id = pagerduty_service.bar.id
+			}
+		
+			sets {
+				id = "start"
+				rules {
+					label = "rule 1"
+					actions {							
+							automation_actions {
+								name = "test1"
+								url = "https://test1.com"
+		
+								headers {
+									key = "foo1"
+									value = "bar1"
+								}
+								parameters {
+									key = "source_region"
+									value = "eu"
+								}
+							}
+					}
+				}
+			}
+		}
+	`)
+}
+
+func testAccCheckPagerDutyEventOrchestrationServiceAutomationActionsParamsDeleteConfig(ep, s string) string {
+	return fmt.Sprintf("%s%s", createBaseServicePathConfig(ep, s),
+		`resource "pagerduty_event_orchestration_service" "serviceA" {
+			parent {
+				id = pagerduty_service.bar.id
 			}
 		
 			sets {
@@ -252,11 +323,11 @@ func testAccCheckPagerDutyEventOrchestrationServiceAutomationActionsResetConfig(
 	`)
 }
 
-func testAccCheckPagerDutyEventOrchestrationServicePDAutomationActionsConfig(ep, s string) string {
+func testAccCheckPagerDutyEventOrchestrationServiceExtractionsVariablesConfig(ep, s string) string {
 	return fmt.Sprintf("%s%s", createBaseServicePathConfig(ep, s),
 		`resource "pagerduty_event_orchestration_service" "serviceA" {
 			parent {
-				id = "pagerduty_service.bar.id"
+				id = pagerduty_service.bar.id
 			}
 		
 			sets {
@@ -264,10 +335,196 @@ func testAccCheckPagerDutyEventOrchestrationServicePDAutomationActionsConfig(ep,
 				rules {
 					label = "rule 1"
 					actions {							
-							pagerduty_automation_actions {
-								action_id = "01CSB5SMOKCKVRI5GN0LJG7SMB"
-							}
+						variables {
+							name = "server_name_cpu"
+							path = "event.summary"
+							type = "regex"
+							value = "High CPU on (.*) server"
+						}
+						variables {
+							name = "server_name_memory"
+							path = "event.custom_details"
+							type = "regex"
+							value = "High memory usage on (.*) server"
+						}
+						extractions {
+							target = "event.summary"
+							template = "High memory usage on variables.hostname server"
+						}
+						extractions {
+							target = "event.custom_details"
+							template = "High memory usage on variables.hostname server"
+						}
 					}
+				}
+			}
+		}
+	`)
+}
+
+func testAccCheckPagerDutyEventOrchestrationServiceExtractionsVariablesUpdatedConfig(ep, s string) string {
+	return fmt.Sprintf("%s%s", createBaseServicePathConfig(ep, s),
+		`resource "pagerduty_event_orchestration_service" "serviceA" {
+			parent {
+				id = pagerduty_service.bar.id
+			}
+		
+			sets {
+				id = "start"
+				rules {
+					label = "rule 1"
+					actions {
+						variables {
+							name = "host_name"
+							path = "event.custom_details.memory"
+							type = "regex"
+							value = "High memory usage on (.*) server"
+						}
+						extractions {
+							target = "event.custom_details.info"
+							template = "High memory usage on {{variables.hostname}} server: {{event.custom_details.max_memory}}"
+						}
+					}
+				}
+			}
+		}
+	`)
+}
+
+func testAccCheckPagerDutyEventOrchestrationServiceAllActionsConfig(ep, s string) string {
+	return fmt.Sprintf("%s%s", createBaseServicePathConfig(ep, s),
+		`resource "pagerduty_event_orchestration_service" "serviceA" {
+			parent {
+				id = pagerduty_service.bar.id
+			}
+		
+			sets {
+				id = "start"
+				rules {
+					label = "rule 1"
+					conditions {
+						expression = "event.summary matches part 'timeout'"
+					}
+					conditions {
+						expression = "event.custom_details.timeout_err exists"
+					}
+					actions {
+						route_to = "set-1"
+						priority = "P0IN2KQ"
+						annotate = "Routed through an event orchestration"
+						pagerduty_automation_actions {
+							action_id = "01CSB5SMOKCKVRI5GN0LJG7SMB"
+						}
+						severity = "critical"
+						event_action = "trigger"
+					}
+				}
+			}
+			sets {
+				id = "set-1"
+				rules {
+					label = "set-1 rule 1"
+					actions {
+						suspend = 300
+					}
+				}
+				rules {
+					label = "set-1 rule 2"
+					conditions {
+						expression = "event.source matches part 'stg-'"
+					}
+					actions {
+						suppress = true
+					}
+				}
+			}
+		}
+	`)
+}
+
+func testAccCheckPagerDutyEventOrchestrationServiceAllActionsUpdateConfig(ep, s string) string {
+	return fmt.Sprintf("%s%s", createBaseServicePathConfig(ep, s),
+		`resource "pagerduty_event_orchestration_service" "serviceA" {
+			parent {
+				id = pagerduty_service.bar.id
+			}
+		
+			sets {
+				id = "start"
+				rules {
+					label = "rule 1 updated"
+					conditions {
+						expression = "event.custom_details.timeout_err matches part 'timeout'"
+					}
+					actions {
+						route_to = "set-2"
+						priority = "P0IN2KR"
+						annotate = "Routed through a service orchestration!"
+						pagerduty_automation_actions {
+							action_id = "01CSB5SMOKCKVRI5GN0LJG7SMBUPDATED"
+						}
+						severity = "warning"
+						event_action = "resolve"
+					}
+				}
+			}
+			sets {
+				id = "set-2"
+				rules {
+					label = "set-2 rule 1"
+					actions {
+						suspend = 15
+					}
+				}
+				rules {
+					label = "set-2 rule 2"
+					conditions {
+						expression = "event.source matches part 'test-'"
+					}
+					actions {
+						annotate = "Matched set-2 rule 2"
+						variables {
+							name = "host_name"
+							path = "event.custom_details.memory"
+							type = "regex"
+							value = "High memory usage on (.*) server"
+						}
+						extractions {
+							target = "event.summary"
+							template = "High memory usage on {{variables.hostname}} server: {{event.custom_details.max_memory}}"
+						}
+					}
+				}
+			}
+		}
+	`)
+}
+
+func testAccCheckPagerDutyEventOrchestrationServiceAllActionsDeleteConfig(ep, s string) string {
+	return fmt.Sprintf("%s%s", createBaseServicePathConfig(ep, s),
+		`resource "pagerduty_event_orchestration_service" "serviceA" {
+			parent {
+				id = pagerduty_service.bar.id
+			}
+		
+			sets {
+				id = "start"
+				rules {
+					label = "rule 1 updated"
+					actions {
+						route_to = "set-2"
+					}
+				}
+			}
+			sets {
+				id = "set-2"
+				rules {
+					label = "set-2 rule 1"
+					actions { }
+				}
+				rules {
+					label = "set-2 rule 2"
+					actions { }
 				}
 			}
 		}

--- a/pagerduty/resource_pagerduty_event_orchestration_path_service_test.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_service_test.go
@@ -59,26 +59,31 @@ func TestAccPagerDutyEventOrchestrationPathService_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						resourceName, "sets.0.rules.#", "1",
 					),
-					testAccCheckPagerDutyEventOrchestrationServiceRuleActions(resourceName, "sets.0.rules.0", &pagerduty.EventOrchestrationPathRuleActions{
-						PagerdutyAutomationActions: []*pagerduty.EventOrchestrationPathPagerdutyAutomationAction{
-							&pagerduty.EventOrchestrationPathPagerdutyAutomationAction{ActionId: "SOME_ACTION_ID"},
-						},
-						AutomationActions: []*pagerduty.EventOrchestrationPathAutomationAction{
-							&pagerduty.EventOrchestrationPathAutomationAction{
-								Name:     "test",
-								Url:      "https://test.com",
-								AutoSend: true,
-								Headers: []*pagerduty.EventOrchestrationPathAutomationActionObject{
-									&pagerduty.EventOrchestrationPathAutomationActionObject{Key: "foo", Value: "bar"},
-									&pagerduty.EventOrchestrationPathAutomationActionObject{Key: "baz", Value: "buz"},
-								},
-								Parameters: []*pagerduty.EventOrchestrationPathAutomationActionObject{
-									&pagerduty.EventOrchestrationPathAutomationActionObject{Key: "source", Value: "orch"},
-									&pagerduty.EventOrchestrationPathAutomationActionObject{Key: "region", Value: "us"},
-								},
-							},
-						},
-					}),
+					resource.TestCheckTypeSetElemNestedAttrs(
+						resourceName,
+						"sets.0.rules.0.actions.0.pagerduty_automation_actions.*",
+						map[string]string{"action_id": "SOME_ACTION_ID"},
+					),
+					// testAccCheckPagerDutyEventOrchestrationServiceRuleActions(resourceName, "sets.0.rules.0", &pagerduty.EventOrchestrationPathRuleActions{
+					// 	PagerdutyAutomationActions: []*pagerduty.EventOrchestrationPathPagerdutyAutomationAction{
+					// 		&pagerduty.EventOrchestrationPathPagerdutyAutomationAction{ActionId: "SOME_ACTION_ID"},
+					// 	},
+					// 	AutomationActions: []*pagerduty.EventOrchestrationPathAutomationAction{
+					// 		&pagerduty.EventOrchestrationPathAutomationAction{
+					// 			Name:     "test",
+					// 			Url:      "https://test.com",
+					// 			AutoSend: true,
+					// 			Headers: []*pagerduty.EventOrchestrationPathAutomationActionObject{
+					// 				&pagerduty.EventOrchestrationPathAutomationActionObject{Key: "foo", Value: "bar"},
+					// 				&pagerduty.EventOrchestrationPathAutomationActionObject{Key: "baz", Value: "buz"},
+					// 			},
+					// 			Parameters: []*pagerduty.EventOrchestrationPathAutomationActionObject{
+					// 				&pagerduty.EventOrchestrationPathAutomationActionObject{Key: "source", Value: "orch"},
+					// 				&pagerduty.EventOrchestrationPathAutomationActionObject{Key: "region", Value: "us"},
+					// 			},
+					// 		},
+					// 	},
+					// }),
 				),
 			},
 			// update all fields

--- a/pagerduty/resource_pagerduty_event_orchestration_path_service_test.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_service_test.go
@@ -112,11 +112,11 @@ func TestAccPagerDutyEventOrchestrationPathService_Basic(t *testing.T) {
 				),
 			},
 
-			// test route to
-			// reset rule action items -> should be default
-			// reset rule actions -> should be []
-			// reset rule conditions -> should be []
-			// reset rules
+			// TODO:
+			// test deleting route_to
+			// test regex extractions
+			// test catch_all
+			// test resetting rules
 		},
 	})
 }

--- a/pagerduty/resource_pagerduty_event_orchestration_path_service_test.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_service_test.go
@@ -15,11 +15,6 @@ func init() {
 	resource.AddTestSweepers("pagerduty_event_orchestration_service", &resource.Sweeper{
 		Name: "pagerduty_event_orchestration_service",
 		F:    testSweepEventOrchestration,
-		Dependencies: []string{
-			"pagerduty_user",
-			"pagerduty_escalation_policy",
-			"pagerduty_service",
-		},
 	})
 }
 
@@ -212,8 +207,6 @@ func testAccCheckPagerDutyEventOrchestrationPathServiceExists(rn string) resourc
 		if found.Parent.ID != orch.Primary.ID {
 			return fmt.Errorf("Event Orchrestration Service not found: %v - %v", orch.Primary.ID, found)
 		}
-
-		// return fmt.Errorf(">>> attr: %v", orch.Primary.Attributes)
 
 		return nil
 	}

--- a/pagerduty/resource_pagerduty_event_orchestration_path_unrouted.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_unrouted.go
@@ -117,13 +117,21 @@ func resourcePagerDutyEventOrchestrationPathUnrouted() *schema.Resource {
 													Optional: true,
 													Elem: &schema.Resource{
 														Schema: map[string]*schema.Schema{
+															"regex": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+															"source": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
 															"target": {
 																Type:     schema.TypeString,
 																Required: true,
 															},
 															"template": {
 																Type:     schema.TypeString,
-																Required: true,
+																Optional: true,
 															},
 														}},
 												},
@@ -201,13 +209,21 @@ func resourcePagerDutyEventOrchestrationPathUnrouted() *schema.Resource {
 										Optional: true,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
+												"regex": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"source": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
 												"target": {
 													Type:     schema.TypeString,
 													Required: true,
 												},
 												"template": {
 													Type:     schema.TypeString,
-													Required: true,
+													Optional: true,
 												},
 											}},
 									},
@@ -389,8 +405,8 @@ func expandUnroutedActions(v interface{}) *pagerduty.EventOrchestrationPathRuleA
 			actions.RouteTo = am["route_to"].(string)
 			actions.Severity = am["severity"].(string)
 			actions.EventAction = am["event_action"].(string)
-			actions.Variables = expandUnroutedActionsVariables(am["variables"])
-			actions.Extractions = expandUnroutedActionsExtractions(am["extractions"])
+			actions.Variables = expandEventOrchestrationPathVariables(am["variables"])
+			actions.Extractions = expandEventOrchestrationPathExtractions(am["extractions"])
 		}
 	}
 
@@ -414,39 +430,6 @@ func expandUnroutedConditions(v interface{}) []*pagerduty.EventOrchestrationPath
 	return conditions
 }
 
-func expandUnroutedActionsExtractions(v interface{}) []*pagerduty.EventOrchestrationPathActionExtractions {
-	unroutedExtractions := []*pagerduty.EventOrchestrationPathActionExtractions{}
-
-	for _, eai := range v.([]interface{}) {
-		ea := eai.(map[string]interface{})
-		ext := &pagerduty.EventOrchestrationPathActionExtractions{
-			Target:   ea["target"].(string),
-			Template: ea["template"].(string),
-		}
-		unroutedExtractions = append(unroutedExtractions, ext)
-	}
-	return unroutedExtractions
-}
-
-func expandUnroutedActionsVariables(v interface{}) []*pagerduty.EventOrchestrationPathActionVariables {
-	unroutedVariables := []*pagerduty.EventOrchestrationPathActionVariables{}
-
-	for _, er := range v.([]interface{}) {
-		rer := er.(map[string]interface{})
-
-		unroutedVar := &pagerduty.EventOrchestrationPathActionVariables{
-			Name:  rer["name"].(string),
-			Path:  rer["path"].(string),
-			Type:  rer["type"].(string),
-			Value: rer["value"].(string),
-		}
-
-		unroutedVariables = append(unroutedVariables, unroutedVar)
-	}
-
-	return unroutedVariables
-}
-
 func expandUnroutedCatchAll(v interface{}) *pagerduty.EventOrchestrationPathCatchAll {
 	var catchAll = new(pagerduty.EventOrchestrationPathCatchAll)
 
@@ -467,8 +450,8 @@ func expandUnroutedCatchAllActions(v interface{}) *pagerduty.EventOrchestrationP
 			am := ai.(map[string]interface{})
 			actions.Severity = am["severity"].(string)
 			actions.EventAction = am["event_action"].(string)
-			actions.Variables = expandUnroutedActionsVariables(am["variables"])
-			actions.Extractions = expandUnroutedActionsExtractions(am["extractions"])
+			actions.Variables = expandEventOrchestrationPathVariables(am["variables"])
+			actions.Extractions = expandEventOrchestrationPathExtractions(am["extractions"])
 		}
 	}
 
@@ -528,43 +511,15 @@ func flattenUnroutedActions(actions *pagerduty.EventOrchestrationPathRuleActions
 	}
 
 	if actions.Variables != nil {
-		flattenedAction["variables"] = flattenUnroutedActionsVariables(actions.Variables)
+		flattenedAction["variables"] = flattenEventOrchestrationPathVariables(actions.Variables)
 	}
 	if actions.Extractions != nil {
-		flattenedAction["extractions"] = flattenUnroutedActionsExtractions(actions.Extractions)
+		flattenedAction["extractions"] = flattenEventOrchestrationPathExtractions(actions.Extractions)
 	}
 
 	actionsMap = append(actionsMap, flattenedAction)
 
 	return actionsMap
-}
-
-func flattenUnroutedActionsVariables(v []*pagerduty.EventOrchestrationPathActionVariables) []interface{} {
-	var flatVariablesList []interface{}
-
-	for _, s := range v {
-		flatVariable := map[string]interface{}{
-			"name":  s.Name,
-			"path":  s.Path,
-			"type":  s.Type,
-			"value": s.Value,
-		}
-		flatVariablesList = append(flatVariablesList, flatVariable)
-	}
-	return flatVariablesList
-}
-
-func flattenUnroutedActionsExtractions(e []*pagerduty.EventOrchestrationPathActionExtractions) []interface{} {
-	var flatExtractionsList []interface{}
-
-	for _, s := range e {
-		flatExtraction := map[string]interface{}{
-			"target":   s.Target,
-			"template": s.Template,
-		}
-		flatExtractionsList = append(flatExtractionsList, flatExtraction)
-	}
-	return flatExtractionsList
 }
 
 func flattenUnroutedCatchAll(catchAll *pagerduty.EventOrchestrationPathCatchAll) []map[string]interface{} {
@@ -588,10 +543,10 @@ func flattenUnroutedCatchAllActions(actions *pagerduty.EventOrchestrationPathRul
 	}
 
 	if actions.Variables != nil {
-		flattenedAction["variables"] = flattenUnroutedActionsVariables(actions.Variables)
+		flattenedAction["variables"] = flattenEventOrchestrationPathVariables(actions.Variables)
 	}
 	if actions.Variables != nil {
-		flattenedAction["extractions"] = flattenUnroutedActionsExtractions(actions.Extractions)
+		flattenedAction["extractions"] = flattenEventOrchestrationPathExtractions(actions.Extractions)
 	}
 
 	actionsMap = append(actionsMap, flattenedAction)

--- a/pagerduty/resource_pagerduty_event_orchestration_path_unrouted.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_unrouted.go
@@ -530,7 +530,7 @@ func flattenUnroutedActions(actions *pagerduty.EventOrchestrationPathRuleActions
 	if actions.Variables != nil {
 		flattenedAction["variables"] = flattenUnroutedActionsVariables(actions.Variables)
 	}
-	if actions.Variables != nil {
+	if actions.Extractions != nil {
 		flattenedAction["extractions"] = flattenUnroutedActionsExtractions(actions.Extractions)
 	}
 

--- a/pagerduty/util.go
+++ b/pagerduty/util.go
@@ -145,3 +145,10 @@ func stringPtrToStringType(v *string) string {
 	}
 	return *v
 }
+
+func intTypeToIntPtr(v int) *int {
+	if v == 0 {
+		return nil
+	}
+	return &v
+}

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/event_orchestration_path.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/event_orchestration_path.go
@@ -29,13 +29,13 @@ type EventOrchestrationPathReference struct {
 
 type EventOrchestrationPathSet struct {
 	ID    string                        `json:"id,omitempty"`
-	Rules []*EventOrchestrationPathRule `json:"rules,omitempty"`
+	Rules []*EventOrchestrationPathRule `json:"rules"`
 }
 
 type EventOrchestrationPathRule struct {
 	ID         string                                 `json:"id,omitempty"`
 	Label      string                                 `json:"label,omitempty"`
-	Conditions []*EventOrchestrationPathRuleCondition `json:"conditions,omitempty"`
+	Conditions []*EventOrchestrationPathRuleCondition `json:"conditions"`
 	Actions    *EventOrchestrationPathRuleActions     `json:"actions,omitempty"`
 	Disabled   bool                                   `json:"disabled,omitempty"`
 }

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/event_orchestration_path.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/event_orchestration_path.go
@@ -88,7 +88,9 @@ type EventOrchestrationPathActionVariables struct {
 
 type EventOrchestrationPathActionExtractions struct {
 	Target   string `json:"target,omitempty"`
+	Regex string `json:"regex,omitempty"`
 	Template string `json:"template,omitempty"`
+	Source string `json:"source,omitempty"`
 }
 
 type EventOrchestrationPathCatchAll struct {

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/event_orchestration_path.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/event_orchestration_path.go
@@ -51,7 +51,7 @@ type EventOrchestrationPathRuleCondition struct {
 type EventOrchestrationPathRuleActions struct {
 	RouteTo                    string                                             `json:"route_to,omitempty"`
 	Suppress                   bool                                               `json:"suppress"`
-	Suspend                    int                                                `json:"suspend,omitempty"`
+	Suspend                    *int                                               `json:"suspend"`
 	Priority                   string                                             `json:"priority"`
 	Annotate                   string                                             `json:"annotate"`
 	PagerdutyAutomationActions []*EventOrchestrationPathPagerdutyAutomationAction `json:"pagerduty_automation_actions"`

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/event_orchestration_path.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/event_orchestration_path.go
@@ -49,7 +49,7 @@ type EventOrchestrationPathRuleCondition struct {
 // Service: https://developer.pagerduty.com/api-reference/179537b835e2d-get-the-service-orchestration-for-a-service
 // Unrouted: https://developer.pagerduty.com/api-reference/70aa1139e1013-get-the-unrouted-orchestration-for-a-global-event-orchestration
 type EventOrchestrationPathRuleActions struct {
-	RouteTo                    string                                             `json:"route_to,omitempty"`
+	RouteTo                    string                                             `json:"route_to"`
 	Suppress                   bool                                               `json:"suppress"`
 	Suspend                    *int                                               `json:"suspend"`
 	Priority                   string                                             `json:"priority"`

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/event_orchestration_path.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/event_orchestration_path.go
@@ -51,7 +51,7 @@ type EventOrchestrationPathRuleCondition struct {
 type EventOrchestrationPathRuleActions struct {
 	RouteTo                    string                                             `json:"route_to,omitempty"`
 	Suppress                   bool                                               `json:"suppress"`
-	Suspend                    int                                                `json:"suspend"`
+	Suspend                    int                                                `json:"suspend,omitempty"`
 	Priority                   string                                             `json:"priority"`
 	Annotate                   string                                             `json:"annotate"`
 	PagerdutyAutomationActions []*EventOrchestrationPathPagerdutyAutomationAction `json:"pagerduty_automation_actions"`

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/event_orchestration_path.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/event_orchestration_path.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 )
 
-// TODO: Check omitempty for all structs
 type EventOrchestrationPathService service
 
 type EventOrchestrationPath struct {
@@ -51,16 +50,16 @@ type EventOrchestrationPathRuleCondition struct {
 // Unrouted: https://developer.pagerduty.com/api-reference/70aa1139e1013-get-the-unrouted-orchestration-for-a-global-event-orchestration
 type EventOrchestrationPathRuleActions struct {
 	RouteTo                    string                                             `json:"route_to,omitempty"`
-	Suppress                   bool                                               `json:"suppress,omitempty"`
-	Suspend                    int                                                `json:"suspend,omitempty"`
-	Priority                   string                                             `json:"priority,omitempty"`
-	Annotate                   string                                             `json:"annotate,omitempty"`
-	PagerdutyAutomationActions []*EventOrchestrationPathPagerdutyAutomationAction `json:"pagerduty_automation_actions,omitempty"`
-	AutomationActions          []*EventOrchestrationPathAutomationAction          `json:"automation_actions,omitempty"`
-	Severity                   string                                             `json:"severity,omitempty"`
-	EventAction                string                                             `json:"event_action,omitempty"`
-	Variables                  []*EventOrchestrationPathActionVariables           `json:"variables,omitempty"`
-	Extractions                []*EventOrchestrationPathActionExtractions         `json:"extractions,omitempty"`
+	Suppress                   bool                                               `json:"suppress"`
+	Suspend                    int                                                `json:"suspend"`
+	Priority                   string                                             `json:"priority"`
+	Annotate                   string                                             `json:"annotate"`
+	PagerdutyAutomationActions []*EventOrchestrationPathPagerdutyAutomationAction `json:"pagerduty_automation_actions"`
+	AutomationActions          []*EventOrchestrationPathAutomationAction          `json:"automation_actions"`
+	Severity                   string                                             `json:"severity"`
+	EventAction                string                                             `json:"event_action"`
+	Variables                  []*EventOrchestrationPathActionVariables           `json:"variables"`
+	Extractions                []*EventOrchestrationPathActionExtractions         `json:"extractions"`
 }
 
 type EventOrchestrationPathPagerdutyAutomationAction struct {
@@ -71,8 +70,8 @@ type EventOrchestrationPathAutomationAction struct {
 	Name       string                                          `json:"name,omitempty"`
 	Url        string                                          `json:"url,omitempty"`
 	AutoSend   bool                                            `json:"auto_send,omitempty"`
-	Headers    []*EventOrchestrationPathAutomationActionObject `json:"headers,omitempty"`
-	Parameters []*EventOrchestrationPathAutomationActionObject `json:"parameters,omitempty"`
+	Headers    []*EventOrchestrationPathAutomationActionObject `json:"headers"`
+	Parameters []*EventOrchestrationPathAutomationActionObject `json:"parameters"`
 }
 
 type EventOrchestrationPathAutomationActionObject struct {

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/pagerduty.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/pagerduty.go
@@ -202,6 +202,7 @@ func (c *Client) newRequestDoOptions(method, url string, qryOptions, body, v int
 }
 
 func (c *Client) do(req *http.Request, v interface{}) (*Response, error) {
+	log.Printf(">>> req: %v", req)
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/pagerduty.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/pagerduty.go
@@ -202,7 +202,6 @@ func (c *Client) newRequestDoOptions(method, url string, qryOptions, body, v int
 }
 
 func (c *Client) do(req *http.Request, v interface{}) (*Response, error) {
-	log.Printf(">>> req: %v", req)
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Changes
- Add support for the `pagerduty_event_orchestration_service` resource
- Modify the unrouted resource to use shared method for variables and extractions

### Testing
<img width="971" alt="image" src="https://user-images.githubusercontent.com/47909261/169423172-068c62c1-9486-40dc-8c6e-d2d061b1800e.png">
