### PR TITLE
Addressing pagerduty_slack_connection unable to set "No Priority" vs "Any Priority" for priorities configuration

### DIFF
--- a/pagerduty/resource_pagerduty_slack_connection_test.go
+++ b/pagerduty/resource_pagerduty_slack_connection_test.go
@@ -103,6 +103,41 @@ func TestAccPagerDutySlackConnection_Envar(t *testing.T) {
 	})
 }
 
+func TestAccPagerDutySlackConnection_NonAndAnyPriorities(t *testing.T) {
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.test", username)
+	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutySlackConnectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutySlackConnectionConfigNonAndAnyPriorities(username, email, escalationPolicy, service, workspaceID, channelID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutySlackConnectionExists("pagerduty_slack_connection.foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_slack_connection.foo", "source_name", service),
+					resource.TestCheckResourceAttr(
+						"pagerduty_slack_connection.foo", "config.0.priorities.#", "0"),
+				),
+			},
+			{
+				Config: testAccCheckPagerDutySlackConnectionConfigNonAndAnyPrioritiesUpdated(username, email, escalationPolicy, service, workspaceID, channelID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutySlackConnectionExists("pagerduty_slack_connection.foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_slack_connection.foo", "config.0.priorities.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_slack_connection.foo", "config.0.priorities.0", "*"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckPagerDutySlackConnectionDestroy(s *terraform.State) error {
 	config := &pagerduty.Config{
 		Token:   os.Getenv("PAGERDUTY_USER_TOKEN"),
@@ -387,4 +422,130 @@ func testAccCheckPagerDutySlackConnectionConfigEnvar(team, channelID string) str
 			}
 		}
 		`, team, channelID)
+}
+
+func testAccCheckPagerDutySlackConnectionConfigNonAndAnyPriorities(username, useremail, escalationPolicy, service, workspaceID, channelID string) string {
+	return fmt.Sprintf(`
+  resource "pagerduty_user" "foo" {
+    name        = "%s"
+    email       = "%s"
+  }
+
+  resource "pagerduty_escalation_policy" "foo" {
+    name        = "%s"
+    description = "foo"
+    num_loops   = 1
+
+    rule {
+      escalation_delay_in_minutes = 10
+
+      target {
+        type = "user_reference"
+        id   = pagerduty_user.foo.id
+      }
+    }
+  }
+
+  resource "pagerduty_service" "foo" {
+    name                    = "%s"
+    description             = "foo"
+    auto_resolve_timeout    = 1800
+    acknowledgement_timeout = 1800
+    escalation_policy       = pagerduty_escalation_policy.foo.id
+
+    incident_urgency_rule {
+      type = "constant"
+      urgency = "high"
+    }
+  }
+  resource "pagerduty_slack_connection" "foo" {
+    source_id = pagerduty_service.foo.id
+    source_type = "service_reference"
+    workspace_id = "%s"
+    channel_id = "%s"
+    notification_type = "responder"
+    config {
+      events = [
+        "incident.triggered",
+        "incident.acknowledged",
+        "incident.escalated",
+        "incident.resolved",
+        "incident.reassigned",
+        "incident.annotated",
+        "incident.unacknowledged",
+        "incident.delegated",
+        "incident.priority_updated",
+        "incident.responder.added",
+        "incident.responder.replied",
+        "incident.status_update_published",
+        "incident.reopened"
+      ]
+      priorities = []
+      urgency = "high"
+    }
+  }
+  `, username, useremail, escalationPolicy, service, workspaceID, channelID)
+}
+
+func testAccCheckPagerDutySlackConnectionConfigNonAndAnyPrioritiesUpdated(username, email, escalationPolicy, service, workspaceID, channelID string) string {
+	return fmt.Sprintf(`
+  resource "pagerduty_user" "foo" {
+    name        = "%s"
+    email       = "%s"
+  }
+
+  resource "pagerduty_escalation_policy" "foo" {
+    name        = "%s"
+    description = "foo"
+    num_loops   = 1
+
+    rule {
+      escalation_delay_in_minutes = 10
+
+      target {
+        type = "user_reference"
+        id   = pagerduty_user.foo.id
+      }
+    }
+  }
+
+  resource "pagerduty_service" "foo" {
+    name                    = "%s"
+    description             = "foo"
+    auto_resolve_timeout    = 1800
+    acknowledgement_timeout = 1800
+    escalation_policy       = pagerduty_escalation_policy.foo.id
+
+    incident_urgency_rule {
+      type = "constant"
+      urgency = "high"
+    }
+  }
+  resource "pagerduty_slack_connection" "foo" {
+    source_id = pagerduty_service.foo.id
+    source_type = "service_reference"
+    workspace_id = "%s"
+    channel_id = "%s"
+    notification_type = "responder"
+    config {
+      events = [
+        "incident.triggered",
+        "incident.acknowledged",
+        "incident.escalated",
+        "incident.resolved",
+        "incident.reassigned",
+        "incident.annotated",
+        "incident.unacknowledged",
+        "incident.delegated",
+        "incident.priority_updated",
+        "incident.responder.added",
+        "incident.responder.replied",
+        "incident.status_update_published",
+        "incident.reopened"
+      ]
+      priorities = ["*"]
+      urgency = "high"
+    }
+  }
+  `, username, email, escalationPolicy, service, workspaceID, channelID)
 }

--- a/website/docs/r/slack_connection.html.markdown
+++ b/website/docs/r/slack_connection.html.markdown
@@ -80,6 +80,8 @@ The following arguments are supported:
     - `incident.status_update_published`
     - `incident.reopened`
   * `priorities` - (Optional) Allows you to filter events by priority. Needs to be an array of PagerDuty priority IDs. Available through [pagerduty_priority](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/data-sources/priority) data source.
+    - When omitted or set to an empty array (`[]`) in the configuration for a Slack Connection, its default behaviour is to set `priorities` to `No Priority` value.
+    - When set to `["*"]` its corresponding value for `priorities` in Slack Connection's configuration will be `Any Priority`.
   * `urgency` - (Optional) Allows you to filter events by urgency. Either `high` or `low`.
 
 ## Attributes Reference


### PR DESCRIPTION
Addressing #456 

After validating the behaviour of PagerDuty's API in regards of configuring the priorities for Slack Connection resource and comparing it with the current capabilities of our TF Provider, I could make sure that there ware no way to configure a `No Priority` priorities setting sticking to the interface of the PagerDuty's API. So it was necessary to add a more explicit way to achieve this configuration. As a result We end up making a little upgrade to the priorities attribute interface:

* `priorities` - (Optional) Allows you to filter events by priority. Needs to be an array of PagerDuty priority IDs. Available through [pagerduty_priority](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/data-sources/priority) data source.
  - When omitted or set to an empty array (`[]`) in the configuration for a Slack Connection, its default behaviour is to set `priorities` to `No Priority` value.
  - When set to `["*"]` its corresponding value for `priorities` in Slack Connection's configuration will be `Any Priority`.

![Screen Shot 2022-06-09 at 00 30 11](https://user-images.githubusercontent.com/24704624/172908009-f9007757-ffa1-4f08-9234-4be7b63a372d.png)

Test results:

