### PR TITLE
[ORCA-3486] - Reuse shared Event Orchestration Path logic, add import tests

### DIFF
--- a/pagerduty/event_orchestration_path_util.go
+++ b/pagerduty/event_orchestration_path_util.go
@@ -29,6 +29,22 @@ var PagerDutyEventOrchestrationPathConditions = map[string]*schema.Schema{
 	},
 }
 
+func validateEventOrchestrationPathSeverity() schema.SchemaValidateFunc {
+	return validateValueFunc([]string{
+		"info",
+		"error",
+		"warning",
+		"critical",
+	})
+}
+
+func validateEventOrchestrationPathEventAction() schema.SchemaValidateFunc {
+	return validateValueFunc([]string{
+		"trigger",
+		"resolve",
+	})
+}
+
 func checkExtractions(context context.Context, diff *schema.ResourceDiff, i interface{}) error {
 	sn := diff.Get("sets.#").(int)
 

--- a/pagerduty/event_orchestration_path_util.go
+++ b/pagerduty/event_orchestration_path_util.go
@@ -7,22 +7,7 @@ import (
 	"github.com/heimweh/go-pagerduty/pagerduty"
 )
 
-var PagerDutyEventOrchestrationPathParent = map[string]*schema.Schema{
-	"id": {
-		Type:     schema.TypeString,
-		Required: true,
-	},
-	"type": {
-		Type:     schema.TypeString,
-		Computed: true,
-	},
-	"self": {
-		Type:     schema.TypeString,
-		Computed: true,
-	},
-}
-
-var PagerDutyEventOrchestrationPathConditions = map[string]*schema.Schema{
+var eventOrchestrationPathConditionsSchema = map[string]*schema.Schema{
 	"expression": {
 		Type:     schema.TypeString,
 		Required: true,
@@ -118,6 +103,35 @@ func checkExtractionAttributes(diff *schema.ResourceDiff, loc string) error {
 		}
 	}
 	return nil
+}
+
+func expandEventOrchestrationPathConditions(v interface{}) []*pagerduty.EventOrchestrationPathRuleCondition {
+	conditions := []*pagerduty.EventOrchestrationPathRuleCondition{}
+
+	for _, cond := range v.([]interface{}) {
+		c := cond.(map[string]interface{})
+
+		cx := &pagerduty.EventOrchestrationPathRuleCondition{
+			Expression: c["expression"].(string),
+		}
+
+		conditions = append(conditions, cx)
+	}
+
+	return conditions
+}
+
+func flattenEventOrchestrationPathConditions(conditions []*pagerduty.EventOrchestrationPathRuleCondition) []interface{} {
+	var flattendConditions []interface{}
+
+	for _, condition := range conditions {
+		flattendCondition := map[string]interface{}{
+			"expression": condition.Expression,
+		}
+		flattendConditions = append(flattendConditions, flattendCondition)
+	}
+
+	return flattendConditions
 }
 
 func expandEventOrchestrationPathVariables(v interface{}) []*pagerduty.EventOrchestrationPathActionVariables {

--- a/pagerduty/event_orchestration_path_util.go
+++ b/pagerduty/event_orchestration_path_util.go
@@ -29,6 +29,44 @@ var PagerDutyEventOrchestrationPathConditions = map[string]*schema.Schema{
 	},
 }
 
+var eventOrchestrationPathVariablesSchema = map[string]*schema.Schema{
+	"name": {
+		Type:     schema.TypeString,
+		Required: true,
+	},
+	"path": {
+		Type:     schema.TypeString,
+		Required: true,
+	},
+	"type": {
+		Type:     schema.TypeString,
+		Required: true,
+	},
+	"value": {
+		Type:     schema.TypeString,
+		Required: true,
+	},
+}
+
+var eventOrchestrationPathExtractionsSchema = map[string]*schema.Schema{
+	"regex": {
+		Type:     schema.TypeString,
+		Optional: true,
+	},
+	"source": {
+		Type:     schema.TypeString,
+		Optional: true,
+	},
+	"target": {
+		Type:     schema.TypeString,
+		Required: true,
+	},
+	"template": {
+		Type:     schema.TypeString,
+		Optional: true,
+	},
+}
+
 func validateEventOrchestrationPathSeverity() schema.SchemaValidateFunc {
 	return validateValueFunc([]string{
 		"info",

--- a/pagerduty/import_pagerduty_event_orchestration_path_router_test.go
+++ b/pagerduty/import_pagerduty_event_orchestration_path_router_test.go
@@ -1,0 +1,38 @@
+package pagerduty
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccPagerDutyEventOrchestrationPathRouter_import(t *testing.T) {
+	team := fmt.Sprintf("tf-name-%s", acctest.RandString(5))
+	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	orchestration := fmt.Sprintf("tf-orchestration-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyEventOrchestrationRouterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyEventOrchestrationRouterConfigWithMultipleRules(team, escalationPolicy, service, orchestration),
+			},
+			{
+				ResourceName:      "pagerduty_event_orchestration_router.router",
+				ImportStateIdFunc: testAccCheckPagerDutyEventOrchestrationPathRouterID,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckPagerDutyEventOrchestrationPathRouterID(s *terraform.State) (string, error) {
+	return s.RootModule().Resources["pagerduty_event_orchestration.orch"].Primary.ID, nil
+}

--- a/pagerduty/import_pagerduty_event_orchestration_path_service_test.go
+++ b/pagerduty/import_pagerduty_event_orchestration_path_service_test.go
@@ -19,7 +19,7 @@ func TestAccPagerDutyEventOrchestrationPathService_import(t *testing.T) {
 		CheckDestroy: testAccCheckPagerDutyEventOrchestrationServicePathDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckPagerDutyEventOrchestrationPathServiceAutomationActionsConfig(escalationPolicy, service),
+				Config: testAccCheckPagerDutyEventOrchestrationPathServiceAllActionsConfig(escalationPolicy, service),
 			},
 			{
 				ResourceName:      "pagerduty_event_orchestration_service.serviceA",

--- a/pagerduty/import_pagerduty_event_orchestration_path_unrouted_test.go
+++ b/pagerduty/import_pagerduty_event_orchestration_path_unrouted_test.go
@@ -1,0 +1,38 @@
+package pagerduty
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccPagerDutyEventOrchestrationPathUnrouted_import(t *testing.T) {
+	team := fmt.Sprintf("tf-name-%s", acctest.RandString(5))
+	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	orchestration := fmt.Sprintf("tf-orchestration-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyEventOrchestrationPathUnroutedDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyEventOrchestrationPathUnroutedWithAllConfig(team, escalationPolicy, service, orchestration),
+			},
+			{
+				ResourceName:      "pagerduty_event_orchestration_unrouted.unrouted",
+				ImportStateIdFunc: testAccCheckPagerDutyEventOrchestrationPathUnroutedID,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckPagerDutyEventOrchestrationPathUnroutedID(s *terraform.State) (string, error) {
+	return s.RootModule().Resources["pagerduty_event_orchestration.orch"].Primary.ID, nil
+}

--- a/pagerduty/resource_pagerduty_event_orchestration_path_router.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_router.go
@@ -51,7 +51,7 @@ func resourcePagerDutyEventOrchestrationPathRouter() *schema.Resource {
 										Type:     schema.TypeList,
 										Optional: true,
 										Elem: &schema.Resource{
-											Schema: PagerDutyEventOrchestrationPathConditions,
+											Schema: eventOrchestrationPathConditionsSchema,
 										},
 									},
 									"actions": {
@@ -235,30 +235,13 @@ func expandRules(v interface{}) []*pagerduty.EventOrchestrationPathRule {
 			ID:         r["id"].(string),
 			Label:      r["label"].(string),
 			Disabled:   r["disabled"].(bool),
-			Conditions: expandRouterConditions(r["conditions"].(interface{})),
-			Actions:    expandRouterActions(r["actions"].([]interface{})),
+			Conditions: expandEventOrchestrationPathConditions(r["conditions"]),
+			Actions:    expandRouterActions(r["actions"]),
 		}
 
 		rules = append(rules, ruleInSet)
 	}
 	return rules
-}
-
-func expandRouterConditions(v interface{}) []*pagerduty.EventOrchestrationPathRuleCondition {
-	items := v.([]interface{})
-	conditions := []*pagerduty.EventOrchestrationPathRuleCondition{}
-
-	for _, cond := range items {
-		c := cond.(map[string]interface{})
-
-		cx := &pagerduty.EventOrchestrationPathRuleCondition{
-			Expression: c["expression"].(string),
-		}
-
-		conditions = append(conditions, cx)
-	}
-
-	return conditions
 }
 
 func expandRouterActions(v interface{}) *pagerduty.EventOrchestrationPathRuleActions {
@@ -302,26 +285,13 @@ func flattenRules(rules []*pagerduty.EventOrchestrationPathRule) []interface{} {
 			"id":         rule.ID,
 			"label":      rule.Label,
 			"disabled":   rule.Disabled,
-			"conditions": flattenRouterConditions(rule.Conditions),
+			"conditions": flattenEventOrchestrationPathConditions(rule.Conditions),
 			"actions":    flattenRouterActions(rule.Actions),
 		}
 		flattenedRules = append(flattenedRules, flattenedRule)
 	}
 
 	return flattenedRules
-}
-
-func flattenRouterConditions(conditions []*pagerduty.EventOrchestrationPathRuleCondition) []interface{} {
-	var flattendConditions []interface{}
-
-	for _, condition := range conditions {
-		flattendCondition := map[string]interface{}{
-			"expression": condition.Expression,
-		}
-		flattendConditions = append(flattendConditions, flattendCondition)
-	}
-
-	return flattendConditions
 }
 
 func flattenRouterActions(actions *pagerduty.EventOrchestrationPathRuleActions) []map[string]interface{} {

--- a/pagerduty/resource_pagerduty_event_orchestration_path_service.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_service.go
@@ -9,7 +9,7 @@ import (
 	"github.com/heimweh/go-pagerduty/pagerduty"
 )
 
-var eventOrchestrationAutomationActionObject = map[string]*schema.Schema{
+var eventOrchestrationAutomationActionObjectSchema = map[string]*schema.Schema{
 	"key": {
 		Type:     schema.TypeString,
 		Required: true,
@@ -20,7 +20,7 @@ var eventOrchestrationAutomationActionObject = map[string]*schema.Schema{
 	},
 }
 
-var eventOrchestrationPathServiceCatchAllActions = map[string]*schema.Schema{
+var eventOrchestrationPathServiceCatchAllActionsSchema = map[string]*schema.Schema{
 	"suppress": {
 		Type:     schema.TypeBool,
 		Optional: true,
@@ -73,14 +73,14 @@ var eventOrchestrationPathServiceCatchAllActions = map[string]*schema.Schema{
 					Type:     schema.TypeList,
 					Optional: true,
 					Elem: &schema.Resource{
-						Schema: eventOrchestrationAutomationActionObject,
+						Schema: eventOrchestrationAutomationActionObjectSchema,
 					},
 				},
 				"parameters": {
 					Type:     schema.TypeList,
 					Optional: true,
 					Elem: &schema.Resource{
-						Schema: eventOrchestrationAutomationActionObject,
+						Schema: eventOrchestrationAutomationActionObjectSchema,
 					},
 				},
 			},
@@ -100,54 +100,22 @@ var eventOrchestrationPathServiceCatchAllActions = map[string]*schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
 		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"name": {
-					Type:     schema.TypeString,
-					Required: true,
-				},
-				"path": {
-					Type:     schema.TypeString,
-					Required: true,
-				},
-				"type": {
-					Type:     schema.TypeString,
-					Required: true,
-				},
-				"value": {
-					Type:     schema.TypeString,
-					Required: true,
-				},
-			}},
+			Schema: eventOrchestrationPathVariablesSchema,
+		},
 	},
 	"extractions": {
 		Type:     schema.TypeList,
 		Optional: true,
 		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"regex": {
-					Type:     schema.TypeString,
-					Optional: true,
-				},
-				"source": {
-					Type:     schema.TypeString,
-					Optional: true,
-				},
-				"target": {
-					Type:     schema.TypeString,
-					Required: true,
-				},
-				"template": {
-					Type:     schema.TypeString,
-					Optional: true,
-				},
-			}},
+			Schema: eventOrchestrationPathExtractionsSchema,
+		},
 	},
 }
 
-var eventOrchestrationPathServiceRuleActions = buildEventOrchestrationPathServiceRuleActions()
+var eventOrchestrationPathServiceRuleActionsSchema = buildEventOrchestrationPathServiceRuleActionsSchema()
 
-func buildEventOrchestrationPathServiceRuleActions() map[string]*schema.Schema {
-	a := eventOrchestrationPathServiceCatchAllActions
+func buildEventOrchestrationPathServiceRuleActionsSchema() map[string]*schema.Schema {
+	a := eventOrchestrationPathServiceCatchAllActionsSchema
 	a["route_to"] = &schema.Schema{
 		Type:     schema.TypeString,
 		Optional: true,
@@ -205,7 +173,7 @@ func resourcePagerDutyEventOrchestrationPathService() *schema.Resource {
 										Required: true,
 										MaxItems: 1,
 										Elem: &schema.Resource{
-											Schema: eventOrchestrationPathServiceRuleActions,
+											Schema: eventOrchestrationPathServiceRuleActionsSchema,
 										},
 									},
 									"disabled": {
@@ -229,7 +197,7 @@ func resourcePagerDutyEventOrchestrationPathService() *schema.Resource {
 							Required: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
-								Schema: eventOrchestrationPathServiceRuleActions,
+								Schema: eventOrchestrationPathServiceRuleActionsSchema,
 							},
 						},
 					},

--- a/pagerduty/resource_pagerduty_event_orchestration_path_service.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_service.go
@@ -87,22 +87,14 @@ var eventOrchestrationPathServiceCatchAllActions = map[string]*schema.Schema{
 		},
 	},
 	"severity": {
-		Type:     schema.TypeString,
-		Optional: true,
-		ValidateFunc: validateValueFunc([]string{
-			"info",
-			"error",
-			"warning",
-			"critical",
-		}),
+		Type:         schema.TypeString,
+		Optional:     true,
+		ValidateFunc: validateEventOrchestrationPathSeverity(),
 	},
 	"event_action": {
-		Type:     schema.TypeString,
-		Optional: true,
-		ValidateFunc: validateValueFunc([]string{
-			"trigger",
-			"resolve",
-		}),
+		Type:         schema.TypeString,
+		Optional:     true,
+		ValidateFunc: validateEventOrchestrationPathEventAction(),
 	},
 	"variables": {
 		Type:     schema.TypeList,

--- a/pagerduty/resource_pagerduty_event_orchestration_path_unrouted.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_unrouted.go
@@ -51,7 +51,7 @@ func resourcePagerDutyEventOrchestrationPathUnrouted() *schema.Resource {
 										Type:     schema.TypeList,
 										Optional: true,
 										Elem: &schema.Resource{
-											Schema: PagerDutyEventOrchestrationPathConditions,
+											Schema: eventOrchestrationPathConditionsSchema,
 										},
 									},
 									"actions": {
@@ -283,8 +283,8 @@ func expandUnroutedRules(v interface{}) []*pagerduty.EventOrchestrationPathRule 
 			ID:         r["id"].(string),
 			Label:      r["label"].(string),
 			Disabled:   r["disabled"].(bool),
-			Conditions: expandUnroutedConditions(r["conditions"]),
-			Actions:    expandUnroutedActions(r["actions"].([]interface{})),
+			Conditions: expandEventOrchestrationPathConditions(r["conditions"]),
+			Actions:    expandUnroutedActions(r["actions"]),
 		}
 
 		rules = append(rules, ruleInSet)
@@ -310,23 +310,6 @@ func expandUnroutedActions(v interface{}) *pagerduty.EventOrchestrationPathRuleA
 	}
 
 	return actions
-}
-
-func expandUnroutedConditions(v interface{}) []*pagerduty.EventOrchestrationPathRuleCondition {
-	items := v.([]interface{})
-	conditions := []*pagerduty.EventOrchestrationPathRuleCondition{}
-
-	for _, cond := range items {
-		c := cond.(map[string]interface{})
-
-		cx := &pagerduty.EventOrchestrationPathRuleCondition{
-			Expression: c["expression"].(string),
-		}
-
-		conditions = append(conditions, cx)
-	}
-
-	return conditions
 }
 
 func expandUnroutedCatchAll(v interface{}) *pagerduty.EventOrchestrationPathCatchAll {
@@ -378,26 +361,13 @@ func flattenUnroutedRules(rules []*pagerduty.EventOrchestrationPathRule) []inter
 			"id":         rule.ID,
 			"label":      rule.Label,
 			"disabled":   rule.Disabled,
-			"conditions": flattenUnroutedConditions(rule.Conditions),
+			"conditions": flattenEventOrchestrationPathConditions(rule.Conditions),
 			"actions":    flattenUnroutedActions(rule.Actions),
 		}
 		flattenedRules = append(flattenedRules, flattenedRule)
 	}
 
 	return flattenedRules
-}
-
-func flattenUnroutedConditions(conditions []*pagerduty.EventOrchestrationPathRuleCondition) []interface{} {
-	var flattendConditions []interface{}
-
-	for _, condition := range conditions {
-		flattendCondition := map[string]interface{}{
-			"expression": condition.Expression,
-		}
-		flattendConditions = append(flattendConditions, flattendCondition)
-	}
-
-	return flattendConditions
 }
 
 func flattenUnroutedActions(actions *pagerduty.EventOrchestrationPathRuleActions) []map[string]interface{} {

--- a/pagerduty/resource_pagerduty_event_orchestration_path_unrouted.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_unrouted.go
@@ -65,22 +65,14 @@ func resourcePagerDutyEventOrchestrationPathUnrouted() *schema.Resource {
 													Optional: true, // If there is only start set we don't need route_to
 												},
 												"severity": {
-													Type:     schema.TypeString,
-													Optional: true,
-													ValidateFunc: validateValueFunc([]string{
-														"info",
-														"error",
-														"warning",
-														"critical",
-													}),
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validateEventOrchestrationPathSeverity(),
 												},
 												"event_action": {
-													Type:     schema.TypeString,
-													Optional: true,
-													ValidateFunc: validateValueFunc([]string{
-														"trigger",
-														"resolve",
-													}),
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validateEventOrchestrationPathEventAction(),
 												},
 												"variables": {
 													Type:     schema.TypeList,

--- a/pagerduty/resource_pagerduty_event_orchestration_path_unrouted.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_unrouted.go
@@ -78,46 +78,15 @@ func resourcePagerDutyEventOrchestrationPathUnrouted() *schema.Resource {
 													Type:     schema.TypeList,
 													Optional: true,
 													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"name": {
-																Type:     schema.TypeString,
-																Required: true,
-															},
-															"path": {
-																Type:     schema.TypeString,
-																Required: true,
-															},
-															"type": {
-																Type:     schema.TypeString,
-																Required: true,
-															},
-															"value": {
-																Type:     schema.TypeString,
-																Required: true,
-															},
-														}}},
+														Schema: eventOrchestrationPathVariablesSchema,
+													},
+												},
 												"extractions": {
 													Type:     schema.TypeList,
 													Optional: true,
 													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"regex": {
-																Type:     schema.TypeString,
-																Optional: true,
-															},
-															"source": {
-																Type:     schema.TypeString,
-																Optional: true,
-															},
-															"target": {
-																Type:     schema.TypeString,
-																Required: true,
-															},
-															"template": {
-																Type:     schema.TypeString,
-																Optional: true,
-															},
-														}},
+														Schema: eventOrchestrationPathExtractionsSchema,
+													},
 												},
 											},
 										},
