### PR TITLE
Address GOAWAY on three more datasources

### DIFF
--- a/pagerduty/data_source_pagerduty_schedule.go
+++ b/pagerduty/data_source_pagerduty_schedule.go
@@ -40,14 +40,10 @@ func dataSourcePagerDutyScheduleRead(d *schema.ResourceData, meta interface{}) e
 	return resource.Retry(5*time.Minute, func() *resource.RetryError {
 		resp, _, err := client.Schedules.List(o)
 		if err != nil {
-			if isErrCode(err, 429) {
-				// Delaying retry by 30s as recommended by PagerDuty
-				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-				time.Sleep(30 * time.Second)
-				return resource.RetryableError(err)
-			}
-
-			return resource.NonRetryableError(err)
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
+			return resource.RetryableError(err)
 		}
 
 		var found *pagerduty.Schedule

--- a/pagerduty/data_source_pagerduty_user.go
+++ b/pagerduty/data_source_pagerduty_user.go
@@ -44,14 +44,10 @@ func dataSourcePagerDutyUserRead(d *schema.ResourceData, meta interface{}) error
 	return resource.Retry(5*time.Minute, func() *resource.RetryError {
 		resp, err := client.Users.ListAll(o)
 		if err != nil {
-			if isErrCode(err, 429) {
-				// Delaying retry by 30s as recommended by PagerDuty
-				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-				time.Sleep(30 * time.Second)
-				return resource.RetryableError(err)
-			}
-
-			return resource.NonRetryableError(err)
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
+			return resource.RetryableError(err)
 		}
 
 		var found *pagerduty.FullUser

--- a/pagerduty/data_source_pagerduty_vendor.go
+++ b/pagerduty/data_source_pagerduty_vendor.go
@@ -45,14 +45,10 @@ func dataSourcePagerDutyVendorRead(d *schema.ResourceData, meta interface{}) err
 	return resource.Retry(5*time.Minute, func() *resource.RetryError {
 		resp, _, err := client.Vendors.List(o)
 		if err != nil {
-			if isErrCode(err, 429) {
-				// Delaying retry by 30s as recommended by PagerDuty
-				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-				time.Sleep(30 * time.Second)
-				return resource.RetryableError(err)
-			}
-
-			return resource.NonRetryableError(err)
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
+			return resource.RetryableError(err)
 		}
 
 		var found *pagerduty.Vendor


### PR DESCRIPTION
This builds on #507 and removes the check for the 429 error code response and relax the `resource.Retry` to retry on all errors returned by the API for three more data sources that were reported to PagerDuty Support as experiencing the same GOAWAY error as #476 did.  