### PR TITLE
remove `expectNonEmptyPlanFromTest` from Service test

### DIFF
--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -554,7 +554,13 @@ func expandAlertGroupingConfig(v interface{}) *pagerduty.AlertGroupingConfig {
 	return alertGroupingConfig
 }
 func flattenAlertGroupingParameters(v *pagerduty.AlertGroupingParameters) interface{} {
-	alertGroupingParameters := map[string]interface{}{"type": "", "config": []map[string]interface{}{{"aggregate": nil, "fields": nil, "timeout": nil}}}
+	alertGroupingParameters := map[string]interface{}{}
+
+	if v.Config == nil && v.Type == nil {
+		return []interface{}{alertGroupingParameters}
+	} else {
+		alertGroupingParameters = map[string]interface{}{"type": "", "config": []map[string]interface{}{{"aggregate": nil, "fields": nil, "timeout": nil}}}
+	}
 
 	if v.Type != nil {
 		alertGroupingParameters["type"] = v.Type

--- a/pagerduty/resource_pagerduty_service_test.go
+++ b/pagerduty/resource_pagerduty_service_test.go
@@ -256,8 +256,8 @@ func TestAccPagerDutyService_AlertContentGrouping(t *testing.T) {
 						"pagerduty_service.foo", "alert_grouping", "rules"),
 					resource.TestCheckNoResourceAttr(
 						"pagerduty_service.foo", "alert_grouping_parameters.0.config"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "alert_grouping_parameters.0.type", ""),
+					resource.TestCheckNoResourceAttr(
+						"pagerduty_service.foo", "alert_grouping_parameters.0.type"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "incident_urgency_rule.#", "1"),
 					resource.TestCheckResourceAttr(
@@ -265,7 +265,6 @@ func TestAccPagerDutyService_AlertContentGrouping(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "incident_urgency_rule.0.type", "constant"),
 				),
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})


### PR DESCRIPTION
This is on response to feedback left PR #527 by @pdecat, I updated the way that We were handling the response from the API and as a result, I was able to remove the `expectNonEmptyPlanFromTest` flag. Which as He pointed out: "It prevents detecting changes in the API response from what is expected.". So thank you for noticing it and for the feedback.