### PR TITLE
Address: Unique contact method error not being captured

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,3 +16,5 @@ require (
 	google.golang.org/genproto v0.0.0-20201109203340-2640f1f9cdfb // indirect
 	google.golang.org/grpc v1.33.2 // indirect
 )
+
+replace github.com/heimweh/go-pagerduty => github.com/imjaroiswebdev/go-pagerduty v0.0.0-20221205131155-2c89c4e1bcba

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	cloud.google.com/go v0.71.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.1
-	github.com/heimweh/go-pagerduty v0.0.0-20220907210255-0dcec1fd4239
+	github.com/heimweh/go-pagerduty v0.0.0-20221206203812-2a3d8ee100c5
 	github.com/klauspost/compress v1.15.9 // indirect
 	github.com/montanaflynn/stats v0.6.6 // indirect
 	go.mongodb.org/mongo-driver v1.10.2 // indirect
@@ -16,5 +16,3 @@ require (
 	google.golang.org/genproto v0.0.0-20201109203340-2640f1f9cdfb // indirect
 	google.golang.org/grpc v1.33.2 // indirect
 )
-
-replace github.com/heimweh/go-pagerduty => github.com/imjaroiswebdev/go-pagerduty v0.0.0-20221205131155-2c89c4e1bcba

--- a/go.sum
+++ b/go.sum
@@ -224,14 +224,14 @@ github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/heimweh/go-pagerduty v0.0.0-20220907210255-0dcec1fd4239 h1:v6xLbQD42SuG7U3o65s6bi243E+W53pbtYVi8loALVs=
-github.com/heimweh/go-pagerduty v0.0.0-20220907210255-0dcec1fd4239/go.mod h1:t9vftsO1IjYHGdgJXeemZtomCWnxi2SRgu0PRcRb2oY=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
+github.com/imjaroiswebdev/go-pagerduty v0.0.0-20221205131155-2c89c4e1bcba h1:9Rh+JncJ6yVM+SsUqRvq5vm4q21P7dLRTajtyF6p1nk=
+github.com/imjaroiswebdev/go-pagerduty v0.0.0-20221205131155-2c89c4e1bcba/go.mod h1:t9vftsO1IjYHGdgJXeemZtomCWnxi2SRgu0PRcRb2oY=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=

--- a/go.sum
+++ b/go.sum
@@ -224,14 +224,14 @@ github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
+github.com/heimweh/go-pagerduty v0.0.0-20221206203812-2a3d8ee100c5 h1:4+gtjALebwTtqnmywtYyb5mtNWMmrCAibHi1rhMBuWk=
+github.com/heimweh/go-pagerduty v0.0.0-20221206203812-2a3d8ee100c5/go.mod h1:t9vftsO1IjYHGdgJXeemZtomCWnxi2SRgu0PRcRb2oY=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
-github.com/imjaroiswebdev/go-pagerduty v0.0.0-20221205131155-2c89c4e1bcba h1:9Rh+JncJ6yVM+SsUqRvq5vm4q21P7dLRTajtyF6p1nk=
-github.com/imjaroiswebdev/go-pagerduty v0.0.0-20221205131155-2c89c4e1bcba/go.mod h1:t9vftsO1IjYHGdgJXeemZtomCWnxi2SRgu0PRcRb2oY=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -122,7 +122,7 @@ github.com/hashicorp/terraform-registry-address
 github.com/hashicorp/terraform-svchost
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20220907210255-0dcec1fd4239 => github.com/imjaroiswebdev/go-pagerduty v0.0.0-20221205131155-2c89c4e1bcba
+# github.com/heimweh/go-pagerduty v0.0.0-20221206203812-2a3d8ee100c5
 ## explicit
 github.com/heimweh/go-pagerduty/pagerduty
 # github.com/klauspost/compress v1.15.9
@@ -349,4 +349,3 @@ google.golang.org/protobuf/types/known/anypb
 google.golang.org/protobuf/types/known/durationpb
 google.golang.org/protobuf/types/known/emptypb
 google.golang.org/protobuf/types/known/timestamppb
