### PR TITLE
docs(orchestration_unrouted): remove duplicate line

### DIFF
--- a/website/docs/r/event_orchestration_unrouted.html.markdown
+++ b/website/docs/r/event_orchestration_unrouted.html.markdown
@@ -79,7 +79,6 @@ The following arguments are supported:
   * `template` - (Optional) A string that will be used to populate the `target` field. You can reference variables or event data within your template using double curly braces. For example:
     * Use variables named `ip` and `subnet` with a template like: `{{variables.ip}}/{{variables.subnet}}`
     * Combine the event severity & summary with template like: `{{event.severity}}:{{event.summary}}`
-  * `target` - (Required) The PagerDuty Common Event Format [PD-CEF](https://support.pagerduty.com/docs/pd-cef) field that will be set with the value from the `template` or based on `regex` and `source` fields.
   * `regex` - (Optional) A [RE2 regular expression](https://github.com/google/re2/wiki/Syntax) that will be matched against field specified via the `source` argument. If the regex contains one or more capture groups, their values will be extracted and appended together. If it contains no capture groups, the whole match is used. This field can be ignored for `template` based extractions.
   * `source` - (Optional) The path to the event field where the `regex` will be applied to extract a value. You can use any valid [PCL path](https://developer.pagerduty.com/docs/ZG9jOjM1NTE0MDc0-pcl-overview#paths) like `event.summary` and you can reference previously-defined variables using a path like `variables.hostname`. This field can be ignored for `template` based extractions.
 


### PR DESCRIPTION
Removing a duplicate line in the page: event_orchestration_unrouted 

see: https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/event_orchestration_unrouted#extraction 