### PR TITLE
[ORCA-3486] Extend unrouted tests, add CustomizeDiff, clean shared functions

### DIFF
--- a/pagerduty/event_orchestration_path_util.go
+++ b/pagerduty/event_orchestration_path_util.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/heimweh/go-pagerduty/pagerduty"
 )
@@ -50,6 +51,30 @@ var eventOrchestrationPathExtractionsSchema = map[string]*schema.Schema{
 		Type:     schema.TypeString,
 		Optional: true,
 	},
+}
+
+func invalidExtractionRegexTemplateNilConfig() string {
+	return `
+		extractions {
+			target = "event.summary"
+		}`
+}
+
+func invalidExtractionRegexTemplateValConfig() string {
+	return `
+		extractions {
+			regex = ".*"
+			template = "hi"
+			target = "event.summary"
+		}`
+}
+
+func invalidExtractionRegexNilSourceConfig() string {
+	return `
+		extractions {
+			regex = ".*"
+			target = "event.summary"
+		}`
 }
 
 func validateEventOrchestrationPathSeverity() schema.SchemaValidateFunc {

--- a/pagerduty/resource_pagerduty_event_orchestration_path_service_test.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_service_test.go
@@ -465,30 +465,6 @@ func testAccCheckPagerDutyEventOrchestrationPathServiceInvalidExtractionsConfig(
 	)
 }
 
