### PR TITLE
Address: `pagerduty_schedule` output not showing `rendered_coverage_percentage`

### DIFF
--- a/pagerduty/resource_pagerduty_schedule_test.go
+++ b/pagerduty/resource_pagerduty_schedule_test.go
@@ -80,6 +80,10 @@ func TestAccPagerDutySchedule_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "layer.0.start", start),
 					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.0.rendered_coverage_percentage", "0.00"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "final_schedule.0.rendered_coverage_percentage", "0.00"),
+					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "layer.0.rotation_virtual_start", rotationVirtualStart),
 				),
 			},

--- a/pagerduty/util.go
+++ b/pagerduty/util.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"math"
 	"strings"
 	"time"
 
@@ -151,4 +152,11 @@ func intTypeToIntPtr(v int) *int {
 		return nil
 	}
 	return &v
+}
+
+// renderRoundedPercentage is a helper function to render percetanges
+// represented as float64 numbers, by its round with two decimals string
+// representation.
+func renderRoundedPercentage(p float64) string {
+	return fmt.Sprintf("%.2f", math.Round(p*100))
 }


### PR DESCRIPTION
Address #332 

Tests result...
![image](https://user-images.githubusercontent.com/24704624/173687848-70d7a038-d434-474d-8fd3-db2b17432c74.png)
