### PR TITLE
feat: add pagerduty_rulesets datasource

### DIFF
--- a/pagerduty/data_source_pagerduty_rulesets.go
+++ b/pagerduty/data_source_pagerduty_rulesets.go
@@ -1,0 +1,101 @@
+package pagerduty
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+func dataSourcePagerDutyRulesets() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourcePagerDutyRulesetsRead,
+
+		Schema: map[string]*schema.Schema{
+			"search": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"rulesets": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"routing_keys": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourcePagerDutyRulesetsRead(d *schema.ResourceData, meta interface{}) error {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] Reading PagerDuty rulesets")
+
+	searchName := d.Get("search").(string)
+
+	return resource.Retry(5*time.Minute, func() *resource.RetryError {
+		resp, _, err := client.Rulesets.List()
+		if err != nil {
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
+			return resource.RetryableError(err)
+		}
+
+		var rulesets []*pagerduty.Ruleset
+		re := regexp.MustCompile(searchName)
+		for _, ruleset := range resp.Rulesets {
+			if re.MatchString(ruleset.Name) {
+				rulesets = append(rulesets, ruleset)
+			}
+		}
+
+		if len(rulesets) == 0 {
+			return resource.NonRetryableError(
+				fmt.Errorf("Unable to locate any ruleset with the name: %s", searchName),
+			)
+		}
+
+		d.SetId(resource.UniqueId())
+		d.Set("search", searchName)
+		d.Set("rulesets", flattenPagerDutyRulesets(rulesets))
+
+		return nil
+	})
+}
+
+func flattenPagerDutyRulesets(rulesets []*pagerduty.Ruleset) []interface{} {
+	var result []interface{}
+
+	for _, i := range rulesets {
+		ruleset := map[string]interface{}{
+			"id":           i.ID,
+			"name":         i.Name,
+			"routing_keys": i.RoutingKeys,
+		}
+		result = append(result, ruleset)
+	}
+	return result
+}

--- a/pagerduty/data_source_pagerduty_rulesets_test.go
+++ b/pagerduty/data_source_pagerduty_rulesets_test.go
@@ -1,0 +1,64 @@
+package pagerduty
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccDataSourcePagerDutyRulesets_Basic(t *testing.T) {
+	ruleset := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourcePagerDutyRulesetsConfig(ruleset),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourcePagerDutyRulesets("pagerduty_ruleset.test", "data.pagerduty_rulesets.by_name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourcePagerDutyRulesets(src, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		srcR := s.RootModule().Resources[src]
+		srcA := srcR.Primary.Attributes
+
+		r := s.RootModule().Resources[n]
+		a := r.Primary.Attributes
+
+		if a["id"] == "" {
+			return fmt.Errorf("Expected to get a ruleset ID from PagerDuty")
+		}
+
+		testAtts := []string{"id", "name"}
+
+		for _, att := range testAtts {
+			sub_att := fmt.Sprintf("rulesets.0.%s", att)
+			if a[sub_att] != srcA[att] {
+				return fmt.Errorf("Expected the ruleset %s to be: %s, but got: %s", att, srcA[att], a[sub_att])
+			}
+		}
+		return nil
+	}
+}
+
+func testAccDataSourcePagerDutyRulesetsConfig(ruleset string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_ruleset" "test" {
+  name                    = "%s"
+}
+
+data "pagerduty_rulesets" "by_name" {
+  search = pagerduty_ruleset.test.name
+}
+`, ruleset)
+}

--- a/pagerduty/provider.go
+++ b/pagerduty/provider.go
@@ -59,6 +59,7 @@ func Provider() *schema.Provider {
 			"pagerduty_business_service":    dataSourcePagerDutyBusinessService(),
 			"pagerduty_priority":            dataSourcePagerDutyPriority(),
 			"pagerduty_ruleset":             dataSourcePagerDutyRuleset(),
+			"pagerduty_rulesets":            dataSourcePagerDutyRulesets(),
 			"pagerduty_tag":                 dataSourcePagerDutyTag(),
 			"pagerduty_event_orchestration": dataSourcePagerDutyEventOrchestration(),
 		},

--- a/website/docs/d/rulesets.html.markdown
+++ b/website/docs/d/rulesets.html.markdown
@@ -1,0 +1,44 @@
+---
+layout: "pagerduty"
+page_title: "PagerDuty: pagerduty_rulesets"
+sidebar_current: "docs-pagerduty-datasource-rulesets"
+description: |-
+  Get information about multiple ruleset that you have created.
+---
+
+# pagerduty\_rulesets
+
+Use this data source to get information about multiple [ruleset][1] that you can use for managing and grouping [event rules][2].
+
+## Example Usage
+
+```hcl
+resource "pagerduty_ruleset" "first" {
+	name = "MyFirstRuleSet"
+}
+
+resource "pagerduty_ruleset" "second" {
+	name = "MySecondRuleSet"
+}
+
+data "pagerduty_rulesets" "example" {
+  search = ".*RuleSet$"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `search` - (Required) The ruleset regex name to find in the PagerDuty API.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `rulesets` - List of rulesets which name match `search` argument.
+	* `id` - The ID of the ruleset.
+	* `name` - Name of the ruleset.
+	* `routing_keys` - Routing keys routed to this ruleset.
+
+[1]: https://developer.pagerduty.com/api-reference/b3A6Mjc0ODE3MQ-list-rulesets


### PR DESCRIPTION
Hello,

I want to add a new datasource **pagerduty_rulesets** which allow to search multiples rulesets with a regex.

Example:
```
data "pagerduty_rulesets" "example" {
  search = ".*RuleSet$"
}
```

I added:
- [x] doc
- [x] tests