### PR TITLE
Remove 429 check on remaining data sources

### DIFF
--- a/pagerduty/data_source_pagerduty_business_service.go
+++ b/pagerduty/data_source_pagerduty_business_service.go
@@ -40,14 +40,10 @@ func dataSourcePagerDutyBusinessServiceRead(d *schema.ResourceData, meta interfa
 	return resource.Retry(5*time.Minute, func() *resource.RetryError {
 		resp, _, err := client.BusinessServices.List()
 		if err != nil {
-			if isErrCode(err, 429) {
-				// Delaying retry by 30s as recommended by PagerDuty
-				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-				time.Sleep(30 * time.Second)
-				return resource.RetryableError(err)
-			}
-
-			return resource.NonRetryableError(err)
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
+			return resource.RetryableError(err)
 		}
 
 		var found *pagerduty.BusinessService

--- a/pagerduty/data_source_pagerduty_extension_schema.go
+++ b/pagerduty/data_source_pagerduty_extension_schema.go
@@ -41,14 +41,10 @@ func dataSourcePagerDutyExtensionSchemaRead(d *schema.ResourceData, meta interfa
 	return resource.Retry(5*time.Minute, func() *resource.RetryError {
 		resp, _, err := client.ExtensionSchemas.List(&pagerduty.ListExtensionSchemasOptions{Query: searchName})
 		if err != nil {
-			if isErrCode(err, 429) {
-				// Delaying retry by 30s as recommended by PagerDuty
-				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-				time.Sleep(30 * time.Second)
-				return resource.RetryableError(err)
-			}
-
-			return resource.NonRetryableError(err)
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
+			return resource.RetryableError(err)
 		}
 
 		var found *pagerduty.ExtensionSchema

--- a/pagerduty/data_source_pagerduty_priority.go
+++ b/pagerduty/data_source_pagerduty_priority.go
@@ -42,14 +42,10 @@ func dataSourcePagerDutyPriorityRead(d *schema.ResourceData, meta interface{}) e
 	return resource.Retry(5*time.Minute, func() *resource.RetryError {
 		resp, _, err := client.Priorities.List()
 		if err != nil {
-			if isErrCode(err, 429) {
-				// Delaying retry by 30s as recommended by PagerDuty
-				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-				time.Sleep(30 * time.Second)
-				return resource.RetryableError(err)
-			}
-
-			return resource.NonRetryableError(err)
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
+			return resource.RetryableError(err)
 		}
 
 		var found *pagerduty.Priority

--- a/pagerduty/data_source_pagerduty_service.go
+++ b/pagerduty/data_source_pagerduty_service.go
@@ -44,14 +44,10 @@ func dataSourcePagerDutyServiceRead(d *schema.ResourceData, meta interface{}) er
 	return resource.Retry(5*time.Minute, func() *resource.RetryError {
 		resp, _, err := client.Services.List(o)
 		if err != nil {
-			if isErrCode(err, 429) {
-				// Delaying retry by 30s as recommended by PagerDuty
-				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-				time.Sleep(30 * time.Second)
-				return resource.RetryableError(err)
-			}
-
-			return resource.NonRetryableError(err)
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
+			return resource.RetryableError(err)
 		}
 
 		var found *pagerduty.Service

--- a/pagerduty/data_source_pagerduty_service_integration.go
+++ b/pagerduty/data_source_pagerduty_service_integration.go
@@ -92,10 +92,6 @@ func dataSourcePagerDutyServiceIntegrationRead(d *schema.ResourceData, meta inte
 }
 
 func handleError(err error) *resource.RetryError {
-	if isErrCode(err, 429) {
-		time.Sleep(30 * time.Second)
-		return resource.RetryableError(err)
-	}
-
-	return resource.NonRetryableError(err)
+	time.Sleep(30 * time.Second)
+	return resource.RetryableError(err)
 }

--- a/pagerduty/data_source_pagerduty_tag.go
+++ b/pagerduty/data_source_pagerduty_tag.go
@@ -41,14 +41,10 @@ func dataSourcePagerDutyTagRead(d *schema.ResourceData, meta interface{}) error 
 	return resource.Retry(5*time.Minute, func() *resource.RetryError {
 		resp, _, err := client.Tags.List(o)
 		if err != nil {
-			if isErrCode(err, 429) {
-				// Delaying retry by 30s as recommended by PagerDuty
-				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-				time.Sleep(30 * time.Second)
-				return resource.RetryableError(err)
-			}
-
-			return resource.NonRetryableError(err)
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
+			return resource.RetryableError(err)
 		}
 
 		var found *pagerduty.Tag

--- a/pagerduty/data_source_pagerduty_team.go
+++ b/pagerduty/data_source_pagerduty_team.go
@@ -49,14 +49,10 @@ func dataSourcePagerDutyTeamRead(d *schema.ResourceData, meta interface{}) error
 	return resource.Retry(5*time.Minute, func() *resource.RetryError {
 		resp, _, err := client.Teams.List(o)
 		if err != nil {
-			if isErrCode(err, 429) {
-				// Delaying retry by 30s as recommended by PagerDuty
-				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-				time.Sleep(30 * time.Second)
-				return resource.RetryableError(err)
-			}
-
-			return resource.NonRetryableError(err)
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
+			return resource.RetryableError(err)
 		}
 
 		var found *pagerduty.Team


### PR DESCRIPTION
Similar to #521, this builds on #507 and removes the check for the 429 error code response and relax the `resource.Retry` to retry on all errors returned by the API for the remaining data sources that have not already been changed, since we're still getting reports similar to #476.