### PR TITLE
Print number and error for failing contact method validation

### DIFF
--- a/pagerduty/resource_pagerduty_user_contact_method.go
+++ b/pagerduty/resource_pagerduty_user_contact_method.go
@@ -2,7 +2,6 @@ package pagerduty
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"strconv"
@@ -28,10 +27,10 @@ func resourcePagerDutyUserContactMethod() *schema.Resource {
 			t := diff.Get("type").(string)
 			if t == "sms_contact_method" || t == "phone_contact_method" {
 				if strings.HasPrefix(a, "0") {
-					return errors.New("phone numbers starting with a 0 are not supported")
+					return fmt.Errorf("phone numbers starting with a 0 are not supported was %q", a)
 				}
 				if _, err := strconv.Atoi(a); err != nil {
-					return errors.New("phone numbers should only contain digits")
+					return fmt.Errorf("phone number %q is not valid as it contains non-digit characters: %w", a, err)
 				}
 			}
 			return nil


### PR DESCRIPTION
The validation is great but sometimes it is helpful to see what the input was and the error that as produced. Print the input and the error when available.