### PR TITLE
add input validation and drift detection during deletion for `service_dependency`

### DIFF
--- a/pagerduty/resource_pagerduty_service_dependency.go
+++ b/pagerduty/resource_pagerduty_service_dependency.go
@@ -66,7 +66,9 @@ func resourcePagerDutyServiceDependency() *schema.Resource {
 										ForceNew: true,
 										ValidateFunc: validateValueFunc([]string{
 											"business_service",
+											"business_service_reference",
 											"service",
+											"technical_service_reference",
 										}),
 									},
 								},
@@ -196,6 +198,12 @@ func resourcePagerDutyServiceDependencyDisassociate(d *schema.ResourceData, meta
 	if retryErr != nil {
 		time.Sleep(5 * time.Second)
 		return retryErr
+	}
+	// If the dependency is not found, then chances are it had been deleted
+	// outside Terraform or be part of a stale state. So it's needed to be cleared
+	// from the state.
+	if foundDep == nil {
+		return nil
 	}
 
 	// convertType is needed because the PagerDuty API returns the 'reference' values in responses but wants the other

--- a/website/docs/r/service_dependency.html.markdown
+++ b/website/docs/r/service_dependency.html.markdown
@@ -52,7 +52,7 @@ The following arguments are supported:
 Dependency supporting and dependent service supports the following:
 
 * `id` - (Required) The ID of the service dependency.
-* `type` - (Required) Can be `business_service` or `service`.
+* `type` - (Required) Can be `business_service`,  `service`, `business_service_reference` or `technical_service_reference`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Address: #526 

Documentation improvement:

Dependency supporting and dependent service supports the following:

* `id` - (Required) The ID of the service dependency.
* `type` - (Required) Can be `business_service` or `service`.

Tests results...
![Screen Shot 2022-06-16 at 16 57 45](https://user-images.githubusercontent.com/24704624/174162942-60f51449-366b-4f33-b653-1d57241310a1.png)