-# github.com/heimweh/go-pagerduty => github.com/imjaroiswebdev/go-pagerduty v0.0.0-20221205131155-2c89c4e1bcba

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -122,7 +122,7 @@ github.com/hashicorp/terraform-registry-address
 github.com/hashicorp/terraform-svchost
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20220907210255-0dcec1fd4239
+# github.com/heimweh/go-pagerduty v0.0.0-20220907210255-0dcec1fd4239 => github.com/imjaroiswebdev/go-pagerduty v0.0.0-20221205131155-2c89c4e1bcba
 ## explicit
 github.com/heimweh/go-pagerduty/pagerduty
 # github.com/klauspost/compress v1.15.9
@@ -349,3 +349,4 @@ google.golang.org/protobuf/types/known/anypb
 google.golang.org/protobuf/types/known/durationpb
 google.golang.org/protobuf/types/known/emptypb
 google.golang.org/protobuf/types/known/timestamppb
+# github.com/heimweh/go-pagerduty => github.com/imjaroiswebdev/go-pagerduty v0.0.0-20221205131155-2c89c4e1bcba

--- a/website/docs/r/user_contact_method.html.markdown
+++ b/website/docs/r/user_contact_method.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # pagerduty_user_contact_method
 
--> Since contact methods are frequently added through PagerDuty's web console or mobile app during a user's onboarding process, whenever you try to create contact method resource with the same configuration of an already existent contact method of your PagerDuty configuration; this particular resource resource will leverage the resource creation work to import those  configurations to your Terraform state.
+-> NOTE: This resource behaves a little differently than may be expected. If the defined contact method already exists for the user in PagerDuty this resource will import the values of the existing contact method into your Terraform state. 
 
 A [contact method](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODI0MA-create-a-user-contact-method) is a contact method for a PagerDuty user (email, phone or SMS).
 

--- a/website/docs/r/user_contact_method.html.markdown
+++ b/website/docs/r/user_contact_method.html.markdown
@@ -8,6 +8,8 @@ description: |-
 
 # pagerduty_user_contact_method
 
+-> Since contact methods are frequently added through PagerDuty's web console or mobile app during a user's onboarding process, whenever you try to create contact method resource with the same configuration of an already existent contact method of your PagerDuty configuration; this particular resource resource will leverage the resource creation work to import those  configurations to your Terraform state.
+
 A [contact method](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODI0MA-create-a-user-contact-method) is a contact method for a PagerDuty user (email, phone or SMS).
 
 

--- a/website/docs/r/user_contact_method.html.markdown
+++ b/website/docs/r/user_contact_method.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # pagerduty_user_contact_method
 
-> *NOTE: This resource behaves a little differently than may be expected. If the defined contact method already exists for the user in PagerDuty this resource will import the values of the existing contact method into your Terraform state.*
+-> This resource behaves a little differently than may be expected. If the defined contact method already exists for the user in PagerDuty this resource will import the values of the existing contact method into your Terraform state.
 
 A [contact method](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODI0MA-create-a-user-contact-method) is a contact method for a PagerDuty user (email, phone or SMS).
 

--- a/website/docs/r/user_contact_method.html.markdown
+++ b/website/docs/r/user_contact_method.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # pagerduty_user_contact_method
 
--> NOTE: This resource behaves a little differently than may be expected. If the defined contact method already exists for the user in PagerDuty this resource will import the values of the existing contact method into your Terraform state. 
+> *NOTE: This resource behaves a little differently than may be expected. If the defined contact method already exists for the user in PagerDuty this resource will import the values of the existing contact method into your Terraform state.*
 
 A [contact method](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODI0MA-create-a-user-contact-method) is a contact method for a PagerDuty user (email, phone or SMS).
 


### PR DESCRIPTION
Address: #583 

Additionally an update to the documentation of the `pagerduty_user_contact_method` resource has been introduced to clarify the particular way in which this resource behaves...
![Screenshot 2022-12-05 at 10 59 03](https://user-images.githubusercontent.com/24704624/205655680-faab5d07-1d8a-4fc5-96ac-13a04db9fbd8.png)

Test results...

![Screenshot 2022-12-01 at 00 14 11](https://user-images.githubusercontent.com/24704624/205654319-d35c985b-525a-45a5-b4bf-fc602849d2e9.png)
