### PR TITLE
Test and handle time-based alert grouping parameters

### DIFF
--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -574,13 +574,8 @@ func expandAlertGroupingParameters(v interface{}) *pagerduty.AlertGroupingParame
 
 	// For Intelligent grouping type, config is null
 	alertGroupingParameters.Config = nil
-	if groupingType == "time" {
-		timeConfig := riur["config"].(map[string]interface{})
-		to := timeConfig["timeout"].(int)
-		alertGroupingParameters.Config.Timeout = &to
-	}
-	if groupingType == "content_based" {
-		alertGroupingParameters.Config = expandAlertGroupingContentBasedConfig(riur["config"])
+	if groupingType == "content_based" || groupingType == "time" {
+		alertGroupingParameters.Config = expandAlertGroupingContentBasedConfig(riur["config"], groupingType)
 	}
 	return alertGroupingParameters
 }
@@ -597,7 +592,7 @@ func expandAutoPauseNotificationsParameters(v interface{}) *pagerduty.AutoPauseN
 	return autoPauseNotificationsParameters
 }
 
-func expandAlertGroupingContentBasedConfig(v interface{}) *pagerduty.AlertGroupingConfig {
+func expandAlertGroupingContentBasedConfig(v interface{}, groupingType string) *pagerduty.AlertGroupingConfig {
 	alertGroupingConfig := &pagerduty.AlertGroupingConfig{}
 	if len(v.([]interface{})) == 0 || v.([]interface{})[0] == nil {
 		return nil
@@ -613,6 +608,10 @@ func expandAlertGroupingContentBasedConfig(v interface{}) *pagerduty.AlertGroupi
 	if val, ok := riur["aggregate"]; ok {
 		agg := val.(string)
 		alertGroupingConfig.Aggregate = &agg
+	}
+	if val, ok := riur["timeout"]; ok && groupingType == "time" {
+		to := val.(int)
+		alertGroupingConfig.Timeout = &to
 	}
 	return alertGroupingConfig
 }

--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -575,7 +575,7 @@ func expandAlertGroupingParameters(v interface{}) *pagerduty.AlertGroupingParame
 	// For Intelligent grouping type, config is null
 	alertGroupingParameters.Config = nil
 	if groupingType == "content_based" || groupingType == "time" {
-		alertGroupingParameters.Config = expandAlertGroupingContentBasedConfig(riur["config"], groupingType)
+		alertGroupingParameters.Config = expandAlertGroupingConfig(riur["config"], groupingType)
 	}
 	return alertGroupingParameters
 }
@@ -592,7 +592,7 @@ func expandAutoPauseNotificationsParameters(v interface{}) *pagerduty.AutoPauseN
 	return autoPauseNotificationsParameters
 }
 
