### PR TITLE
Addressing data_source_pagerduty_user paginated lists not finding users after first page

### DIFF
--- a/pagerduty/data_source_pagerduty_user.go
+++ b/pagerduty/data_source_pagerduty_user.go
@@ -42,7 +42,7 @@ func dataSourcePagerDutyUserRead(d *schema.ResourceData, meta interface{}) error
 	}
 
 	return resource.Retry(5*time.Minute, func() *resource.RetryError {
-		resp, _, err := client.Users.List(o)
+		resp, err := client.Users.ListAll(o)
 		if err != nil {
 			if isErrCode(err, 429) {
 				// Delaying retry by 30s as recommended by PagerDuty
@@ -54,9 +54,9 @@ func dataSourcePagerDutyUserRead(d *schema.ResourceData, meta interface{}) error
 			return resource.NonRetryableError(err)
 		}
 
-		var found *pagerduty.User
+		var found *pagerduty.FullUser
 
-		for _, user := range resp.Users {
+		for _, user := range resp {
 			if user.Email == searchEmail {
 				found = user
 				break


### PR DESCRIPTION
Fixes #442 

From now on when using Data Sources for querying users that are located after the first 25 registries the data_source_pagerduty_user query will return the expected result.

Tests results:

```logs
TF_ACC=1 go test -v -run AccDataSourcePagerDutyUser ./... -timeout 120m
=== RUN   TestAccDataSourcePagerDutyUserContactMethod_Basic
--- PASS: TestAccDataSourcePagerDutyUserContactMethod_Basic (17.43s)
=== RUN   TestAccDataSourcePagerDutyUser_Basic
--- PASS: TestAccDataSourcePagerDutyUser_Basic (14.93s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   32.817s
```