-func invalidExtractionRegexTemplateNilConfig() string {
-	return `
-		extractions {
-			target = "event.summary"
-		}`
-}
-
-func invalidExtractionRegexTemplateValConfig() string {
-	return `
-		extractions {
-			regex = ".*"
-			template = "hi"
-			target = "event.summary"
-		}`
-}
-
-func invalidExtractionRegexNilSourceConfig() string {
-	return `
-		extractions {
-			regex = ".*"
-			target = "event.summary"
-		}`
-}
-
 func testAccCheckPagerDutyEventOrchestrationPathServiceAllActionsConfig(ep, s string) string {
 	return fmt.Sprintf("%s%s", createBaseServicePathConfig(ep, s),
 		`resource "pagerduty_event_orchestration_service" "serviceA" {

--- a/pagerduty/resource_pagerduty_event_orchestration_path_unrouted.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_unrouted.go
@@ -19,6 +19,7 @@ func resourcePagerDutyEventOrchestrationPathUnrouted() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: resourcePagerDutyEventOrchestrationPathUnroutedImport,
 		},
+		CustomizeDiff: checkExtractions,
 		Schema: map[string]*schema.Schema{
 			"event_orchestration": {
 				Type:     schema.TypeString,

--- a/pagerduty/resource_pagerduty_event_orchestration_path_unrouted_test.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_unrouted_test.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -80,32 +81,45 @@ func TestAccPagerDutyEventOrchestrationPathUnrouted_Basic(t *testing.T) {
 						"pagerduty_event_orchestration_unrouted.unrouted", "sets.0.rules.0.actions.0.event_action", "trigger"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_event_orchestration_unrouted.unrouted", "sets.0.rules.0.actions.0.variables.#", "2"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_event_orchestration_unrouted.unrouted", "sets.0.rules.0.actions.0.variables.0.name", "server_name_cpu"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_event_orchestration_unrouted.unrouted", "sets.0.rules.0.actions.0.variables.0.path", "event.summary"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_event_orchestration_unrouted.unrouted", "sets.0.rules.0.actions.0.variables.0.type", "regex"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_event_orchestration_unrouted.unrouted", "sets.0.rules.0.actions.0.variables.0.value", "High CPU on (.*) server"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_event_orchestration_unrouted.unrouted", "sets.0.rules.0.actions.0.variables.1.name", "server_name_memory"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_event_orchestration_unrouted.unrouted", "sets.0.rules.0.actions.0.variables.1.path", "event.custom_details"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_event_orchestration_unrouted.unrouted", "sets.0.rules.0.actions.0.variables.1.type", "regex"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_event_orchestration_unrouted.unrouted", "sets.0.rules.0.actions.0.variables.1.value", "High memory usage on (.*) server"),
+					resource.TestCheckTypeSetElemNestedAttrs(
+						"pagerduty_event_orchestration_unrouted.unrouted",
+						"sets.0.rules.0.actions.0.variables.*",
+						map[string]string{
+							"name":  "server_name_cpu",
+							"path":  "event.summary",
+							"type":  "regex",
+							"value": "High CPU on (.*) server",
+						},
+					),
+					resource.TestCheckTypeSetElemNestedAttrs(
+						"pagerduty_event_orchestration_unrouted.unrouted",
+						"sets.0.rules.0.actions.0.variables.*",
+						map[string]string{
+							"name":  "server_name_memory",
+							"path":  "event.custom_details",
+							"type":  "regex",
+							"value": "High memory usage on (.*) server",
+						},
+					),
 					resource.TestCheckResourceAttr(
 						"pagerduty_event_orchestration_unrouted.unrouted", "sets.0.rules.0.actions.0.extractions.#", "2"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_event_orchestration_unrouted.unrouted", "sets.0.rules.0.actions.0.extractions.0.target", "event.summary"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_event_orchestration_unrouted.unrouted", "sets.0.rules.0.actions.0.extractions.0.template", "High memory usage on variables.hostname server"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_event_orchestration_unrouted.unrouted", "sets.0.rules.0.actions.0.extractions.1.target", "event.custom_details"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_event_orchestration_unrouted.unrouted", "sets.0.rules.0.actions.0.extractions.1.template", "High memory usage on variables.hostname server"),
+
+					resource.TestCheckTypeSetElemNestedAttrs(
+						"pagerduty_event_orchestration_unrouted.unrouted",
+						"sets.0.rules.0.actions.0.extractions.*",
+						map[string]string{
+							"target":   "event.summary",
+							"template": "High memory usage on {{variables.hostname}} server",
+						},
+					),
+					resource.TestCheckTypeSetElemNestedAttrs(
+						"pagerduty_event_orchestration_unrouted.unrouted",
+						"sets.0.rules.0.actions.0.extractions.*",
+						map[string]string{
+							"target":   "event.custom_details",
+							"template": "High memory usage on {{variables.hostname}} server",
+						},
+					),
 					//Set #2
 					resource.TestCheckResourceAttr(
 						"pagerduty_event_orchestration_unrouted.unrouted", "sets.1.id", "child-1"),
@@ -122,33 +136,90 @@ func TestAccPagerDutyEventOrchestrationPathUnrouted_Basic(t *testing.T) {
 						"pagerduty_event_orchestration_unrouted.unrouted", "catch_all.0.actions.0.event_action", "trigger"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_event_orchestration_unrouted.unrouted", "catch_all.0.actions.0.variables.#", "2"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_event_orchestration_unrouted.unrouted", "catch_all.0.actions.0.variables.0.name", "server_name_cpu"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_event_orchestration_unrouted.unrouted", "catch_all.0.actions.0.variables.0.path", "event.summary"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_event_orchestration_unrouted.unrouted", "catch_all.0.actions.0.variables.0.type", "regex"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_event_orchestration_unrouted.unrouted", "catch_all.0.actions.0.variables.0.value", "High CPU on (.*) server"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_event_orchestration_unrouted.unrouted", "catch_all.0.actions.0.variables.1.name", "server_name_memory"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_event_orchestration_unrouted.unrouted", "catch_all.0.actions.0.variables.1.path", "event.custom_details"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_event_orchestration_unrouted.unrouted", "catch_all.0.actions.0.variables.1.type", "regex"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_event_orchestration_unrouted.unrouted", "catch_all.0.actions.0.variables.1.value", "High memory usage on (.*) server"),
+					resource.TestCheckTypeSetElemNestedAttrs(
+						"pagerduty_event_orchestration_unrouted.unrouted",
+						"catch_all.0.actions.0.variables.*",
+						map[string]string{
+							"name":  "server_name_cpu",
+							"path":  "event.summary",
+							"type":  "regex",
+							"value": "High CPU on (.*) server",
+						},
+					),
+					resource.TestCheckTypeSetElemNestedAttrs(
+						"pagerduty_event_orchestration_unrouted.unrouted",
+						"catch_all.0.actions.0.variables.*",
+						map[string]string{
+							"name":  "server_name_memory",
+							"path":  "event.custom_details",
+							"type":  "regex",
+							"value": "High memory usage on (.*) server",
+						},
+					),
 					resource.TestCheckResourceAttr(
 						"pagerduty_event_orchestration_unrouted.unrouted", "catch_all.0.actions.0.extractions.#", "2"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_event_orchestration_unrouted.unrouted", "catch_all.0.actions.0.extractions.0.target", "event.summary"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_event_orchestration_unrouted.unrouted", "catch_all.0.actions.0.extractions.0.template", "High memory usage on variables.hostname server"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_event_orchestration_unrouted.unrouted", "catch_all.0.actions.0.extractions.1.target", "event.custom_details"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_event_orchestration_unrouted.unrouted", "catch_all.0.actions.0.extractions.1.template", "High memory usage on variables.hostname server"),
+
+					resource.TestCheckTypeSetElemNestedAttrs(
+						"pagerduty_event_orchestration_unrouted.unrouted",
+						"catch_all.0.actions.0.extractions.*",
+						map[string]string{
+							"target":   "event.summary",
+							"template": "High memory usage on {{variables.hostname}} server",
+						},
+					),
+					resource.TestCheckTypeSetElemNestedAttrs(
+						"pagerduty_event_orchestration_unrouted.unrouted",
+						"catch_all.0.actions.0.extractions.*",
+						map[string]string{
+							"target":   "event.custom_details",
+							"template": "High memory usage on {{variables.hostname}} server",
+						},
+					),
 				),
+			},
+			// Providing invalid extractions attributes for set rules
+			{
+				Config: testAccCheckPagerDutyEventOrchestrationPathUnroutedInvalidExtractionsConfig(
+					team, escalationPolicy, service, orchestration, invalidExtractionRegexTemplateValConfig(), "",
+				),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("Invalid configuration in sets.0.rules.0.actions.0.extractions.0: regex and template cannot both have values"),
+			},
+			{
+				Config: testAccCheckPagerDutyEventOrchestrationPathUnroutedInvalidExtractionsConfig(
+					team, escalationPolicy, service, orchestration, invalidExtractionRegexTemplateValConfig(), "",
+				),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("Invalid configuration in sets.0.rules.0.actions.0.extractions.0: regex and template cannot both have values"),
+			},
+			{
+				Config: testAccCheckPagerDutyEventOrchestrationPathUnroutedInvalidExtractionsConfig(
+					team, escalationPolicy, service, orchestration, invalidExtractionRegexNilSourceConfig(), "",
+				),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("Invalid configuration in sets.0.rules.0.actions.0.extractions.0: source can't be blank"),
+			},
+			// Providing invalid extractions attributes for the catch_all rule
+			{
+				Config: testAccCheckPagerDutyEventOrchestrationPathUnroutedInvalidExtractionsConfig(
+					team, escalationPolicy, service, orchestration, "", invalidExtractionRegexTemplateNilConfig(),
+				),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("Invalid configuration in catch_all.0.actions.0.extractions.0: regex and template cannot both be null"),
+			},
+			{
+				Config: testAccCheckPagerDutyEventOrchestrationPathUnroutedInvalidExtractionsConfig(
+					team, escalationPolicy, service, orchestration, "", invalidExtractionRegexTemplateValConfig(),
+				),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("Invalid configuration in catch_all.0.actions.0.extractions.0: regex and template cannot both have values"),
+			},
+			{
+				Config: testAccCheckPagerDutyEventOrchestrationPathUnroutedInvalidExtractionsConfig(
+					team, escalationPolicy, service, orchestration, "", invalidExtractionRegexNilSourceConfig(),
+				),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("Invalid configuration in catch_all.0.actions.0.extractions.0: source can't be blank"),
 			},
 			{
 				Config: testAccCheckPagerDutyEventOrchestrationPathUnroutedConfigNoRules(team, escalationPolicy, service, orchestration),
@@ -368,11 +439,11 @@ func testAccCheckPagerDutyEventOrchestrationPathUnroutedWithAllConfig(t, ep, s, 
 						}
 						extractions {
 							target = "event.summary"
-							template = "High memory usage on variables.hostname server"
+							template = "High memory usage on {{variables.hostname}} server"
 						}
 						extractions {
 							target = "event.custom_details"
-							template = "High memory usage on variables.hostname server"
+							template = "High memory usage on {{variables.hostname}} server"
 						}
 					}
 				}
@@ -396,7 +467,7 @@ func testAccCheckPagerDutyEventOrchestrationPathUnroutedWithAllConfig(t, ep, s, 
 						}
 						extractions {
 							target = "event.summary"
-							template = "High CPU on event.custom_details.hostname server"
+							template = "High CPU on {{event.custom_details.hostname}} server"
 						}
 					}
 				}
@@ -417,7 +488,7 @@ func testAccCheckPagerDutyEventOrchestrationPathUnroutedWithAllConfig(t, ep, s, 
 						}
 						extractions {
 							target = "event.summary"
-							template = "High CPU on event.custom_details.hostname server"
+							template = "High CPU on {{event.custom_details.hostname}} server"
 						}
 					}
 				}
@@ -440,14 +511,39 @@ func testAccCheckPagerDutyEventOrchestrationPathUnroutedWithAllConfig(t, ep, s, 
 					}
 					extractions {
 						target = "event.summary"
-						template = "High memory usage on variables.hostname server"
+						template = "High memory usage on {{variables.hostname}} server"
 					}
 					extractions {
 						target = "event.custom_details"
-						template = "High memory usage on variables.hostname server"
+						template = "High memory usage on {{variables.hostname}} server"
 					}
 				}
 			}
 		}
 	`)
+}
+
+func testAccCheckPagerDutyEventOrchestrationPathUnroutedInvalidExtractionsConfig(t, ep, s, o, re, cae string) string {
+	return fmt.Sprintf(
+		"%s%s",
+		createUnroutedBaseConfig(t, ep, s, o),
+		fmt.Sprintf(`resource "pagerduty_event_orchestration_unrouted" "unrouted" {
+				event_orchestration = pagerduty_event_orchestration.orch.id
+						
+				sets {
+					id = "start"
+					rules {
+						actions {
+							%s
+						}
+					}
+				}
+				catch_all {
+					actions {
+						%s
+					}
+				}
+			}
+		`, re, cae),
+	)
 }