-func expandAlertGroupingContentBasedConfig(v interface{}, groupingType string) *pagerduty.AlertGroupingConfig {
+func expandAlertGroupingConfig(v interface{}, groupingType string) *pagerduty.AlertGroupingConfig {
 	alertGroupingConfig := &pagerduty.AlertGroupingConfig{}
 	if len(v.([]interface{})) == 0 || v.([]interface{})[0] == nil {
 		return nil

--- a/pagerduty/resource_pagerduty_service_test.go
+++ b/pagerduty/resource_pagerduty_service_test.go
@@ -283,7 +283,35 @@ func TestAccPagerDutyService_AlertContentGrouping(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "alert_grouping_parameters.0.type", "time"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "alert_grouping_parameters.0.config.0.timeout.0", "5"),
+						"pagerduty_service.foo", "alert_grouping_parameters.0.config.0.timeout", "5"),
+					resource.TestCheckNoResourceAttr(
+						"pagerduty_service.foo", "alert_grouping_parameters.0.config.0"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.0.urgency", "high"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.0.type", "constant"),
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyServiceConfigWithAlertTimeGroupingTimeoutZeroUpdated(username, email, escalationPolicy, service),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyServiceExists("pagerduty_service.foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "name", service),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "description", "foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "auto_resolve_timeout", "1800"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "acknowledgement_timeout", "1800"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "alert_creation", "create_alerts_and_incidents"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "alert_grouping_parameters.0.type", "time"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "alert_grouping_parameters.0.config.0.timeout", "0"),
 					resource.TestCheckNoResourceAttr(
 						"pagerduty_service.foo", "alert_grouping_parameters.0.config.0"),
 					resource.TestCheckResourceAttr(
@@ -1084,43 +1112,6 @@ resource "pagerduty_service" "foo" {
 `, username, email, escalationPolicy, service)
 }
 
-func testAccCheckPagerDutyServiceConfigWithAlertGroupingUpdated(username, email, escalationPolicy, service string) string {
-	return fmt.Sprintf(`
-resource "pagerduty_user" "foo" {
-	name        = "%s"
-	email       = "%s"
-	color       = "green"
-	role        = "user"
-	job_title   = "foo"
-	description = "foo"
-}
-
-resource "pagerduty_escalation_policy" "foo" {
-	name        = "%s"
-	description = "bar"
-	num_loops   = 2
-	rule {
-		escalation_delay_in_minutes = 10
-		target {
-			type = "user_reference"
-			id   = pagerduty_user.foo.id
-		}
-	}
-}
-
-resource "pagerduty_service" "foo" {
-	name                    = "%s"
-	description             = "foo"
-	auto_resolve_timeout    = 1800
-	acknowledgement_timeout = 1800
-	escalation_policy       = pagerduty_escalation_policy.foo.id
-	alert_creation          = "create_alerts_and_incidents"
-	alert_grouping          = "intelligent"
-	alert_grouping_timeout  = 1900
-}
-`, username, email, escalationPolicy, service)
-}
-
 func testAccCheckPagerDutyServiceConfigWithAlertTimeGroupingUpdated(username, email, escalationPolicy, service string) string {
 	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
@@ -1158,6 +1149,84 @@ resource "pagerduty_service" "foo" {
           timeout = 5
         }
     }
+}
+`, username, email, escalationPolicy, service)
+}
+
+func testAccCheckPagerDutyServiceConfigWithAlertTimeGroupingTimeoutZeroUpdated(username, email, escalationPolicy, service string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "foo" {
+	name        = "%s"
+	email       = "%s"
+	color       = "green"
+	role        = "user"
+	job_title   = "foo"
+	description = "foo"
+}
+
+resource "pagerduty_escalation_policy" "foo" {
+	name        = "%s"
+	description = "bar"
+	num_loops   = 2
+	rule {
+		escalation_delay_in_minutes = 10
+		target {
+			type = "user_reference"
+			id   = pagerduty_user.foo.id
+		}
+	}
+}
+
+resource "pagerduty_service" "foo" {
+	name                    = "%s"
+	description             = "foo"
+	auto_resolve_timeout    = 1800
+	acknowledgement_timeout = 1800
+	escalation_policy       = pagerduty_escalation_policy.foo.id
+	alert_creation          = "create_alerts_and_incidents"
+	alert_grouping_parameters {
+        type = "time"
+        config {
+          timeout = 0
+        }
+    }
+}
+`, username, email, escalationPolicy, service)
+}
+
+func testAccCheckPagerDutyServiceConfigWithAlertGroupingUpdated(username, email, escalationPolicy, service string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "foo" {
+	name        = "%s"
+	email       = "%s"
+	color       = "green"
+	role        = "user"
+	job_title   = "foo"
+	description = "foo"
+}
+
+resource "pagerduty_escalation_policy" "foo" {
+	name        = "%s"
+	description = "bar"
+	num_loops   = 2
+	rule {
+		escalation_delay_in_minutes = 10
+		target {
+			type = "user_reference"
+			id   = pagerduty_user.foo.id
+		}
+	}
+}
+
+resource "pagerduty_service" "foo" {
+	name                    = "%s"
+	description             = "foo"
+	auto_resolve_timeout    = 1800
+	acknowledgement_timeout = 1800
+	escalation_policy       = pagerduty_escalation_policy.foo.id
+	alert_creation          = "create_alerts_and_incidents"
+	alert_grouping          = "intelligent"
+	alert_grouping_timeout  = 1900
 }
 `, username, email, escalationPolicy, service)
 }


### PR DESCRIPTION
Setting time in the alert grouping parameters crashes the provider after #570 . This should be tested and fixed.
Marking as draft the API request does not appear to set the timeout as expected. (PD support investigating)