### PR TITLE
fix slack_connection doc

### DIFF
--- a/website/docs/r/slack_connection.html.markdown
+++ b/website/docs/r/slack_connection.html.markdown
@@ -94,7 +94,7 @@ The following attributes are exported:
 
 ## Import
 
-Slack connections can be imported using the related `slack_team(workspace)` ID and the `slack_connection` ID separated by a dot, e.g.
+Slack connections can be imported using the related `workspace` ID and the `slack_connection` ID separated by a dot, e.g.
 
 ```
 $ terraform import pagerduty_slack_connection.main T02A123LV1A.PUABCDL

--- a/website/docs/r/slack_connection.html.markdown
+++ b/website/docs/r/slack_connection.html.markdown
@@ -59,7 +59,7 @@ The following arguments are supported:
 
   * `source_id` - (Required) The ID of the source in PagerDuty. Valid sources are services or teams.
   * `source_type` - (Required) The type of the source. Either `team_reference` or `service_reference`.
-  * `workspace_id` - (Required) The ID of the connected Slack workspace. Can also be defined by the `SLACK_CONNECTION_WORKSPACE_ID` environment variable.
+  * `workspace_id` - (Required) The slack team (workspace) ID of the connected Slack workspace. Can also be defined by the `SLACK_CONNECTION_WORKSPACE_ID` environment variable.
   * `channel_id` - (Required) The ID of a Slack channel in the workspace.
   * `config` - (Required) Configuration options for the Slack connection that provide options to filter events.
   * `notification_type` - (Required) Type of notification. Either `responder` or `stakeholder`.
@@ -94,7 +94,7 @@ The following attributes are exported:
 
 ## Import
 
-Slack connections can be imported using the related `workspace` ID and the `slack_connection` ID separated by a dot, e.g.
+Slack connections can be imported using the related `slack_team(workspace)` ID and the `slack_connection` ID separated by a dot, e.g.
 
 ```
 $ terraform import pagerduty_slack_connection.main T02A123LV1A.PUABCDL


### PR DESCRIPTION
Match the notation in the API documentation as `slack_team_id`


https://developer.pagerduty.com/api-reference/fb85c0f6c87f7-create-a-slack-connection
<img width="848" alt="image" src="https://user-images.githubusercontent.com/48937821/201041426-21c75661-bf80-4c81-a2d1-c1579942ed44.png">