@@ -170,46 +139,15 @@ func resourcePagerDutyEventOrchestrationPathUnrouted() *schema.Resource {
 										Type:     schema.TypeList,
 										Optional: true,
 										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"name": {
-													Type:     schema.TypeString,
-													Required: true,
-												},
-												"path": {
-													Type:     schema.TypeString,
-													Required: true,
-												},
-												"type": {
-													Type:     schema.TypeString,
-													Required: true,
-												},
-												"value": {
-													Type:     schema.TypeString,
-													Required: true,
-												},
-											}}},
+											Schema: eventOrchestrationPathVariablesSchema,
+										},
+									},
 									"extractions": {
 										Type:     schema.TypeList,
 										Optional: true,
 										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"regex": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"source": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"target": {
-													Type:     schema.TypeString,
-													Required: true,
-												},
-												"template": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-											}},
+											Schema: eventOrchestrationPathExtractionsSchema,
+										},
 									},
 								},
 							},


### PR DESCRIPTION
### Changes

- [x] Reuse condition schema and mapping functions in router/unrouted/service
- [x] Reuse extractions and variables schema in service and unrouted
- [x] Reuse validation functions for severity and event_action in service and unrouted
- [x] Add import tests for router and unrouted

### Testing
<img width="1282" alt="image" src="https://user-images.githubusercontent.com/47909261/169619716-6dacfc16-f7f3-49fb-9ef0-3cebb4bdc874.png">
