### PR TITLE
Address: Unable to switch off alert grouping on a service

### DIFF
--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -510,10 +510,16 @@ func flattenService(d *schema.ResourceData, service *pagerduty.Service) error {
 }
 
 func expandAlertGroupingParameters(v interface{}) *pagerduty.AlertGroupingParameters {
-	riur := v.([]interface{})[0].(map[string]interface{})
 	alertGroupingParameters := &pagerduty.AlertGroupingParameters{
 		Config: &pagerduty.AlertGroupingConfig{},
 	}
+	// First We capture a possible nil value for the interface to avoid the a
+	// panic
+	pre := v.([]interface{})[0]
+	if isNilFunc(pre) {
+		return nil
+	}
+	riur := pre.(map[string]interface{})
 	if len(riur["type"].(string)) > 0 {
 		gt := riur["type"].(string)
 		alertGroupingParameters.Type = &gt

--- a/pagerduty/util.go
+++ b/pagerduty/util.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"reflect"
 	"strings"
 	"time"
 
@@ -151,4 +152,17 @@ func intTypeToIntPtr(v int) *int {
 		return nil
 	}
 	return &v
+}
+
+// isNilFunc is a helper which verifies if an empty interface expecting a
+// nullable value indeed has a `nil` type assigned or it's just empty.
+func isNilFunc(i interface{}) bool {
+	if i == nil {
+		return true
+	}
+	switch reflect.TypeOf(i).Kind() {
+	case reflect.Ptr, reflect.Map, reflect.Array, reflect.Chan, reflect.Slice:
+		return reflect.ValueOf(i).IsNil()
+	}
+	return false
 }


### PR DESCRIPTION
Addressing #520 

With this fix the Provider will not crash when trying to switch off alert grouping on a service, and also it will accept an interface more alike with the API and GUI.

Tests result:
![Screen Shot 2022-06-10 at 18 44 36](https://user-images.githubusercontent.com/24704624/173160447-d0048d86-b19a-4e8e-b3a5-2c5941ef3e13.png)

