### PR TITLE
ORCA-3486 - remove team attribute from service path

### DIFF
--- a/pagerduty/resource_pagerduty_event_orchestration_path_router.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_router.go
@@ -20,10 +20,6 @@ func resourcePagerDutyEventOrchestrationPathRouter() *schema.Resource {
 			State: resourcePagerDutyEventOrchestrationPathRouterImport,
 		},
 		Schema: map[string]*schema.Schema{
-			"type": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"parent": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -131,8 +127,6 @@ func resourcePagerDutyEventOrchestrationPathRouterRead(d *schema.ResourceData, m
 			time.Sleep(2 * time.Second)
 			return resource.RetryableError(err)
 		} else if routerPath != nil {
-			d.Set("type", routerPath.Type)
-
 			if routerPath.Sets != nil {
 				d.Set("sets", flattenSets(routerPath.Sets))
 			}
@@ -178,9 +172,7 @@ func performRouterPathUpdate(d *schema.ResourceData, routerPath *pagerduty.Event
 		if updatedPath == nil {
 			return resource.NonRetryableError(fmt.Errorf("No Event Orchestration Router found."))
 		}
-		// set props
 		d.SetId(routerPath.Parent.ID)
-		d.Set("type", updatedPath.Type)
 
 		if routerPath.Sets != nil {
 			d.Set("sets", flattenSets(routerPath.Sets))

--- a/pagerduty/resource_pagerduty_event_orchestration_path_router.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_router.go
@@ -359,6 +359,7 @@ func resourcePagerDutyEventOrchestrationPathRouterImport(d *schema.ResourceData,
 	}
 
 	d.SetId(orchestrationID)
+	d.Set("event_orchestration", orchestrationID)
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/pagerduty/resource_pagerduty_event_orchestration_path_router_test.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_router_test.go
@@ -207,205 +207,195 @@ func createBaseConfig(t, ep, s, o string) string {
 func testAccCheckPagerDutyEventOrchestrationRouterConfigNoRules(t, ep, s, o string) string {
 	return fmt.Sprintf("%s%s", createBaseConfig(t, ep, s, o),
 		`resource "pagerduty_event_orchestration_router" "router" {
-		parent {
-			id = pagerduty_event_orchestration.orch.id
-		}
-		catch_all {
-			actions {
-				route_to = "unrouted"
+			event_orchestration = pagerduty_event_orchestration.orch.id
+
+			catch_all {
+				actions {
+					route_to = "unrouted"
+				}
+			}
+			sets {
+				id = "start"
 			}
 		}
-		sets {
-			id = "start"
-		}
-	}
 	`)
 }
 
 func testAccCheckPagerDutyEventOrchestrationRouterConfig(t, ep, s, o string) string {
 	return fmt.Sprintf("%s%s", createBaseConfig(t, ep, s, o),
 		`resource "pagerduty_event_orchestration_router" "router" {
-		parent {
-			id = pagerduty_event_orchestration.orch.id
-		}
-		catch_all {
-			actions {
-				route_to = "unrouted"
-			}
-		}
-		sets {
-			id = "start"
-			rules {
-				disabled = false
-				label = "rule1 label"
+			event_orchestration = pagerduty_event_orchestration.orch.id
+
+			catch_all {
 				actions {
-					route_to = pagerduty_service.bar.id
+					route_to = "unrouted"
+				}
+			}
+			sets {
+				id = "start"
+				rules {
+					disabled = false
+					label = "rule1 label"
+					actions {
+						route_to = pagerduty_service.bar.id
+					}
 				}
 			}
 		}
-	}
 	`)
 }
 
 func testAccCheckPagerDutyEventOrchestrationRouterConfigWithConditions(t, ep, s, o string) string {
 	return fmt.Sprintf("%s%s", createBaseConfig(t, ep, s, o),
-		`
-resource "pagerduty_event_orchestration_router" "router" {
-	parent {
-        id = pagerduty_event_orchestration.orch.id
-    }
-	catch_all {
-		actions {
-			route_to = "unrouted"
-		}
-	}
-	sets {
-		id = "start"
-		rules {
-			disabled = false
-			label = "rule1 label"
-			actions {
-				route_to = pagerduty_service.bar.id
+		`resource "pagerduty_event_orchestration_router" "router" {
+			event_orchestration = pagerduty_event_orchestration.orch.id
+
+			catch_all {
+				actions {
+					route_to = "unrouted"
+				}
 			}
-			conditions {
-				expression = "event.summary matches part 'database'"
+			sets {
+				id = "start"
+				rules {
+					disabled = false
+					label = "rule1 label"
+					actions {
+						route_to = pagerduty_service.bar.id
+					}
+					conditions {
+						expression = "event.summary matches part 'database'"
+					}
+				}
 			}
 		}
-	}
-}
-`)
+	`)
 }
 
 func testAccCheckPagerDutyEventOrchestrationRouterConfigWithMultipleRules(t, ep, s, o string) string {
 	return fmt.Sprintf(
 		"%s%s", createBaseConfig(t, ep, s, o),
-		`
-resource "pagerduty_service" "bar2" {
-	name = "tf-barService2"
-	escalation_policy       = pagerduty_escalation_policy.foo.id
+		`resource "pagerduty_service" "bar2" {
+			name = "tf-barService2"
+			escalation_policy       = pagerduty_escalation_policy.foo.id
 
-	incident_urgency_rule {
-		type = "constant"
-		urgency = "high"
-	}
-}
-
-resource "pagerduty_event_orchestration_router" "router" {
-	parent {
-        id = pagerduty_event_orchestration.orch.id
-    }
-	catch_all {
-		actions {
-			route_to = "unrouted"
-		}
-	}
-	sets {
-		id = "start"
-		rules {
-			disabled = false
-			label = "rule1 label"
-			actions {
-				route_to = pagerduty_service.bar.id
-			}
-			conditions {
-				expression = "event.summary matches part 'database'"
-			}
-			conditions {
-				expression = "event.severity matches part 'critical'"
+			incident_urgency_rule {
+				type = "constant"
+				urgency = "high"
 			}
 		}
 
-		rules {
-			disabled = false
-			label = "rule2 label"
-			actions {
-				route_to = pagerduty_service.bar2.id
+		resource "pagerduty_event_orchestration_router" "router" {
+			event_orchestration = pagerduty_event_orchestration.orch.id
+
+			catch_all {
+				actions {
+					route_to = "unrouted"
+				}
 			}
-			conditions {
-				expression = "event.severity matches part 'critical'"
+			sets {
+				id = "start"
+				rules {
+					disabled = false
+					label = "rule1 label"
+					actions {
+						route_to = pagerduty_service.bar.id
+					}
+					conditions {
+						expression = "event.summary matches part 'database'"
+					}
+					conditions {
+						expression = "event.severity matches part 'critical'"
+					}
+				}
+
+				rules {
+					disabled = false
+					label = "rule2 label"
+					actions {
+						route_to = pagerduty_service.bar2.id
+					}
+					conditions {
+						expression = "event.severity matches part 'critical'"
+					}
+				}
 			}
 		}
-	}
-}
-`)
+	`)
 }
 
 func testAccCheckPagerDutyEventOrchestrationRouterConfigNoConditions(t, ep, s, o string) string {
 	return fmt.Sprintf("%s%s", createBaseConfig(t, ep, s, o),
-		`
-resource "pagerduty_event_orchestration_router" "router" {
-	parent {
-        id = pagerduty_event_orchestration.orch.id
-    }
-	catch_all {
-		actions {
-			route_to = pagerduty_service.bar.id
-		}
-	}
-	sets {
-		id = "start"
-		rules {
-			disabled = false
-			label = "rule1 label"
-			actions {
-				route_to = pagerduty_service.bar.id
+		`resource "pagerduty_event_orchestration_router" "router" {
+			event_orchestration = pagerduty_event_orchestration.orch.id
+
+			catch_all {
+				actions {
+					route_to = pagerduty_service.bar.id
+				}
+			}
+			sets {
+				id = "start"
+				rules {
+					disabled = false
+					label = "rule1 label"
+					actions {
+						route_to = pagerduty_service.bar.id
+					}
+				}
 			}
 		}
-	}
-}
-`)
+	`)
 }
 
 func testAccCheckPagerDutyEventOrchestrationRouterConfigWithCatchAllToService(t, ep, s, o string) string {
 	return fmt.Sprintf("%s%s", createBaseConfig(t, ep, s, o),
-		`
-resource "pagerduty_event_orchestration_router" "router" {
-	parent {
-        id = pagerduty_event_orchestration.orch.id
-    }
-	catch_all {
-		actions {
-			route_to = pagerduty_service.bar.id
-		}
-	}
-	sets {
-		id = "start"
-		rules {
-			disabled = false
-			label = "rule1 label"
-			actions {
-				route_to = pagerduty_service.bar.id
+		`resource "pagerduty_event_orchestration_router" "router" {
+			event_orchestration = pagerduty_event_orchestration.orch.id
+			
+			catch_all {
+				actions {
+					route_to = pagerduty_service.bar.id
+				}
 			}
-			conditions {
-				expression = "event.severity matches part 'critical'"
+			sets {
+				id = "start"
+				rules {
+					disabled = false
+					label = "rule1 label"
+					actions {
+						route_to = pagerduty_service.bar.id
+					}
+					conditions {
+						expression = "event.severity matches part 'critical'"
+					}
+				}
 			}
 		}
-	}
-}
-`)
+		`)
 }
 
 func testAccCheckPagerDutyEventOrchestrationRouterConfigDeleteAllRulesInSet(t, ep, s, o string) string {
 	return fmt.Sprintf("%s%s", createBaseConfig(t, ep, s, o),
-		`
-resource "pagerduty_event_orchestration_router" "router" {
-	parent {
-        id = pagerduty_event_orchestration.orch.id
-    }
-	catch_all {
-		actions {
-			route_to = pagerduty_service.bar.id
+		`resource "pagerduty_event_orchestration_router" "router" {
+			event_orchestration = pagerduty_event_orchestration.orch.id
+			
+			catch_all {
+				actions {
+					route_to = pagerduty_service.bar.id
+				}
+			}
+			sets {
+				id = "start"
+			}
 		}
-	}
-	sets {
-		id = "start"
-	}
+		`)
 }
-`)
-}
+
 func testAccCheckPagerDutyEventOrchestrationRouterConfigDelete(t, ep, s, o string) string {
 	return createBaseConfig(t, ep, s, o)
 }
+
 func testAccCheckPagerDutyEventOrchestrationRouterPathRouteToMatch(router, service string, catchAll bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		r, rOk := s.RootModule().Resources[router]

--- a/pagerduty/resource_pagerduty_event_orchestration_path_router_test.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_router_test.go
@@ -31,8 +31,6 @@ func TestAccPagerDutyEventOrchestrationPathRouter_Basic(t *testing.T) {
 				Config: testAccCheckPagerDutyEventOrchestrationRouterConfigNoRules(team, escalationPolicy, service, orchestration),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyEventOrchestrationRouterExists("pagerduty_event_orchestration_router.router"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_event_orchestration_router.router", "type", "router"),
 					testAccCheckPagerDutyEventOrchestrationRouterPathRouteToMatch(
 						"pagerduty_event_orchestration_router.router", "unrouted", true), //test for catch_all route_to prop, by default it should be unrouted
 					resource.TestCheckResourceAttr(
@@ -43,8 +41,6 @@ func TestAccPagerDutyEventOrchestrationPathRouter_Basic(t *testing.T) {
 				Config: testAccCheckPagerDutyEventOrchestrationRouterConfig(team, escalationPolicy, service, orchestration),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyEventOrchestrationRouterExists("pagerduty_event_orchestration_router.router"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_event_orchestration_router.router", "type", "router"),
 					testAccCheckPagerDutyEventOrchestrationRouterPathRouteToMatch(
 						"pagerduty_event_orchestration_router.router", "pagerduty_service.bar", false), // test for rule action route_to
 					testAccCheckPagerDutyEventOrchestrationRouterPathRouteToMatch(
@@ -134,19 +130,17 @@ func testAccCheckPagerDutyEventOrchestrationRouterExists(rn string) resource.Tes
 			return fmt.Errorf("Not found: %s", rn)
 		}
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No Event Orchestration Path Type is set")
+			return fmt.Errorf("No Event Orchestration Router is set")
 		}
 
 		orch, _ := s.RootModule().Resources["pagerduty_event_orchestration.orch"]
 		client, _ := testAccProvider.Meta().(*Config).Client()
-		found, _, err := client.EventOrchestrationPaths.Get(orch.Primary.ID, "router")
+		_, _, err := client.EventOrchestrationPaths.Get(orch.Primary.ID, "router")
 
 		if err != nil {
 			return fmt.Errorf("Orchestration Path type not found: %v for orchestration %v", "router", orch.Primary.ID)
 		}
-		if found.Type != "router" {
-			return fmt.Errorf("Event Orchrestration path not found: %v - %v", "router", found)
-		}
+
 		return nil
 	}
 }

--- a/pagerduty/resource_pagerduty_event_orchestration_path_service.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_service.go
@@ -175,13 +175,9 @@ func resourcePagerDutyEventOrchestrationPathService() *schema.Resource {
 		},
 		CustomizeDiff: checkExtractions,
 		Schema: map[string]*schema.Schema{
-			"parent": {
-				Type:     schema.TypeList,
+			"service": {
+				Type:     schema.TypeString,
 				Required: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: PagerDutyEventOrchestrationPathParent,
-				},
 			},
 			"sets": {
 				Type:     schema.TypeList,
@@ -320,13 +316,13 @@ func resourcePagerDutyEventOrchestrationPathServiceImport(d *schema.ResourceData
 
 	id := d.Id()
 
-	p, _, pErr := client.EventOrchestrationPaths.Get(id, "service")
+	_, _, pErr := client.EventOrchestrationPaths.Get(id, "service")
 	if pErr != nil {
 		return []*schema.ResourceData{}, pErr
 	}
 
 	d.SetId(id)
-	d.Set("parent", flattenServicePathParent(p.Parent))
+	d.Set("service", id)
 
 	return []*schema.ResourceData{d}, nil
 }
@@ -334,7 +330,7 @@ func resourcePagerDutyEventOrchestrationPathServiceImport(d *schema.ResourceData
 func buildServicePathStruct(d *schema.ResourceData) *pagerduty.EventOrchestrationPath {
 	return &pagerduty.EventOrchestrationPath{
 		Parent: &pagerduty.EventOrchestrationPathReference{
-			ID: d.Get("parent.0.id").(string),
+			ID: d.Get("service").(string),
 		},
 		Sets:     expandServicePathSets(d.Get("sets")),
 		CatchAll: expandServicePathCatchAll(d.Get("catch_all")),
@@ -476,22 +472,12 @@ func expandEventOrchestrationAutomationActionObjects(v interface{}) []*pagerduty
 
 func setEventOrchestrationPathServiceProps(d *schema.ResourceData, p *pagerduty.EventOrchestrationPath) error {
 	d.SetId(p.Parent.ID)
-	d.Set("parent", flattenServicePathParent(p.Parent))
+	d.Set("service", p.Parent.ID)
 	// TODO: see if we can reuse expand functions for all orch path sets.
 	// Maybe pass in the rule actions and catch-all rule actions expanding function?
 	d.Set("sets", flattenServicePathSets(p.Sets))
 	d.Set("catch_all", flattenServicePathCatchAll(p.CatchAll))
 	return nil
-}
-
-func flattenServicePathParent(p *pagerduty.EventOrchestrationPathReference) []interface{} {
-	var parent = map[string]interface{}{
-		"id":   p.ID,
-		"type": p.Type,
-		"self": p.Self,
-	}
-
-	return []interface{}{parent}
 }
 
 func flattenServicePathSets(orchPathSets []*pagerduty.EventOrchestrationPathSet) []interface{} {

--- a/pagerduty/resource_pagerduty_event_orchestration_path_service.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_service.go
@@ -175,10 +175,6 @@ func resourcePagerDutyEventOrchestrationPathService() *schema.Resource {
 		},
 		CustomizeDiff: checkExtractions,
 		Schema: map[string]*schema.Schema{
-			"type": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"parent": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -480,7 +476,6 @@ func expandEventOrchestrationAutomationActionObjects(v interface{}) []*pagerduty
 
 func setEventOrchestrationPathServiceProps(d *schema.ResourceData, p *pagerduty.EventOrchestrationPath) error {
 	d.SetId(p.Parent.ID)
-	d.Set("type", p.Type)
 	d.Set("parent", flattenServicePathParent(p.Parent))
 	// TODO: see if we can reuse expand functions for all orch path sets.
 	// Maybe pass in the rule actions and catch-all rule actions expanding function?

--- a/pagerduty/resource_pagerduty_event_orchestration_path_service_test.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_service_test.go
@@ -32,7 +32,6 @@ func TestAccPagerDutyEventOrchestrationPathService_Basic(t *testing.T) {
 	baseChecks := []resource.TestCheckFunc{
 		testAccCheckPagerDutyEventOrchestrationPathServiceExists(resourceName),
 		testAccCheckPagerDutyEventOrchestrationPathServiceParent(resourceName, serviceResourceName),
-		resource.TestCheckResourceAttr(resourceName, "type", "service"),
 	}
 
 	resource.Test(t, resource.TestCase{

--- a/pagerduty/resource_pagerduty_event_orchestration_path_service_test.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_service_test.go
@@ -3,7 +3,6 @@ package pagerduty
 import (
 	"fmt"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -31,7 +30,7 @@ func TestAccPagerDutyEventOrchestrationPathService_Basic(t *testing.T) {
 	// "State value checking is only recommended for testing Computed attributes and attribute defaults."
 	baseChecks := []resource.TestCheckFunc{
 		testAccCheckPagerDutyEventOrchestrationPathServiceExists(resourceName),
-		testAccCheckPagerDutyEventOrchestrationPathServiceParent(resourceName, serviceResourceName),
+		testAccCheckPagerDutyEventOrchestrationPathServiceServiceID(resourceName, serviceResourceName),
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -222,7 +221,7 @@ func testAccCheckPagerDutyEventOrchestrationServicePathNotExists(rn string) reso
 	}
 }
 
-func testAccCheckPagerDutyEventOrchestrationPathServiceParent(rn, sn string) resource.TestCheckFunc {
+func testAccCheckPagerDutyEventOrchestrationPathServiceServiceID(rn, sn string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		p, _ := s.RootModule().Resources[rn]
 		srv, ok := s.RootModule().Resources[sn]
@@ -231,20 +230,10 @@ func testAccCheckPagerDutyEventOrchestrationPathServiceParent(rn, sn string) res
 			return fmt.Errorf("Service not found: %s", sn)
 		}
 
-		var pId = p.Primary.Attributes["parent.0.id"]
+		var pId = p.Primary.Attributes["service"]
 		var sId = srv.Primary.Attributes["id"]
 		if pId != sId {
-			return fmt.Errorf("Event Orchestration Service path parent ID (%v) not matching provided service ID: %v", pId, sId)
-		}
-
-		var t = p.Primary.Attributes["parent.0.type"]
-		if t != "service_reference" {
-			return fmt.Errorf("Event Orchestration Service path parent type (%v) not matching expected type: 'service_reference'", t)
-		}
-
-		var self = p.Primary.Attributes["parent.0.self"]
-		if !strings.HasSuffix(self, sId) {
-			return fmt.Errorf("Event Orchestration Service path parent self URL (%v) not containing expected service ID", self)
+			return fmt.Errorf("Event Orchestration Service path service ID (%v) not matching provided service ID: %v", pId, sId)
 		}
 
 		return nil
@@ -291,9 +280,7 @@ func createBaseServicePathConfig(ep, s string) string {
 func testAccCheckPagerDutyEventOrchestrationPathServiceDefaultConfig(ep, s string) string {
 	return fmt.Sprintf("%s%s", createBaseServicePathConfig(ep, s),
 		`resource "pagerduty_event_orchestration_service" "serviceA" {
-			parent {
-				id = pagerduty_service.bar.id
-			}
+			service = pagerduty_service.bar.id
 		
 			sets {
 				id = "start"
@@ -309,9 +296,7 @@ func testAccCheckPagerDutyEventOrchestrationPathServiceDefaultConfig(ep, s strin
 func testAccCheckPagerDutyEventOrchestrationPathServiceAutomationActionsConfig(ep, s string) string {
 	return fmt.Sprintf("%s%s", createBaseServicePathConfig(ep, s),
 		`resource "pagerduty_event_orchestration_service" "serviceA" {
-			parent {
-				id = pagerduty_service.bar.id
-			}
+			service = pagerduty_service.bar.id
 		
 			sets {
 				id = "start"
@@ -379,9 +364,7 @@ func testAccCheckPagerDutyEventOrchestrationPathServiceAutomationActionsConfig(e
 func testAccCheckPagerDutyEventOrchestrationPathServiceAutomationActionsParamsUpdateConfig(ep, s string) string {
 	return fmt.Sprintf("%s%s", createBaseServicePathConfig(ep, s),
 		`resource "pagerduty_event_orchestration_service" "serviceA" {
-			parent {
-				id = pagerduty_service.bar.id
-			}
+			service = pagerduty_service.bar.id
 		
 			sets {
 				id = "start"
@@ -430,9 +413,7 @@ func testAccCheckPagerDutyEventOrchestrationPathServiceAutomationActionsParamsUp
 func testAccCheckPagerDutyEventOrchestrationPathServiceAutomationActionsParamsDeleteConfig(ep, s string) string {
 	return fmt.Sprintf("%s%s", createBaseServicePathConfig(ep, s),
 		`resource "pagerduty_event_orchestration_service" "serviceA" {
-			parent {
-				id = pagerduty_service.bar.id
-			}
+			service = pagerduty_service.bar.id
 		
 			sets {
 				id = "start"
@@ -464,9 +445,8 @@ func testAccCheckPagerDutyEventOrchestrationPathServiceInvalidExtractionsConfig(
 		"%s%s",
 		createBaseServicePathConfig(ep, s),
 		fmt.Sprintf(`resource "pagerduty_event_orchestration_service" "serviceA" {
-				parent {
-					id = pagerduty_service.bar.id
-				}			
+				service = pagerduty_service.bar.id
+						
 				sets {
 					id = "start"
 					rules {
@@ -512,9 +492,7 @@ func invalidExtractionRegexNilSourceConfig() string {
 func testAccCheckPagerDutyEventOrchestrationPathServiceAllActionsConfig(ep, s string) string {
 	return fmt.Sprintf("%s%s", createBaseServicePathConfig(ep, s),
 		`resource "pagerduty_event_orchestration_service" "serviceA" {
-			parent {
-				id = pagerduty_service.bar.id
-			}
+			service = pagerduty_service.bar.id
 		
 			sets {
 				id = "start"
@@ -618,9 +596,7 @@ func testAccCheckPagerDutyEventOrchestrationPathServiceAllActionsConfig(ep, s st
 func testAccCheckPagerDutyEventOrchestrationPathServiceAllActionsUpdateConfig(ep, s string) string {
 	return fmt.Sprintf("%s%s", createBaseServicePathConfig(ep, s),
 		`resource "pagerduty_event_orchestration_service" "serviceA" {
-			parent {
-				id = pagerduty_service.bar.id
-			}
+			service = pagerduty_service.bar.id
 		
 			sets {
 				id = "start"
@@ -726,9 +702,7 @@ func testAccCheckPagerDutyEventOrchestrationPathServiceAllActionsUpdateConfig(ep
 func testAccCheckPagerDutyEventOrchestrationPathServiceAllActionsDeleteConfig(ep, s string) string {
 	return fmt.Sprintf("%s%s", createBaseServicePathConfig(ep, s),
 		`resource "pagerduty_event_orchestration_service" "serviceA" {
-			parent {
-				id = pagerduty_service.bar.id
-			}
+			service = pagerduty_service.bar.id
 		
 			sets {
 				id = "start"
@@ -761,9 +735,7 @@ func testAccCheckPagerDutyEventOrchestrationPathServiceAllActionsDeleteConfig(ep
 func testAccCheckPagerDutyEventOrchestrationPathServiceOneSetNoActionsConfig(ep, s string) string {
 	return fmt.Sprintf("%s%s", createBaseServicePathConfig(ep, s),
 		`resource "pagerduty_event_orchestration_service" "serviceA" {
-			parent {
-				id = pagerduty_service.bar.id
-			}
+			service = pagerduty_service.bar.id
 		
 			sets {
 				id = "start"

--- a/pagerduty/resource_pagerduty_event_orchestration_path_unrouted.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_unrouted.go
@@ -20,13 +20,9 @@ func resourcePagerDutyEventOrchestrationPathUnrouted() *schema.Resource {
 			State: resourcePagerDutyEventOrchestrationPathUnroutedImport,
 		},
 		Schema: map[string]*schema.Schema{
-			"parent": {
-				Type:     schema.TypeList,
+			"event_orchestration": {
+				Type:     schema.TypeString,
 				Required: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: PagerDutyEventOrchestrationPathParent,
-				},
 			},
 			"sets": {
 				Type:     schema.TypeList,
@@ -294,6 +290,7 @@ func performUnroutedPathUpdate(d *schema.ResourceData, unroutedPath *pagerduty.E
 			return resource.NonRetryableError(fmt.Errorf("no event orchestration unrouted found"))
 		}
 		d.SetId(unroutedPath.Parent.ID)
+		d.Set("event_orchestration", unroutedPath.Parent.ID)
 		if unroutedPath.Sets != nil {
 			d.Set("sets", flattenUnroutedSets(unroutedPath.Sets))
 		}
@@ -309,22 +306,12 @@ func performUnroutedPathUpdate(d *schema.ResourceData, unroutedPath *pagerduty.E
 	return nil
 }
 
-func buildUnroutedPathParent(d *schema.ResourceData) *pagerduty.EventOrchestrationPath {
-	orchPath := &pagerduty.EventOrchestrationPath{}
-
-	if attr, ok := d.GetOk("parent"); ok {
-		orchPath.Parent = expandOrchestrationPathUnroutedParent(attr)
-	}
-
-	return orchPath
-}
-
 func buildUnroutedPathStructForUpdate(d *schema.ResourceData) *pagerduty.EventOrchestrationPath {
 
-	orchPath := buildUnroutedPathParent(d)
-
-	if attr, ok := d.GetOk("parent"); ok {
-		orchPath.Parent = expandOrchestrationPathUnroutedParent(attr)
+	orchPath := &pagerduty.EventOrchestrationPath{
+		Parent: &pagerduty.EventOrchestrationPathReference{
+			ID: d.Get("event_orchestration").(string),
+		},
 	}
 
 	if attr, ok := d.GetOk("sets"); ok {
@@ -336,16 +323,6 @@ func buildUnroutedPathStructForUpdate(d *schema.ResourceData) *pagerduty.EventOr
 	}
 
 	return orchPath
-}
-
-func expandOrchestrationPathUnroutedParent(v interface{}) *pagerduty.EventOrchestrationPathReference {
-	var parent *pagerduty.EventOrchestrationPathReference
-	p := v.([]interface{})[0].(map[string]interface{})
-	parent = &pagerduty.EventOrchestrationPathReference{
-		ID: p["id"].(string),
-	}
-
-	return parent
 }
 
 func expandUnroutedSets(v interface{}) []*pagerduty.EventOrchestrationPathSet {
@@ -561,6 +538,7 @@ func resourcePagerDutyEventOrchestrationPathUnroutedImport(d *schema.ResourceDat
 	}
 
 	d.SetId(orchestrationID)
+	d.Set("event_orchestration", orchestrationID)
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/pagerduty/resource_pagerduty_event_orchestration_path_unrouted.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_unrouted.go
@@ -20,10 +20,6 @@ func resourcePagerDutyEventOrchestrationPathUnrouted() *schema.Resource {
 			State: resourcePagerDutyEventOrchestrationPathUnroutedImport,
 		},
 		Schema: map[string]*schema.Schema{
-			"type": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"parent": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -251,8 +247,6 @@ func resourcePagerDutyEventOrchestrationPathUnroutedRead(d *schema.ResourceData,
 			time.Sleep(2 * time.Second)
 			return resource.RetryableError(err)
 		} else if unroutedPath != nil {
-			d.Set("type", unroutedPath.Type)
-
 			if unroutedPath.Sets != nil {
 				d.Set("sets", flattenUnroutedSets(unroutedPath.Sets))
 			}
@@ -299,9 +293,7 @@ func performUnroutedPathUpdate(d *schema.ResourceData, unroutedPath *pagerduty.E
 		if updatedPath == nil {
 			return resource.NonRetryableError(fmt.Errorf("no event orchestration unrouted found"))
 		}
-		// set props
 		d.SetId(unroutedPath.Parent.ID)
-		d.Set("type", updatedPath.Type)
 		if unroutedPath.Sets != nil {
 			d.Set("sets", flattenUnroutedSets(unroutedPath.Sets))
 		}

--- a/pagerduty/resource_pagerduty_event_orchestration_path_unrouted_test.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_unrouted_test.go
@@ -32,8 +32,6 @@ func TestAccPagerDutyEventOrchestrationPathUnrouted_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyEventOrchestrationPathUnroutedExists("pagerduty_event_orchestration_unrouted.unrouted"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_event_orchestration_unrouted.unrouted", "type", "unrouted"),
-					resource.TestCheckResourceAttr(
 						"pagerduty_event_orchestration_unrouted.unrouted", "sets.0.rules.#", "0"),
 				),
 			},
@@ -157,8 +155,6 @@ func TestAccPagerDutyEventOrchestrationPathUnrouted_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyEventOrchestrationPathUnroutedExists("pagerduty_event_orchestration_unrouted.unrouted"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_event_orchestration_unrouted.unrouted", "type", "unrouted"),
-					resource.TestCheckResourceAttr(
 						"pagerduty_event_orchestration_unrouted.unrouted", "sets.0.rules.#", "0"),
 				),
 			},
@@ -195,18 +191,15 @@ func testAccCheckPagerDutyEventOrchestrationPathUnroutedExists(rn string) resour
 			return fmt.Errorf("Not found: %s", rn)
 		}
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No Event Orchestration Path Type is set")
+			return fmt.Errorf("No Event Orchestration Unrouted Path is set")
 		}
 
 		orch := s.RootModule().Resources["pagerduty_event_orchestration.orch"]
 		client, _ := testAccProvider.Meta().(*Config).Client()
-		found, _, err := client.EventOrchestrationPaths.Get(orch.Primary.ID, "unrouted")
+		_, _, err := client.EventOrchestrationPaths.Get(orch.Primary.ID, "unrouted")
 
 		if err != nil {
-			return fmt.Errorf("Orchestration Path type not found: %v for orchestration %v", "unrouted", orch.Primary.ID)
-		}
-		if found.Type != "unrouted" {
-			return fmt.Errorf("Event Orchrestration path not found: %v - %v", "unrouted", found)
+			return fmt.Errorf("Event Orchestration Unrouted Path not found: %v for orchestration %v", "unrouted", orch.Primary.ID)
 		}
 
 		return nil

--- a/pagerduty/resource_pagerduty_event_orchestration_path_unrouted_test.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_unrouted_test.go
@@ -266,9 +266,8 @@ func createUnroutedBaseConfig(t, ep, s, o string) string {
 func testAccCheckPagerDutyEventOrchestrationPathUnroutedConfigNoRules(t, ep, s, o string) string {
 	return fmt.Sprintf("%s%s", createUnroutedBaseConfig(t, ep, s, o),
 		`resource "pagerduty_event_orchestration_unrouted" "unrouted" {
-			parent {
-				id = pagerduty_event_orchestration.orch.id
-			}
+			event_orchestration = pagerduty_event_orchestration.orch.id
+
 			sets {
 				id = "start"
 			}
@@ -282,9 +281,8 @@ func testAccCheckPagerDutyEventOrchestrationPathUnroutedConfigNoRules(t, ep, s, 
 func testAccCheckPagerDutyEventOrchestrationPathUnroutedConfigWithConditions(t, ep, s, o string) string {
 	return fmt.Sprintf("%s%s", createUnroutedBaseConfig(t, ep, s, o),
 		`resource "pagerduty_event_orchestration_unrouted" "unrouted" {
-			parent {
-				id = pagerduty_event_orchestration.orch.id
-			}
+			event_orchestration = pagerduty_event_orchestration.orch.id
+
 			sets {
 				id = "start"
 				rules {
@@ -306,9 +304,8 @@ func testAccCheckPagerDutyEventOrchestrationPathUnroutedConfigWithConditions(t, 
 func testAccCheckPagerDutyEventOrchestrationPathUnroutedConfigWithMultipleRules(t, ep, s, o string) string {
 	return fmt.Sprintf("%s%s", createUnroutedBaseConfig(t, ep, s, o),
 		`resource "pagerduty_event_orchestration_unrouted" "unrouted" {
-			parent {
-				id = pagerduty_event_orchestration.orch.id
-			}
+			event_orchestration = pagerduty_event_orchestration.orch.id
+
 			sets {
 				id = "start"
 				rules {
@@ -342,9 +339,8 @@ func testAccCheckPagerDutyEventOrchestrationPathUnroutedConfigWithMultipleRules(
 func testAccCheckPagerDutyEventOrchestrationPathUnroutedWithAllConfig(t, ep, s, o string) string {
 	return fmt.Sprintf("%s%s", createUnroutedBaseConfig(t, ep, s, o),
 		`resource "pagerduty_event_orchestration_unrouted" "unrouted" {
-			parent {
-				id = pagerduty_event_orchestration.orch.id
-			}
+			event_orchestration = pagerduty_event_orchestration.orch.id
+			
 			sets {
 				id = "start"
 				rules {


### PR DESCRIPTION
### Changes

- Flatten the parent attribute, rename it to `event_orchestration` and delete type for unrouted 
- Flatten the parent attribute, rename it to `event_orchestration` and delete type for router
- Flatten the parent attribute, rename it to `service` and delete type for service

### Testing
<img width="969" alt="image" src="https://user-images.githubusercontent.com/47909261/169596073-7cadd87f-690c-444d-81b7-558c2e73b328.png">
