### PR TITLE
feat: add pagerduty_event_orchestrations datasource

### DIFF
--- a/pagerduty/data_source_pagerduty_event_orchestrations.go
+++ b/pagerduty/data_source_pagerduty_event_orchestrations.go
@@ -85,7 +85,10 @@ func dataSourcePagerDutyEventOrchestrationsRead(d *schema.ResourceData, meta int
 			return resource.RetryableError(err)
 		}
 
-		re := regexp.MustCompile(searchName)
+		re, err := regexp.Compile(searchName)
+		if err != nil {
+			return resource.NonRetryableError(fmt.Errorf("invalid regexp for name_filter provided %s", searchName))
+		}
 		for _, orchestration := range resp.Orchestrations {
 			if re.MatchString(orchestration.Name) {
 				eoList = append(eoList, orchestration)

--- a/pagerduty/data_source_pagerduty_event_orchestrations.go
+++ b/pagerduty/data_source_pagerduty_event_orchestrations.go
@@ -1,0 +1,127 @@
+package pagerduty
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+func dataSourcePagerDutyEventOrchestrations() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourcePagerDutyEventOrchestrationsRead,
+
+		Schema: map[string]*schema.Schema{
+			"search": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"event_orchestrations": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"integration": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"parameters": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"routing_key": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"type": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourcePagerDutyEventOrchestrationsRead(d *schema.ResourceData, meta interface{}) error {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] Reading PagerDuty Event Orchestrations")
+
+	searchName := d.Get("search").(string)
+
+	return resource.Retry(5*time.Minute, func() *resource.RetryError {
+		resp, _, err := client.EventOrchestrations.List()
+		if err != nil {
+			return resource.RetryableError(err)
+		}
+
+		var orchestrations []*pagerduty.EventOrchestration
+		re := regexp.MustCompile(searchName)
+		for _, orchestration := range resp.Orchestrations {
+			if re.MatchString(orchestration.Name) {
+				// Get orchestration matched by ID so we can set the integrations property
+				// since the list endpoint does not return it
+				orch, _, err := client.EventOrchestrations.Get(orchestration.ID)
+				if err != nil {
+					return resource.RetryableError(err)
+				}
+				orchestrations = append(orchestrations, orch)
+			}
+		}
+
+		if len(orchestrations) == 0 {
+			return resource.NonRetryableError(
+				fmt.Errorf("Unable to locate any Event Orchestration with the name: %s", searchName),
+			)
+		}
+
+		d.SetId(resource.UniqueId())
+		d.Set("search", searchName)
+		d.Set("event_orchestrations", flattenPagerDutyEventOrchestrations(orchestrations))
+
+		return nil
+	})
+}
+
+func flattenPagerDutyEventOrchestrations(orchestrations []*pagerduty.EventOrchestration) []interface{} {
+	var result []interface{}
+
+	for _, o := range orchestrations {
+		orchestration := map[string]interface{}{
+			"id":          o.ID,
+			"name":        o.Name,
+			"integration": flattenEventOrchestrationIntegrations(o.Integrations),
+		}
+		result = append(result, orchestration)
+	}
+	return result
+}

--- a/pagerduty/data_source_pagerduty_event_orchestrations.go
+++ b/pagerduty/data_source_pagerduty_event_orchestrations.go
@@ -16,7 +16,7 @@ func dataSourcePagerDutyEventOrchestrations() *schema.Resource {
 		Read: dataSourcePagerDutyEventOrchestrationsRead,
 
 		Schema: map[string]*schema.Schema{
-			"search": {
+			"name_filter": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
@@ -76,7 +76,7 @@ func dataSourcePagerDutyEventOrchestrationsRead(d *schema.ResourceData, meta int
 
 	log.Printf("[INFO] Reading PagerDuty Event Orchestrations")
 
-	searchName := d.Get("search").(string)
+	nameFilter := d.Get("name_filter").(string)
 
 	var eoList []*pagerduty.EventOrchestration
 	retryErr := resource.Retry(30*time.Second, func() *resource.RetryError {
@@ -85,9 +85,9 @@ func dataSourcePagerDutyEventOrchestrationsRead(d *schema.ResourceData, meta int
 			return resource.RetryableError(err)
 		}
 
-		re, err := regexp.Compile(searchName)
+		re, err := regexp.Compile(nameFilter)
 		if err != nil {
-			return resource.NonRetryableError(fmt.Errorf("invalid regexp for name_filter provided %s", searchName))
+			return resource.NonRetryableError(fmt.Errorf("invalid regexp for name_filter provided %s", nameFilter))
 		}
 		for _, orchestration := range resp.Orchestrations {
 			if re.MatchString(orchestration.Name) {
@@ -95,7 +95,7 @@ func dataSourcePagerDutyEventOrchestrationsRead(d *schema.ResourceData, meta int
 			}
 		}
 		if len(eoList) == 0 {
-			return resource.NonRetryableError(fmt.Errorf("Unable to locate any Event Orchestration matching the expression: %s", searchName))
+			return resource.NonRetryableError(fmt.Errorf("Unable to locate any Event Orchestration matching the expression: %s", nameFilter))
 		}
 
 		return nil
@@ -124,7 +124,7 @@ func dataSourcePagerDutyEventOrchestrationsRead(d *schema.ResourceData, meta int
 	}
 
 	d.SetId(resource.UniqueId())
-	d.Set("search", searchName)
+	d.Set("name_filter", nameFilter)
 	d.Set("event_orchestrations", flattenPagerDutyEventOrchestrations(orchestrations))
 
 	return nil

--- a/pagerduty/data_source_pagerduty_event_orchestrations_test.go
+++ b/pagerduty/data_source_pagerduty_event_orchestrations_test.go
@@ -40,6 +40,10 @@ func TestAccDataSourcePagerDutyEventOrchestrations_Basic(t *testing.T) {
 				Config:      testAccDataSourcePagerDutyEventOrchestrationsNotFoundConfig(name),
 				ExpectError: regexp.MustCompile("Unable to locate any Event Orchestration matching the expression"),
 			},
+			{
+				Config:      testAccDataSourcePagerDutyEventOrchestrationsInvalidRegexConfig(),
+				ExpectError: regexp.MustCompile("invalid regexp for name_filter provided"),
+			},
 		},
 	})
 }
@@ -117,4 +121,12 @@ data "pagerduty_event_orchestrations" "not_found" {
   search = %q
 }
 `, name)
+}
+
+func testAccDataSourcePagerDutyEventOrchestrationsInvalidRegexConfig() string {
+	return fmt.Sprintf(`
+data "pagerduty_event_orchestrations" "invalid_regex" {
+  search = ")"
+}
+`)
 }

--- a/pagerduty/data_source_pagerduty_event_orchestrations_test.go
+++ b/pagerduty/data_source_pagerduty_event_orchestrations_test.go
@@ -81,7 +81,7 @@ resource "pagerduty_event_orchestration" "test" {
 }
 
 data "pagerduty_event_orchestrations" "by_name" {
-  search = pagerduty_event_orchestration.test.name
+  name_filter = pagerduty_event_orchestration.test.name
 }
 `, name)
 }
@@ -110,7 +110,7 @@ data "pagerduty_event_orchestrations" "by_name" {
     pagerduty_event_orchestration.test3,
   ]
 
-  search = "^%[1]s*"
+  name_filter = "^%[1]s*"
 }
 `, matchingName, notMatchingName)
 }
@@ -118,7 +118,7 @@ data "pagerduty_event_orchestrations" "by_name" {
 func testAccDataSourcePagerDutyEventOrchestrationsNotFoundConfig(name string) string {
 	return fmt.Sprintf(`
 data "pagerduty_event_orchestrations" "not_found" {
-  search = %q
+  name_filter = %q
 }
 `, name)
 }
@@ -126,7 +126,7 @@ data "pagerduty_event_orchestrations" "not_found" {
 func testAccDataSourcePagerDutyEventOrchestrationsInvalidRegexConfig() string {
 	return fmt.Sprintf(`
 data "pagerduty_event_orchestrations" "invalid_regex" {
-  search = ")"
+  name_filter = ")"
 }
 `)
 }

--- a/pagerduty/data_source_pagerduty_event_orchestrations_test.go
+++ b/pagerduty/data_source_pagerduty_event_orchestrations_test.go
@@ -1,0 +1,65 @@
+package pagerduty
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccDataSourcePagerDutyEventOrchestrations_Basic(t *testing.T) {
+	name := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourcePagerDutyEventOrchestrationsConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourcePagerDutyEventOrchestrations("pagerduty_event_orchestration.test", "data.pagerduty_event_orchestrations.by_name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourcePagerDutyEventOrchestrations(src, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		srcR := s.RootModule().Resources[src]
+		srcA := srcR.Primary.Attributes
+
+		r := s.RootModule().Resources[n]
+		a := r.Primary.Attributes
+
+		if a["id"] == "" {
+			return fmt.Errorf("Expected to get an Event Orchestration ID from PagerDuty")
+		}
+
+		testAtts := []string{"id", "name", "integration"}
+
+		for _, att := range testAtts {
+			sub_att := fmt.Sprintf("event_orchestrations.0.%s", att)
+			if a[sub_att] != srcA[att] {
+				return fmt.Errorf("Expected the Event Orchestration %s to be: %s, but got: %s", att, srcA[att], a[sub_att])
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccDataSourcePagerDutyEventOrchestrationsConfig(name string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_event_orchestration" "test" {
+  name                    = "%s"
+}
+
+data "pagerduty_event_orchestrations" "by_name" {
+  search = pagerduty_event_orchestration.test.name
+}
+`, name)
+}