### PR DESCRIPTION
Extended unrouted tests with regex extractions, added CustomizeDiff and moved shared functions for service and unrouted paths to the util file.

```make testacc TESTARGS="-run TestAccPagerDutyEventOrchestrationPath"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccPagerDutyEventOrchestrationPath -timeout 120m
?   	github.com/terraform-providers/terraform-provider-pagerduty	[no test files]
=== RUN   TestAccPagerDutyEventOrchestrationPathRouter_import
--- PASS: TestAccPagerDutyEventOrchestrationPathRouter_import (11.27s)
=== RUN   TestAccPagerDutyEventOrchestrationPathService_import
--- PASS: TestAccPagerDutyEventOrchestrationPathService_import (10.51s)
=== RUN   TestAccPagerDutyEventOrchestrationPathUnrouted_import
--- PASS: TestAccPagerDutyEventOrchestrationPathUnrouted_import (10.08s)
=== RUN   TestAccPagerDutyEventOrchestrationPathRouter_Basic
--- PASS: TestAccPagerDutyEventOrchestrationPathRouter_Basic (32.96s)
=== RUN   TestAccPagerDutyEventOrchestrationPathService_Basic
--- PASS: TestAccPagerDutyEventOrchestrationPathService_Basic (38.30s)
=== RUN   TestAccPagerDutyEventOrchestrationPathUnrouted_Basic
--- PASS: TestAccPagerDutyEventOrchestrationPathUnrouted_Basic (29.20s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	132.825s
```