--- a/pagerduty/provider.go
+++ b/pagerduty/provider.go
@@ -61,6 +61,7 @@ func Provider() *schema.Provider {
 			"pagerduty_ruleset":                   dataSourcePagerDutyRuleset(),
 			"pagerduty_tag":                       dataSourcePagerDutyTag(),
 			"pagerduty_event_orchestration":       dataSourcePagerDutyEventOrchestration(),
+			"pagerduty_event_orchestrations":      dataSourcePagerDutyEventOrchestrations(),
 			"pagerduty_automation_actions_runner": dataSourcePagerDutyAutomationActionsRunner(),
 			"pagerduty_automation_actions_action": dataSourcePagerDutyAutomationActionsAction(),
 			"pagerduty_incident_workflow":         dataSourcePagerDutyIncidentWorkflow(),

--- a/website/docs/d/event_orchestrations.html.markdown
+++ b/website/docs/d/event_orchestrations.html.markdown
@@ -1,0 +1,47 @@
+---
+layout: "pagerduty"
+page_title: "PagerDuty: pagerduty_event_orchestrations"
+sidebar_current: "docs-pagerduty-datasource-event-orchestrations"
+description: |-
+  Get information about Global Event Orchestrations that you have created.
+---
+
+# pagerduty\_event_orchestrations
+
+Use this data source to get informations about specific Global [Event Orchestrations][1]
+
+## Example Usage
+```hcl
+resource "pagerduty_event_orchestration" "tf_orch_a" {
+  name = "Test Event A Orchestration"
+}
+
+resource "pagerduty_event_orchestration" "tf_orch_b" {
+  name = "Test Event B Orchestration"
+}
+
+data "pagerduty_event_orchestrations" "tf_my_monitor" {
+  search = ".*Orchestration$"
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `search` - (Required) The regex name of Global Event orchestrations to find in the PagerDuty API.
+
+## Attributes Reference
+
+* `event_orchestrations` - The list of the Event Orchestrations which name match `search` argument.
+  * `id` - The ID of the found Event Orchestration.
+  * `name` - The name of the found Event Orchestration.
+  * `integration` - An integration for the Event Orchestration.
+    * `id` - ID of the integration
+    * `parameters`
+      * `routing_key` - Routing key that routes to this Orchestration.
+      * `type` - Type of the routing key. `global` is the default type.
+
+
+[1]: https://developer.pagerduty.com/api-reference/7ba0fe7bdb26a-list-event-orchestrations

--- a/website/docs/d/event_orchestrations.html.markdown
+++ b/website/docs/d/event_orchestrations.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # pagerduty\_event_orchestrations
 
-Use this data source to get informations about specific Global [Event Orchestrations][1]
+Use this data source to get information as a list about specific Global [Event Orchestrations][1] filtered by a Regular Expression provided.
 
 ## Example Usage
 ```hcl

--- a/website/docs/d/event_orchestrations.html.markdown
+++ b/website/docs/d/event_orchestrations.html.markdown
@@ -21,7 +21,7 @@ resource "pagerduty_event_orchestration" "tf_orch_b" {
 }
 
 data "pagerduty_event_orchestrations" "tf_my_monitor" {
-  search = ".*Orchestration$"
+  name_filter = ".*Orchestration$"
 }
 
 ```
@@ -30,11 +30,11 @@ data "pagerduty_event_orchestrations" "tf_my_monitor" {
 
 The following arguments are supported:
 
-* `search` - (Required) The regex name of Global Event orchestrations to find in the PagerDuty API.
+* `name_filter` - (Required) The regex name of Global Event orchestrations to find in the PagerDuty API.
 
 ## Attributes Reference
 
-* `event_orchestrations` - The list of the Event Orchestrations which name match `search` argument.
+* `name_filter` - The list of the Event Orchestrations which name match `name_filter` argument.
   * `id` - The ID of the found Event Orchestration.
   * `name` - The name of the found Event Orchestration.
   * `integration` - An integration for the Event Orchestration.


### PR DESCRIPTION
Hello,

I want to add a new datasource pagerduty_event_orchestrations which allow to search multiples event_orchestration with a regex.

Example:
```
data "pagerduty_event_orchestrations" "example" {
  search = ".*Orchestration$"
}
```
I added:

- [x] doc
- [x] tests