### PR TITLE
implementation of incident workflow and triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,3 +124,16 @@ Run a specific subset of tests by name use the `TESTARGS="-run TestName"` option
 ```sh
 $ make testacc TESTARGS="-run TestAccPagerDutyTeam"
 ```
+
+Some tests require additional environment variables to be set to enable them due to account restrictions on certain
+features. Similarly to [`TF_ACC`](https://developer.hashicorp.com/terraform/plugin/sdkv2/testing/acceptance-tests#environment-variables),
+the value of the environment variable is not relevant.
+
+For example:
+```sh
+PAGERDUTY_ACC_INCIDENT_WORKFLOWS=1 make testacc TESTARGS="-run PagerDutyIncidentWorkflow"
+```
+
+| Variable Name                      | Feature Set        |
+|------------------------------------|--------------------|
+| `PAGERDUTY_ACC_INCIDENT_WORKFLOWS` | Incident Workflows |

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,9 @@ go 1.16
 
 require (
 	cloud.google.com/go v0.71.0 // indirect
+	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.1
-	github.com/heimweh/go-pagerduty v0.0.0-20221219143240-8b7c456b23c6
+	github.com/heimweh/go-pagerduty v0.0.0-20221222221341-c1c27ca3744a
 	github.com/klauspost/compress v1.15.9 // indirect
 	github.com/montanaflynn/stats v0.6.6 // indirect
 	go.mongodb.org/mongo-driver v1.10.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -224,8 +224,8 @@ github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/heimweh/go-pagerduty v0.0.0-20221219143240-8b7c456b23c6 h1:aK7yqQASNtcxrTy4L3Gidh0EUBoDLjDVWTcZ7bzcXJY=
-github.com/heimweh/go-pagerduty v0.0.0-20221219143240-8b7c456b23c6/go.mod h1:t9vftsO1IjYHGdgJXeemZtomCWnxi2SRgu0PRcRb2oY=
+github.com/heimweh/go-pagerduty v0.0.0-20221222221341-c1c27ca3744a h1:U2RXTaVK7ZwWKnmaF/any3PQnBfuuZxYGQ57DP8Fvjc=
+github.com/heimweh/go-pagerduty v0.0.0-20221222221341-c1c27ca3744a/go.mod h1:t9vftsO1IjYHGdgJXeemZtomCWnxi2SRgu0PRcRb2oY=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/pagerduty/data_source_pagerduty_incident_workflow.go
+++ b/pagerduty/data_source_pagerduty_incident_workflow.go
@@ -1,0 +1,79 @@
+package pagerduty
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+func dataSourcePagerDutyIncidentWorkflow() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourcePagerDutyIncidentWorkflowRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourcePagerDutyIncidentWorkflowRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO] Reading PagerDuty incident workflow")
+
+	searchName := d.Get("name").(string)
+
+	err = resource.RetryContext(ctx, 5*time.Minute, func() *resource.RetryError {
+		resp, _, err := client.IncidentWorkflows.ListContext(ctx, &pagerduty.ListIncidentWorkflowOptions{})
+		if err != nil {
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
+			return resource.RetryableError(err)
+		}
+
+		var found *pagerduty.IncidentWorkflow
+
+		for _, iw := range resp.IncidentWorkflows {
+			if iw.Name == searchName {
+				found = iw
+				break
+			}
+		}
+
+		if found == nil {
+			return resource.NonRetryableError(
+				fmt.Errorf("unable to locate any incident workflow with name: %s", searchName),
+			)
+		}
+
+		err = flattenIncidentWorkflow(d, found, false, nil)
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+
+}

--- a/pagerduty/data_source_pagerduty_incident_workflow_test.go
+++ b/pagerduty/data_source_pagerduty_incident_workflow_test.go
@@ -1,0 +1,78 @@
+package pagerduty
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourcePagerDutyIncidentWorkflow(t *testing.T) {
+	name := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	dataSourceName := fmt.Sprintf("data.pagerduty_incident_workflow.%s", name)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckIncidentWorkflows(t)
+		},
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourcePagerDutyIncidentWorkflowConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "id"),
+					resource.TestCheckResourceAttr(dataSourceName, "name", name),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourcePagerDutyIncidentWorkflowConfig(name string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_incident_workflow" "input" {
+  name = "%[1]s"
+}
+
+data "pagerduty_incident_workflow" "%[1]s" {
+  depends_on = [
+    pagerduty_incident_workflow.input
+  ]
+  name = "%[1]s"
+}
+`, name)
+}
+
+func TestAccDataSourcePagerDutyIncidentWorkflow_Missing(t *testing.T) {
+	name := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckIncidentWorkflows(t)
+		},
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataSourcePagerDutyIncidentWorkflowConfigBad(name),
+				ExpectError: regexp.MustCompile(fmt.Sprintf("unable to locate any incident workflow with name: %s-incorrect", name)),
+			},
+		},
+	})
+}
+
+func testAccDataSourcePagerDutyIncidentWorkflowConfigBad(name string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_incident_workflow" "input" {
+  name = "%[1]s"
+}
+
+data "pagerduty_incident_workflow" "%[1]s" {
+  name = "%[1]s-incorrect"
+}
+`, name)
+
+}

--- a/pagerduty/import_pagerduty_incident_workflow_test.go
+++ b/pagerduty/import_pagerduty_incident_workflow_test.go
@@ -1,0 +1,42 @@
+package pagerduty
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccPagerDutyIncidentWorkflow_import(t *testing.T) {
+	workflowName := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckIncidentWorkflows(t)
+		},
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckPagerDutyIncidentWorkflowDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyIncidentWorkflowConfigNoSteps(workflowName),
+			},
+
+			{
+				ResourceName:      "pagerduty_incident_workflow.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckPagerDutyIncidentWorkflowConfigNoSteps(name string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_incident_workflow" "test" {
+  name = "%s"
+  description = "some description"
+}
+`, name)
+}

--- a/pagerduty/import_pagerduty_incident_workflow_trigger_test.go
+++ b/pagerduty/import_pagerduty_incident_workflow_trigger_test.go
@@ -1,0 +1,37 @@
+package pagerduty
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccPagerDutyIncidentWorkflowTrigger_import(t *testing.T) {
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.test", username)
+	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	workflow := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckIncidentWorkflows(t)
+		},
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckPagerDutyIncidentWorkflowDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyIncidentWorkflowTriggerConfigManualSingleService(username, email, escalationPolicy, service, workflow),
+			},
+
+			{
+				ResourceName:      "pagerduty_incident_workflow_trigger.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/pagerduty/provider.go
+++ b/pagerduty/provider.go
@@ -62,6 +62,7 @@ func Provider() *schema.Provider {
 			"pagerduty_tag":                       dataSourcePagerDutyTag(),
 			"pagerduty_event_orchestration":       dataSourcePagerDutyEventOrchestration(),
 			"pagerduty_automation_actions_runner": dataSourcePagerDutyAutomationActionsRunner(),
+			"pagerduty_incident_workflow":         dataSourcePagerDutyIncidentWorkflow(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -97,6 +98,8 @@ func Provider() *schema.Provider {
 			"pagerduty_automation_actions_runner":                  resourcePagerDutyAutomationActionsRunner(),
 			"pagerduty_automation_actions_action":                  resourcePagerDutyAutomationActionsAction(),
 			"pagerduty_automation_actions_action_team_association": resourcePagerDutyAutomationActionsActionTeamAssociation(),
+			"pagerduty_incident_workflow":                          resourcePagerDutyIncidentWorkflow(),
+			"pagerduty_incident_workflow_trigger":                  resourcePagerDutyIncidentWorkflowTrigger(),
 		},
 	}
 

--- a/pagerduty/provider_test.go
+++ b/pagerduty/provider_test.go
@@ -13,11 +13,17 @@ import (
 
 var testAccProviders map[string]*schema.Provider
 var testAccProvider *schema.Provider
+var testAccProviderFactories map[string]func() (*schema.Provider, error)
 
 func init() {
 	testAccProvider = Provider()
 	testAccProviders = map[string]*schema.Provider{
 		"pagerduty": testAccProvider,
+	}
+	testAccProviderFactories = map[string]func() (*schema.Provider, error){
+		"pagerduty": func() (*schema.Provider, error) {
+			return testAccProvider, nil
+		},
 	}
 }
 

--- a/pagerduty/resource_pagerduty_incident_workflow.go
+++ b/pagerduty/resource_pagerduty_incident_workflow.go
@@ -1,0 +1,419 @@
+package pagerduty
+
+import (
+	"context"
+	"log"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+func resourcePagerDutyIncidentWorkflow() *schema.Resource {
+	return &schema.Resource{
+		ReadContext:   resourcePagerDutyIncidentWorkflowRead,
+		UpdateContext: resourcePagerDutyIncidentWorkflowUpdate,
+		DeleteContext: resourcePagerDutyIncidentWorkflowDelete,
+		CreateContext: resourcePagerDutyIncidentWorkflowCreate,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		CustomizeDiff: customizeIncidentWorkflowDiff(),
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "Managed by Terraform",
+			},
+			"step": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"action": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"input": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"generated": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// It is allowed for an incident workflow to return more inputs for a step than are present in the
+// Terraform configuration. This can happen when there are inputs which have a default value.
+// These inputs get persisted in the state with `generated` set to `true`
+// but then should not be removed by a `terraform apply`
+func customizeIncidentWorkflowDiff() schema.CustomizeDiffFunc {
+	inputCountRegex := regexp.MustCompile(`^(step\.(\d+)\.input)\.#$`)
+
+	nameDoesNotExistAlready := func(inputs []interface{}, name string) bool {
+		for _, v := range inputs {
+			m := v.(map[string]interface{})
+			if n, ok := m["name"]; ok && n == name {
+				return false
+			}
+		}
+		return true
+	}
+
+	addMissingGeneratedInputs := func(withGenerated []interface{}, maybeWithoutGenerated []interface{}) (interface{}, []string) {
+		result := maybeWithoutGenerated
+		addedNames := make([]string, 0)
+
+		for _, v := range withGenerated {
+			m := v.(map[string]interface{})
+			if b, ok := m["generated"]; ok && b.(bool) && nameDoesNotExistAlready(maybeWithoutGenerated, m["name"].(string)) {
+				result = append(result, m)
+				addedNames = append(addedNames, m["name"].(string))
+			}
+		}
+
+		return result, addedNames
+	}
+
+	updateStepInput := func(step interface{}, index int64, input interface{}) {
+		step.([]interface{})[index].(map[string]interface{})["input"] = input
+	}
+
+	return func(ctx context.Context, d *schema.ResourceDiff, _ interface{}) error {
+		id := d.Id()
+		if id != "" {
+			keys := d.GetChangedKeysPrefix("step")
+
+			_, newStep := d.GetChange("step")
+			needToSetNew := false
+
+			for _, key := range keys {
+				indexMatch := inputCountRegex.FindStringSubmatch(key)
+				if len(indexMatch) == 3 {
+					inputKey := indexMatch[1]
+					inputsFromState, inputsAfterDiff := d.GetChange(inputKey)
+
+					replacementInput, addedNames := addMissingGeneratedInputs(inputsFromState.([]interface{}), inputsAfterDiff.([]interface{}))
+					stepIndex, _ := strconv.ParseInt(indexMatch[2], 10, 32)
+					updateStepInput(newStep, stepIndex, replacementInput)
+					log.Printf("[INFO] Updating diff for step %d to include generated inputs %v.", stepIndex, addedNames)
+					needToSetNew = true
+				}
+			}
+
+			if needToSetNew {
+				err := d.SetNew("step", newStep)
+				if err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+
+	}
+}
+
+func resourcePagerDutyIncidentWorkflowCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	iw, err := buildIncidentWorkflowStruct(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO] Creating PagerDuty incident workflow %s.", iw.Name)
+
+	createdWorkflow, _, err := client.IncidentWorkflows.CreateContext(ctx, iw)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	stepIdMapping := map[int]string{}
+	for i, s := range createdWorkflow.Steps {
+		stepIdMapping[i] = s.ID
+	}
+
+	nonGeneratedInputNames := createNonGeneratedInputNamesFromWorkflowStepsWithoutIDs(iw, stepIdMapping)
+	err = flattenIncidentWorkflow(d, createdWorkflow, true, nonGeneratedInputNames)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func resourcePagerDutyIncidentWorkflowRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[INFO] Reading PagerDuty incident workflow %s", d.Id())
+	err := fetchIncidentWorkflow(ctx, d, meta, handleNotFoundError)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func resourcePagerDutyIncidentWorkflowUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	nonGeneratedInputNames := createNonGeneratedInputNamesFromWorkflowStepsInResourceData(d)
+
+	iw, err := buildIncidentWorkflowStruct(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO] Updating PagerDuty incident workflow %s", d.Id())
+
+	updatedWorkflow, _, err := client.IncidentWorkflows.UpdateContext(ctx, d.Id(), iw)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = flattenIncidentWorkflow(d, updatedWorkflow, true, nonGeneratedInputNames)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func resourcePagerDutyIncidentWorkflowDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	_, err = client.IncidentWorkflows.DeleteContext(ctx, d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func fetchIncidentWorkflow(ctx context.Context, d *schema.ResourceData, meta interface{}, errorCallback func(error, *schema.ResourceData) error) error {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
+
+	nonGeneratedInputNames := createNonGeneratedInputNamesFromWorkflowStepsInResourceData(d)
+
+	return resource.RetryContext(ctx, 2*time.Minute, func() *resource.RetryError {
+		iw, _, err := client.IncidentWorkflows.GetContext(ctx, d.Id())
+		if err != nil {
+			log.Printf("[WARN] Incident workflow read error")
+			errResp := errorCallback(err, d)
+			if errResp != nil {
+				time.Sleep(2 * time.Second)
+				return resource.RetryableError(errResp)
+			}
+
+			return nil
+		}
+
+		if err := flattenIncidentWorkflow(d, iw, true, nonGeneratedInputNames); err != nil {
+			return resource.NonRetryableError(err)
+		}
+		return nil
+
+	})
+}
+
+func createNonGeneratedInputNamesFromWorkflowStepsInResourceData(d *schema.ResourceData) map[string][]string {
+	nonGeneratedInputNames := map[string][]string{}
+
+	if _, ok := d.GetOk("name"); ok {
+		if s, ok := d.GetOk("step"); ok {
+			steps := s.([]interface{})
+
+			for _, v := range steps {
+				stepData := v.(map[string]interface{})
+				if id, idOk := stepData["id"]; idOk {
+					nonGeneratedInputNamesForStep := make([]string, 0)
+					if sdis, inputOk := stepData["input"]; inputOk {
+						for _, sdi := range sdis.([]interface{}) {
+							inputData := sdi.(map[string]interface{})
+							if b, ok := inputData["generated"]; !ok || !b.(bool) {
+								nonGeneratedInputNamesForStep = append(nonGeneratedInputNamesForStep, inputData["name"].(string))
+							}
+						}
+					}
+					nonGeneratedInputNames[id.(string)] = nonGeneratedInputNamesForStep
+				}
+			}
+		}
+	}
+	return nonGeneratedInputNames
+}
+
+func createNonGeneratedInputNamesFromWorkflowStepsWithoutIDs(iw *pagerduty.IncidentWorkflow, stepIdMapping map[int]string) map[string][]string {
+	nonGeneratedInputNames := map[string][]string{}
+
+	if iw != nil {
+		for i, step := range iw.Steps {
+			nonGeneratedInputNamesForStep := make([]string, 0)
+			if step.Configuration != nil {
+				for _, input := range step.Configuration.Inputs {
+					nonGeneratedInputNamesForStep = append(nonGeneratedInputNamesForStep, input.Name)
+				}
+			}
+			nonGeneratedInputNames[stepIdMapping[i]] = nonGeneratedInputNamesForStep
+		}
+	}
+	return nonGeneratedInputNames
+}
+
+func flattenIncidentWorkflow(d *schema.ResourceData, iw *pagerduty.IncidentWorkflow, includeSteps bool, nonGeneratedInputNames map[string][]string) error {
+	d.SetId(iw.ID)
+	d.Set("name", iw.Name)
+	if iw.Description != nil {
+		d.Set("description", *(iw.Description))
+	}
+
+	if includeSteps {
+		steps := flattenIncidentWorkflowSteps(iw, nonGeneratedInputNames)
+		d.Set("step", steps)
+	}
+
+	return nil
+}
+
+func flattenIncidentWorkflowSteps(iw *pagerduty.IncidentWorkflow, nonGeneratedInputNames map[string][]string) []map[string]interface{} {
+	newSteps := make([]map[string]interface{}, len(iw.Steps))
+	for i, s := range iw.Steps {
+		nonGeneratedInputNamesForStep, ok := nonGeneratedInputNames[s.ID]
+		if !ok {
+			nonGeneratedInputNamesForStep = make([]string, 0)
+		}
+
+		m := make(map[string]interface{})
+		m["id"] = s.ID
+		m["name"] = s.Name
+		m["action"] = s.Configuration.ActionID
+		m["input"] = flattenIncidentWorkflowStepInput(s.Configuration.Inputs, nonGeneratedInputNamesForStep)
+
+		newSteps[i] = m
+	}
+	return newSteps
+}
+
+func flattenIncidentWorkflowStepInput(inputs []*pagerduty.IncidentWorkflowActionInput, nonGeneratedInputNames []string) *[]interface{} {
+	newInputs := make([]interface{}, len(inputs))
+
+	for i, v := range inputs {
+		m := make(map[string]interface{})
+		m["name"] = v.Name
+		m["value"] = v.Value
+
+		if !isInputInNonGeneratedInputNames(v, nonGeneratedInputNames) {
+			m["generated"] = true
+		}
+
+		newInputs[i] = m
+	}
+	return &newInputs
+}
+
+func isInputInNonGeneratedInputNames(i *pagerduty.IncidentWorkflowActionInput, names []string) bool {
+	for _, in := range names {
+		if i.Name == in {
+			return true
+		}
+	}
+	return false
+}
+
+func buildIncidentWorkflowStruct(d *schema.ResourceData) (*pagerduty.IncidentWorkflow, error) {
+	iw := pagerduty.IncidentWorkflow{
+		Name: d.Get("name").(string),
+	}
+	if desc, ok := d.GetOk("description"); ok {
+		str := desc.(string)
+		iw.Description = &str
+	}
+
+	if steps, ok := d.GetOk("step"); ok {
+		iw.Steps = buildIncidentWorkflowStepsStruct(steps)
+	}
+
+	return &iw, nil
+
+}
+
+func buildIncidentWorkflowStepsStruct(s interface{}) []*pagerduty.IncidentWorkflowStep {
+	steps := s.([]interface{})
+	newSteps := make([]*pagerduty.IncidentWorkflowStep, len(steps))
+
+	for i, v := range steps {
+		stepData := v.(map[string]interface{})
+		step := pagerduty.IncidentWorkflowStep{
+			Name: stepData["name"].(string),
+			Configuration: &pagerduty.IncidentWorkflowActionConfiguration{
+				ActionID: stepData["action"].(string),
+			},
+		}
+		if id, ok := stepData["id"]; ok {
+			step.ID = id.(string)
+		}
+
+		step.Configuration.Inputs = buildIncidentWorkflowInputsStruct(stepData["input"])
+
+		newSteps[i] = &step
+	}
+	return newSteps
+}
+
+func buildIncidentWorkflowInputsStruct(in interface{}) []*pagerduty.IncidentWorkflowActionInput {
+	inputs := in.([]interface{})
+	newInputs := make([]*pagerduty.IncidentWorkflowActionInput, len(inputs))
+
+	for i, v := range inputs {
+		inputData := v.(map[string]interface{})
+		input := pagerduty.IncidentWorkflowActionInput{
+			Name:  inputData["name"].(string),
+			Value: inputData["value"].(string),
+		}
+
+		newInputs[i] = &input
+	}
+	return newInputs
+}

--- a/pagerduty/resource_pagerduty_incident_workflow_test.go
+++ b/pagerduty/resource_pagerduty_incident_workflow_test.go
@@ -1,0 +1,234 @@
+package pagerduty
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+func init() {
+	resource.AddTestSweepers("pagerduty_incident_workflows", &resource.Sweeper{
+		Name:         "pagerduty_incident_workflows",
+		Dependencies: []string{"pagerduty_incident_workflow_triggers"},
+		F:            testSweepIncidentWorkflow,
+	})
+}
+
+func testSweepIncidentWorkflow(region string) error {
+	config, err := sharedConfigForRegion(region)
+	if err != nil {
+		return err
+	}
+
+	client, err := config.Client()
+	if err != nil {
+		return err
+	}
+
+	workflowsResp, _, err := client.IncidentWorkflows.List(&pagerduty.ListIncidentWorkflowOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, iw := range workflowsResp.IncidentWorkflows {
+		if strings.HasPrefix(iw.Name, "tf-") {
+			log.Printf("Destroying incident workflow %s (%s)", iw.Name, iw.ID)
+			if _, err := client.IncidentWorkflows.Delete(iw.ID); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func TestAccPagerDutyIncidentWorkflow_Basic(t *testing.T) {
+	workflowName := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckIncidentWorkflows(t)
+		},
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckPagerDutyIncidentWorkflowDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyIncidentWorkflowConfig(workflowName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyIncidentWorkflowExists("pagerduty_incident_workflow.test"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_incident_workflow.test", "name", workflowName),
+					resource.TestCheckResourceAttr("pagerduty_incident_workflow.test", "description", "Managed by Terraform"),
+					resource.TestCheckResourceAttr("pagerduty_incident_workflow.test", "step.#", "2"),
+					resource.TestCheckResourceAttr("pagerduty_incident_workflow.test", "step.0.input.#", "1"),
+					resource.TestCheckResourceAttr("pagerduty_incident_workflow.test", "step.0.input.0.generated", "false"),
+					resource.TestCheckResourceAttr("pagerduty_incident_workflow.test", "step.1.input.0.value", "second update"),
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyIncidentWorkflowConfigUpdate(workflowName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyIncidentWorkflowExists("pagerduty_incident_workflow.test"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_incident_workflow.test", "name", workflowName),
+					resource.TestCheckResourceAttr(
+						"pagerduty_incident_workflow.test", "description", "some description"),
+					resource.TestCheckResourceAttr("pagerduty_incident_workflow.test", "step.#", "2"),
+					resource.TestCheckResourceAttr("pagerduty_incident_workflow.test", "step.0.input.#", "1"),
+					resource.TestCheckResourceAttr("pagerduty_incident_workflow.test", "step.0.input.0.generated", "false"),
+					resource.TestCheckResourceAttr("pagerduty_incident_workflow.test", "step.1.input.0.value", "second update updated"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckPagerDutyIncidentWorkflowConfig(name string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_incident_workflow" "test" {
+  name = "%s"
+  step {
+    name           = "Example Step"
+    action         = "pagerduty.com:incident-workflows:send-status-update:1"
+    input {
+      name = "Message"
+      value = "first update"
+    }
+  }
+  step {
+    name          = "Another Step"
+    action        = "pagerduty.com:incident-workflows:send-status-update:1"
+    input {
+      name = "Message"
+      value = "second update"
+    }
+  }
+}
+`, name)
+}
+
+func testAccCheckPagerDutyIncidentWorkflowConfigUpdate(name string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_incident_workflow" "test" {
+  name = "%s"
+  description = "some description"
+  step {
+    name           = "Example Step"
+    action         = "pagerduty.com:incident-workflows:send-status-update:1"
+    input {
+      name = "Message"
+      value = "first update"
+    }
+  }
+  step {
+    name          = "Another Step"
+    action        = "pagerduty.com:incident-workflows:send-status-update:1"
+    input {
+      name = "Message"
+      value = "second update updated"
+    }
+  }
+}
+`, name)
+}
+
+func testAccCheckPagerDutyIncidentWorkflowDestroy(s *terraform.State) error {
+	client, _ := testAccProvider.Meta().(*Config).Client()
+	for _, r := range s.RootModule().Resources {
+		if r.Type != "pagerduty_incident_workflow" {
+			continue
+		}
+
+		if _, _, err := client.IncidentWorkflows.Get(r.Primary.ID); err == nil {
+			return fmt.Errorf("incident workflow still exists")
+		}
+
+	}
+	return nil
+}
+
+func testAccCheckPagerDutyIncidentWorkflowExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no incident workflow ID is set")
+		}
+
+		client, _ := testAccProvider.Meta().(*Config).Client()
+
+		found, _, err := client.IncidentWorkflows.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("incident workflow not found: %v - %v", rs.Primary.ID, found)
+		}
+
+		return nil
+	}
+}
+
+func TestFlattenIncidentWorkflowStepsOneGenerated(t *testing.T) {
+
+	n := &pagerduty.IncidentWorkflow{
+		Steps: []*pagerduty.IncidentWorkflowStep{
+			{
+				ID:   "abc-123",
+				Name: "something",
+				Configuration: &pagerduty.IncidentWorkflowActionConfiguration{
+					Inputs: []*pagerduty.IncidentWorkflowActionInput{
+						{
+							Name:  "test1-value",
+							Value: "test1-value",
+						},
+						{
+							Name:  "test2-value",
+							Value: "test2-value",
+						},
+						{
+							Name:  "test3-value",
+							Value: "test3-value",
+						},
+					},
+				},
+			},
+		},
+	}
+	o := map[string][]string{
+		"abc-123": {"test1-value", "test2-value"},
+	}
+	r := flattenIncidentWorkflowSteps(n, o)
+	l := r[0]["input"].(*[]interface{})
+	if len(*l) != 3 {
+		t.Errorf("flattened step had wrong number of inputs. want 2 got %v", len(*l))
+	}
+	for i, v := range *l {
+		if i < 2 {
+			if _, hadGen := v.(map[string]interface{})["generated"]; hadGen {
+				t.Errorf("was not expecting input %v to be generated", i)
+			}
+		} else {
+			if gen, hadGen := v.(map[string]interface{})["generated"]; !hadGen || !(gen.(bool)) {
+				t.Errorf("was expecting input %v to be generated", i)
+			}
+		}
+	}
+}
+
+func testAccPreCheckIncidentWorkflows(t *testing.T) {
+	if v := os.Getenv("PAGERDUTY_ACC_INCIDENT_WORKFLOWS"); v == "" {
+		t.Skip("PAGERDUTY_ACC_INCIDENT_WORKFLOWS not set. Skipping Incident Workflows-related test")
+	}
+}

--- a/pagerduty/resource_pagerduty_incident_workflow_trigger.go
+++ b/pagerduty/resource_pagerduty_incident_workflow_trigger.go
@@ -1,0 +1,229 @@
+package pagerduty
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+func resourcePagerDutyIncidentWorkflowTrigger() *schema.Resource {
+	return &schema.Resource{
+		ReadContext:   resourcePagerDutyIncidentWorkflowTriggerRead,
+		UpdateContext: resourcePagerDutyIncidentWorkflowTriggerUpdate,
+		DeleteContext: resourcePagerDutyIncidentWorkflowTriggerDelete,
+		CreateContext: resourcePagerDutyIncidentWorkflowTriggerCreate,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		CustomizeDiff: validateIncidentWorkflowTrigger,
+		Schema: map[string]*schema.Schema{
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateDiagFunc: validateValueFuncDiag([]string{
+					"manual",
+					"conditional",
+				}),
+			},
+			"workflow": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"services": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"subscribed_to_all_services": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+			"condition": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourcePagerDutyIncidentWorkflowTriggerCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	iwt, err := buildIncidentWorkflowTriggerStruct(d, true)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO] Creating PagerDuty incident workflow trigger %s for %s.", iwt.Type, iwt.Workflow.ID)
+
+	createdWorkflowTrigger, _, err := client.IncidentWorkflowTriggers.CreateContext(ctx, iwt)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = flattenIncidentWorkflowTrigger(d, createdWorkflowTrigger)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func resourcePagerDutyIncidentWorkflowTriggerRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[INFO] Reading PagerDuty incident workflow trigger %s", d.Id())
+	err := fetchIncidentWorkflowTrigger(ctx, d, meta, handleNotFoundError)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func resourcePagerDutyIncidentWorkflowTriggerUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	iwt, err := buildIncidentWorkflowTriggerStruct(d, false)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO] Updating PagerDuty incident workflow trigger %s", d.Id())
+
+	updatedWorkflowTrigger, _, err := client.IncidentWorkflowTriggers.UpdateContext(ctx, d.Id(), iwt)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = flattenIncidentWorkflowTrigger(d, updatedWorkflowTrigger)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func resourcePagerDutyIncidentWorkflowTriggerDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	_, err = client.IncidentWorkflowTriggers.DeleteContext(ctx, d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func validateIncidentWorkflowTrigger(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
+	triggerType := d.Get("type").(string)
+	_, hadCondition := d.GetOk("condition")
+	if triggerType == "manual" && hadCondition {
+		return fmt.Errorf("when trigger type manual is used, condition must not be specified")
+	}
+	if triggerType == "conditional" && !hadCondition {
+		return fmt.Errorf("when trigger type conditional is used, condition must be specified")
+	}
+
+	s, hadServices := d.GetOk("services")
+	all := d.Get("subscribed_to_all_services").(bool)
+	if all && hadServices && len(s.([]interface{})) > 0 {
+		return fmt.Errorf("when subscribed_to_all_services is true, services must either be not defined or empty")
+	}
+
+	return nil
+}
+
+func fetchIncidentWorkflowTrigger(ctx context.Context, d *schema.ResourceData, meta interface{}, errorCallback func(err error, d *schema.ResourceData) error) error {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
+
+	return resource.RetryContext(ctx, 2*time.Minute, func() *resource.RetryError {
+		iwt, _, err := client.IncidentWorkflowTriggers.GetContext(ctx, d.Id())
+		if err != nil {
+			log.Printf("[WARN] Incident workflow trigger read error")
+			errResp := errorCallback(err, d)
+			if errResp != nil {
+				time.Sleep(2 * time.Second)
+				return resource.RetryableError(errResp)
+			}
+
+			return nil
+		}
+
+		if err := flattenIncidentWorkflowTrigger(d, iwt); err != nil {
+			return resource.NonRetryableError(err)
+		}
+		return nil
+
+	})
+}
+
+func flattenIncidentWorkflowTrigger(d *schema.ResourceData, t *pagerduty.IncidentWorkflowTrigger) error {
+	d.SetId(t.ID)
+	d.Set("type", t.TriggerType.String())
+	d.Set("workflow", t.Workflow.ID)
+	d.Set("services", flattenIncidentWorkflowEnabledServices(t.Services))
+	d.Set("subscribed_to_all_services", t.SubscribedToAllServices)
+	if t.Condition != nil {
+		d.Set("condition", t.Condition)
+	}
+
+	return nil
+}
+
+func flattenIncidentWorkflowEnabledServices(s []*pagerduty.ServiceReference) []string {
+	services := make([]string, len(s))
+	for i, v := range s {
+		services[i] = v.ID
+	}
+	return services
+}
+
+func buildIncidentWorkflowTriggerStruct(d *schema.ResourceData, forUpdate bool) (*pagerduty.IncidentWorkflowTrigger, error) {
+	iwt := pagerduty.IncidentWorkflowTrigger{
+		SubscribedToAllServices: d.Get("subscribed_to_all_services").(bool),
+	}
+
+	if forUpdate {
+		iwt.Workflow = &pagerduty.IncidentWorkflow{
+			ID: d.Get("workflow").(string),
+		}
+		iwt.TriggerType = pagerduty.IncidentWorkflowTriggerTypeFromString(d.Get("type").(string))
+	}
+
+	if services, ok := d.GetOk("services"); ok {
+		iwt.Services = buildIncidentWorkflowTriggerServices(services)
+	}
+
+	if condition, ok := d.GetOk("condition"); ok {
+		condStr := condition.(string)
+		iwt.Condition = &condStr
+	}
+
+	return &iwt, nil
+}
+
+func buildIncidentWorkflowTriggerServices(s interface{}) []*pagerduty.ServiceReference {
+	services := s.([]interface{})
+	newServices := make([]*pagerduty.ServiceReference, len(services))
+	for i, v := range services {
+		newServices[i] = &pagerduty.ServiceReference{
+			ID: v.(string),
+		}
+	}
+	return newServices
+}

--- a/pagerduty/resource_pagerduty_incident_workflow_trigger.go
+++ b/pagerduty/resource_pagerduty_incident_workflow_trigger.go
@@ -26,7 +26,7 @@ func resourcePagerDutyIncidentWorkflowTrigger() *schema.Resource {
 			"type": {
 				Type:     schema.TypeString,
 				Required: true,
-				ValidateDiagFunc: validateValueFuncDiag([]string{
+				ValidateFunc: validateValueFunc([]string{
 					"manual",
 					"conditional",
 				}),

--- a/pagerduty/resource_pagerduty_incident_workflow_trigger_test.go
+++ b/pagerduty/resource_pagerduty_incident_workflow_trigger_test.go
@@ -1,0 +1,283 @@
+package pagerduty
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+func init() {
+	resource.AddTestSweepers("pagerduty_incident_workflow_triggers", &resource.Sweeper{
+		Name: "pagerduty_incident_workflow_triggers",
+		F:    testSweepIncidentWorkflowTrigger,
+	})
+}
+
+func testSweepIncidentWorkflowTrigger(region string) error {
+	config, err := sharedConfigForRegion(region)
+	if err != nil {
+		return err
+	}
+
+	client, err := config.Client()
+	if err != nil {
+		return err
+	}
+
+	workflowsResp, _, err := client.IncidentWorkflows.List(&pagerduty.ListIncidentWorkflowOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, iw := range workflowsResp.IncidentWorkflows {
+		if strings.HasPrefix(iw.Name, "tf-") {
+			triggersResp, _, err := client.IncidentWorkflowTriggers.List(&pagerduty.ListIncidentWorkflowTriggerOptions{WorkflowID: iw.ID})
+			if err != nil {
+				return err
+			}
+
+			for _, t := range triggersResp.Triggers {
+				log.Printf("Destroying incident workflow trigger %s", t.ID)
+				if _, err := client.IncidentWorkflowTriggers.Delete(t.ID); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func TestAccPagerDutyIncidentWorkflowTrigger_BadType(t *testing.T) {
+	config := `
+resource "pagerduty_incident_workflow_trigger" "my_first_workflow_trigger" {
+  type             = "dummy"
+  workflow         = "ignored"
+  subscribed_to_all_services = true
+}
+`
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckIncidentWorkflows(t)
+		},
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`"dummy" is an invalid value. Must be one of \[]string{"manual", "conditional"}`),
+			},
+		},
+	})
+}
+
+func TestAccPagerDutyIncidentWorkflowTrigger_ConditionWithManualType(t *testing.T) {
+	config := `
+resource "pagerduty_incident_workflow_trigger" "my_first_workflow_trigger" {
+  type             = "manual"
+  workflow         = "ignored"
+  condition        = "something"
+  subscribed_to_all_services = true
+}
+`
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckIncidentWorkflows(t)
+		},
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile("when trigger type manual is used, condition must not be specified"),
+			},
+		},
+	})
+}
+
+func TestAccPagerDutyIncidentWorkflowTrigger_ConditionalTypeWithoutCondition(t *testing.T) {
+	config := `
+resource "pagerduty_incident_workflow_trigger" "my_first_workflow_trigger" {
+  type             = "conditional"
+  workflow         = "ignored"
+  subscribed_to_all_services = true
+}
+`
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckIncidentWorkflows(t)
+		},
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile("when trigger type conditional is used, condition must be specified"),
+			},
+		},
+	})
+}
+
+func TestAccPagerDutyIncidentWorkflowTrigger_SubscribedToAllWithInvalidServices(t *testing.T) {
+	config := `
+resource "pagerduty_incident_workflow_trigger" "my_first_workflow_trigger" {
+  type       = "conditional"
+  workflow   = "ignored"
+  condition  = "something"
+  subscribed_to_all_services = true
+  services = ["abc-123"]
+}
+`
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckIncidentWorkflows(t)
+		},
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile("when subscribed_to_all_services is true, services must either be not defined or empty"),
+			},
+		},
+	})
+}
+
+func TestAccPagerDutyIncidentWorkflowTrigger_BasicManual(t *testing.T) {
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.test", username)
+	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	workflow := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckIncidentWorkflows(t)
+		},
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckPagerDutyIncidentWorkflowTriggerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyIncidentWorkflowTriggerConfigManualSingleService(username, email, escalationPolicy, service, workflow),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyIncidentWorkflowTriggerExists("pagerduty_incident_workflow_trigger.test"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_incident_workflow_trigger.test", "type", "manual"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckPagerDutyIncidentWorkflowTriggerConfigManualSingleService(username, email, escalationPolicy, service, workflow string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "pagerduty_incident_workflow_trigger" "test" {
+  type       = "manual"
+  workflow   = pagerduty_incident_workflow.test.id
+  services   = [pagerduty_service.foo.id]
+  subscribed_to_all_services = false
+}
+`, testAccCheckPagerDutyServiceConfig(username, email, escalationPolicy, service), testAccCheckPagerDutyIncidentWorkflowConfig(workflow))
+}
+
+func TestAccPagerDutyIncidentWorkflowTrigger_BasicConditionalAllServices(t *testing.T) {
+	workflow := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckIncidentWorkflows(t)
+		},
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckPagerDutyIncidentWorkflowTriggerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyIncidentWorkflowTriggerConfigConditionalAllServices(workflow, "incident.priority matches 'P1'"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyIncidentWorkflowTriggerExists("pagerduty_incident_workflow_trigger.test"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_incident_workflow_trigger.test", "type", "conditional"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_incident_workflow_trigger.test", "condition", "incident.priority matches 'P1'"),
+					resource.TestCheckResourceAttr("pagerduty_incident_workflow_trigger.test", "subscribed_to_all_services", "true"),
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyIncidentWorkflowTriggerConfigConditionalAllServices(workflow, "incident.priority matches 'P2'"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyIncidentWorkflowTriggerExists("pagerduty_incident_workflow_trigger.test"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_incident_workflow_trigger.test", "type", "conditional"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_incident_workflow_trigger.test", "condition", "incident.priority matches 'P2'"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckPagerDutyIncidentWorkflowTriggerConfigConditionalAllServices(workflow, condition string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "pagerduty_incident_workflow_trigger" "test" {
+  type       = "conditional"
+  workflow   = pagerduty_incident_workflow.test.id
+  services   = []
+  condition  = "%s"
+  subscribed_to_all_services = true
+}
+`, testAccCheckPagerDutyIncidentWorkflowConfig(workflow), condition)
+}
+
+func testAccCheckPagerDutyIncidentWorkflowTriggerDestroy(s *terraform.State) error {
+	client, _ := testAccProvider.Meta().(*Config).Client()
+	for _, r := range s.RootModule().Resources {
+		if r.Type != "pagerduty_incident_workflow_trigger" {
+			continue
+		}
+
+		if _, _, err := client.IncidentWorkflowTriggers.Get(r.Primary.ID); err == nil {
+			return fmt.Errorf("incident workflow trigger still exists")
+		}
+
+	}
+	return nil
+}
+
+func testAccCheckPagerDutyIncidentWorkflowTriggerExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no incident workflow trigger ID is set")
+		}
+
+		client, _ := testAccProvider.Meta().(*Config).Client()
+
+		found, _, err := client.IncidentWorkflowTriggers.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("incident workflow trigger not found: %v - %v", rs.Primary.ID, found)
+		}
+
+		return nil
+	}
+}

--- a/pagerduty/resource_pagerduty_incident_workflow_trigger_test.go
+++ b/pagerduty/resource_pagerduty_incident_workflow_trigger_test.go
@@ -72,7 +72,7 @@ resource "pagerduty_incident_workflow_trigger" "my_first_workflow_trigger" {
 		Steps: []resource.TestStep{
 			{
 				Config:      config,
-				ExpectError: regexp.MustCompile(`"dummy" is an invalid value. Must be one of \[]string{"manual", "conditional"}`),
+				ExpectError: regexp.MustCompile(`"dummy" is an invalid value for argument type. Must be one of \[]string{"manual", "conditional"}`),
 			},
 		},
 	})

--- a/pagerduty/util.go
+++ b/pagerduty/util.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -98,6 +100,31 @@ func validateValueFunc(values []string) schema.SchemaValidateFunc {
 			errors = append(errors, fmt.Errorf("%#v is an invalid value for argument %s. Must be one of %#v", value, k, values))
 		}
 		return
+	}
+}
+
+func validateValueFuncDiag(values []string) schema.SchemaValidateDiagFunc {
+	return func(v interface{}, p cty.Path) diag.Diagnostics {
+		var diags diag.Diagnostics
+
+		value := v.(string)
+		valid := false
+		for _, val := range values {
+			if value == val {
+				valid = true
+				break
+			}
+		}
+
+		if !valid {
+			diags = append(diags, diag.Diagnostic{
+				Severity:      diag.Error,
+				Summary:       fmt.Sprintf("%#v is an invalid value. Must be one of %#v", value, values),
+				AttributePath: p,
+			})
+		}
+
+		return diags
 	}
 }
 

--- a/pagerduty/util.go
+++ b/pagerduty/util.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/go-cty/cty"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -100,31 +98,6 @@ func validateValueFunc(values []string) schema.SchemaValidateFunc {
 			errors = append(errors, fmt.Errorf("%#v is an invalid value for argument %s. Must be one of %#v", value, k, values))
 		}
 		return
-	}
-}
-
-func validateValueFuncDiag(values []string) schema.SchemaValidateDiagFunc {
-	return func(v interface{}, p cty.Path) diag.Diagnostics {
-		var diags diag.Diagnostics
-
-		value := v.(string)
-		valid := false
-		for _, val := range values {
-			if value == val {
-				valid = true
-				break
-			}
-		}
-
-		if !valid {
-			diags = append(diags, diag.Diagnostic{
-				Severity:      diag.Error,
-				Summary:       fmt.Sprintf("%#v is an invalid value. Must be one of %#v", value, values),
-				AttributePath: p,
-			})
-		}
-
-		return diags
 	}
 }
 

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/automation_actions_action.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/automation_actions_action.go
@@ -42,13 +42,8 @@ type AutomationActionsActionTeamAssociationPayload struct {
 func (s *AutomationActionsActionService) Create(action *AutomationActionsAction) (*AutomationActionsAction, *Response, error) {
 	u := "/automation_actions/actions"
 	v := new(AutomationActionsActionPayload)
-	o := RequestOptions{
-		Type:  "header",
-		Label: "X-EARLY-ACCESS",
-		Value: "automation-actions-early-access",
-	}
 
-	resp, err := s.client.newRequestDoOptions("POST", u, nil, &AutomationActionsActionPayload{Action: action}, &v, o)
+	resp, err := s.client.newRequestDoOptions("POST", u, nil, &AutomationActionsActionPayload{Action: action}, &v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -60,13 +55,8 @@ func (s *AutomationActionsActionService) Create(action *AutomationActionsAction)
 func (s *AutomationActionsActionService) Get(id string) (*AutomationActionsAction, *Response, error) {
 	u := fmt.Sprintf("/automation_actions/actions/%s", id)
 	v := new(AutomationActionsActionPayload)
-	o := RequestOptions{
-		Type:  "header",
-		Label: "X-EARLY-ACCESS",
-		Value: "automation-actions-early-access",
-	}
 
-	resp, err := s.client.newRequestDoOptions("GET", u, nil, nil, &v, o)
+	resp, err := s.client.newRequestDoOptions("GET", u, nil, nil, &v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -77,29 +67,19 @@ func (s *AutomationActionsActionService) Get(id string) (*AutomationActionsActio
 // Delete deletes an existing action.
 func (s *AutomationActionsActionService) Delete(id string) (*Response, error) {
 	u := fmt.Sprintf("/automation_actions/actions/%s", id)
-	o := RequestOptions{
-		Type:  "header",
-		Label: "X-EARLY-ACCESS",
-		Value: "automation-actions-early-access",
-	}
 
-	return s.client.newRequestDoOptions("DELETE", u, nil, nil, nil, o)
+	return s.client.newRequestDoOptions("DELETE", u, nil, nil, nil)
 }
 
 // Associate an Automation Action with a team
 func (s *AutomationActionsActionService) AssociateToTeam(actionID, teamID string) (*AutomationActionsActionTeamAssociationPayload, *Response, error) {
 	u := fmt.Sprintf("/automation_actions/actions/%s/teams", actionID)
 	v := new(AutomationActionsActionTeamAssociationPayload)
-	o := RequestOptions{
-		Type:  "header",
-		Label: "X-EARLY-ACCESS",
-		Value: "automation-actions-early-access",
-	}
 	p := &AutomationActionsActionTeamAssociationPayload{
 		Team: &TeamReference{ID: teamID, Type: "team_reference"},
 	}
 
-	resp, err := s.client.newRequestDoOptions("POST", u, nil, p, &v, o)
+	resp, err := s.client.newRequestDoOptions("POST", u, nil, p, &v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -110,26 +90,16 @@ func (s *AutomationActionsActionService) AssociateToTeam(actionID, teamID string
 // Dissociate an Automation Action with a team
 func (s *AutomationActionsActionService) DissociateToTeam(actionID, teamID string) (*Response, error) {
 	u := fmt.Sprintf("/automation_actions/actions/%s/teams/%s", actionID, teamID)
-	o := RequestOptions{
-		Type:  "header",
-		Label: "X-EARLY-ACCESS",
-		Value: "automation-actions-early-access",
-	}
 
-	return s.client.newRequestDoOptions("DELETE", u, nil, nil, nil, o)
+	return s.client.newRequestDoOptions("DELETE", u, nil, nil, nil)
 }
 
 // Gets the details of an Automation Action / team relation
 func (s *AutomationActionsActionService) GetAssociationToTeam(actionID, teamID string) (*AutomationActionsActionTeamAssociationPayload, *Response, error) {
 	u := fmt.Sprintf("/automation_actions/actions/%s/teams/%s", actionID, teamID)
 	v := new(AutomationActionsActionTeamAssociationPayload)
-	o := RequestOptions{
-		Type:  "header",
-		Label: "X-EARLY-ACCESS",
-		Value: "automation-actions-early-access",
-	}
 
-	resp, err := s.client.newRequestDoOptions("GET", u, nil, nil, &v, o)
+	resp, err := s.client.newRequestDoOptions("GET", u, nil, nil, &v)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/automation_actions_runner.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/automation_actions_runner.go
@@ -33,13 +33,8 @@ type AutomationActionsRunnerPayload struct {
 func (s *AutomationActionsRunnerService) Create(runner *AutomationActionsRunner) (*AutomationActionsRunner, *Response, error) {
 	u := "/automation_actions/runners"
 	v := new(AutomationActionsRunnerPayload)
-	o := RequestOptions{
-		Type:  "header",
-		Label: "X-EARLY-ACCESS",
-		Value: "automation-actions-early-access",
-	}
 
-	resp, err := s.client.newRequestDoOptions("POST", u, nil, &AutomationActionsRunnerPayload{Runner: runner}, &v, o)
+	resp, err := s.client.newRequestDoOptions("POST", u, nil, &AutomationActionsRunnerPayload{Runner: runner}, &v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -51,13 +46,8 @@ func (s *AutomationActionsRunnerService) Create(runner *AutomationActionsRunner)
 func (s *AutomationActionsRunnerService) Get(id string) (*AutomationActionsRunner, *Response, error) {
 	u := fmt.Sprintf("/automation_actions/runners/%s", id)
 	v := new(AutomationActionsRunnerPayload)
-	o := RequestOptions{
-		Type:  "header",
-		Label: "X-EARLY-ACCESS",
-		Value: "automation-actions-early-access",
-	}
 
-	resp, err := s.client.newRequestDoOptions("GET", u, nil, nil, &v, o)
+	resp, err := s.client.newRequestDoOptions("GET", u, nil, nil, &v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -68,11 +58,6 @@ func (s *AutomationActionsRunnerService) Get(id string) (*AutomationActionsRunne
 // Delete deletes an existing runner.
 func (s *AutomationActionsRunnerService) Delete(id string) (*Response, error) {
 	u := fmt.Sprintf("/automation_actions/runners/%s", id)
-	o := RequestOptions{
-		Type:  "header",
-		Label: "X-EARLY-ACCESS",
-		Value: "automation-actions-early-access",
-	}
 
-	return s.client.newRequestDoOptions("DELETE", u, nil, nil, nil, o)
+	return s.client.newRequestDoOptions("DELETE", u, nil, nil, nil)
 }

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/incident.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/incident.go
@@ -1,0 +1,178 @@
+package pagerduty
+
+import (
+	"fmt"
+	"log"
+)
+
+// IncidentService handles the communication with incident
+// related methods of the PagerDuty API.
+type IncidentService service
+
+// Incident represents a incident.
+type Incident struct {
+	ID                   string                      `json:"id,omitempty"`
+	Type                 string                      `json:"type,omitempty"`
+	Summary              string                      `json:"summary,omitempty"`
+	Self                 string                      `json:"self,omitempty"`
+	HTMLURL              string                      `json:"html_url,omitempty"`
+	IncidentNumber       int                         `json:"incident_number,omitempty"`
+	CreatedAt            string                      `json:"created_at,omitempty"`
+	Status               string                      `json:"status,omitempty"`
+	Title                string                      `json:"title,omitempty"`
+	Resolution           string                      `json:"resolution,omitempty"`
+	AlertCounts          *AlertCounts                `json:"alert_counts,omitempty"`
+	PendingActions       []*PendingAction            `json:"pending_actions,omitempty"`
+	IncidentKey          string                      `json:"incident_key,omitempty"`
+	Service              *ServiceReference           `json:"service,omitempty"`
+	AssignedVia          string                      `json:"assigned_via,omitempty"`
+	Assignments          []*IncidentAssignment       `json:"assignments,omitempty"`
+	Acknowledgements     []*IncidentAcknowledgement  `json:"acknowledgements,omitempty"`
+	LastStatusChangeAt   string                      `json:"last_status_change_at,omitempty"`
+	LastStatusChangeBy   *IncidentAttributeReference `json:"last_status_change_by,omitempty"`
+	FirstTriggerLogEntry *IncidentAttributeReference `json:"first_trigger_log_entry,omitempty"`
+	EscalationPolicy     *EscalationPolicyReference  `json:"escalation_policy,omitempty"`
+	Teams                []*TeamReference            `json:"teams,omitempty"`
+	Urgency              string                      `json:"urgency,omitempty"`
+}
+
+type AlertCounts struct {
+	All       int `json:"all"`
+	Resolved  int `json:"resolved"`
+	Triggered int `json:"triggered"`
+}
+
+type PendingAction struct {
+	At   string `json:"at"`
+	Type string `json:"type"`
+}
+
+type IncidentAssignment struct {
+	At       string        `json:"at"`
+	Assignee UserReference `json:"assignee"`
+}
+
+type IncidentAcknowledgement struct {
+	At           string                     `json:"at"`
+	Acknowledger IncidentAttributeReference `json:"acknowledger"`
+}
+
+// IncidentPayload represents an incident.
+type IncidentPayload struct {
+	Incident *Incident `json:"incident,omitempty"`
+}
+
+// ManageIncidentsPayload represents a payload with a list of incidents data.
+type ManageIncidentsPayload struct {
+	Incidents []*Incident `json:"incidents,omitempty"`
+}
+
+// ListIncidentsOptions represents options when listing incidents.
+type ListIncidentsOptions struct {
+	Limit       int      `url:"limit,omitempty"`
+	Offset      int      `url:"offset,omitempty"`
+	Total       int      `url:"total,omitempty"`
+	DateRange   string   `url:"date_range,omitempty"`
+	IncidentKey string   `url:"incident_key,omitempty"`
+	Include     []string `url:"include,omitempty,brackets"`
+	ServiceIDs  []string `url:"service_ids,omitempty,brackets"`
+	Since       string   `url:"since,omitempty"`
+	SortBy      []string `url:"sort_by,omitempty,brackets"`
+	Statuses    []string `url:"statuses,omitempty,brackets"`
+	TeamIDs     []string `url:"team_ids,omitempty,brackets"`
+	TimeZone    string   `url:"time_zone,omitempty"`
+	Until       string   `url:"until,omitempty"`
+	Urgencies   []string `url:"urgencies,omitempty,brackets"`
+	UserIDs     []string `url:"user_ids,omitempty,brackets"`
+}
+
+// ManageIncidentsOptions represents options when listing incidents.
+type ManageIncidentsOptions struct {
+	Limit  int `url:"limit,omitempty"`
+	Offset int `url:"offset,omitempty"`
+	Total  int `url:"total,omitempty"`
+}
+
+// ListIncidentsResponse represents a list response of incidents.
+type ListIncidentsResponse struct {
+	Limit     int         `json:"limit,omitempty"`
+	More      bool        `json:"more,omitempty"`
+	Offset    int         `json:"offset,omitempty"`
+	Total     int         `json:"total,omitempty"`
+	Incidents []*Incident `json:"incidents,omitempty"`
+}
+
+type ManageIncidentsResponse ListIncidentsResponse
+
+// List lists existing incidents.
+func (s *IncidentService) List(o *ListIncidentsOptions) (*ListIncidentsResponse, *Response, error) {
+	u := "/incidents"
+	v := new(ListIncidentsResponse)
+
+	resp, err := s.client.newRequestDo("GET", u, o, nil, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v, resp, nil
+}
+
+// ListAll lists all result pages for incidents list.
+func (s *IncidentService) ListAll(o *ListIncidentsOptions) ([]*Incident, error) {
+	var incidents = make([]*Incident, 0, 25)
+	more := true
+	offset := 0
+
+	for more {
+		log.Printf("==== Getting incidents at offset %d", offset)
+		v := new(ListIncidentsResponse)
+		_, err := s.client.newRequestDo("GET", "/incidents", o, nil, &v)
+		if err != nil {
+			return incidents, err
+		}
+		incidents = append(incidents, v.Incidents...)
+		more = v.More
+		offset += v.Limit
+		o.Offset = offset
+	}
+	return incidents, nil
+}
+
+// ManageIncidents updates existing incidents.
+func (s *IncidentService) ManageIncidents(incidents []*Incident, o *ManageIncidentsOptions) (*ManageIncidentsResponse, *Response, error) {
+	u := "/incidents"
+	v := new(ManageIncidentsResponse)
+
+	resp, err := s.client.newRequestDo("PUT", u, o, &ManageIncidentsPayload{Incidents: incidents}, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v, resp, nil
+}
+
+// Create an incident
+func (s *IncidentService) Create(incident *Incident) (*Incident, *Response, error) {
+	u := "/incidents"
+	v := new(IncidentPayload)
+
+	resp, err := s.client.newRequestDo("POST", u, nil, &IncidentPayload{Incident: incident}, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.Incident, resp, nil
+}
+
+// Get retrieves information about an incident.
+func (s *IncidentService) Get(id string) (*Incident, *Response, error) {
+	u := fmt.Sprintf("/incidents/%s", id)
+	v := new(IncidentPayload)
+
+	resp, err := s.client.newRequestDo("GET", u, nil, nil, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.Incident, resp, nil
+}

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/incident_workflow.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/incident_workflow.go
@@ -1,0 +1,207 @@
+package pagerduty
+
+import (
+	"context"
+	"fmt"
+)
+
+// IncidentWorkflowService handles the communication with incident workflow
+// related methods of the PagerDuty API.
+type IncidentWorkflowService service
+
+// IncidentWorkflow represents an incident workflow.
+type IncidentWorkflow struct {
+	ID          string                  `json:"id,omitempty"`
+	Type        string                  `json:"type,omitempty"`
+	Name        string                  `json:"name,omitempty"`
+	Description *string                 `json:"description,omitempty"`
+	Self        string                  `json:"self,omitempty"`
+	Steps       []*IncidentWorkflowStep `json:"steps,omitempty"`
+}
+
+// IncidentWorkflowStep represents a step in an incident workflow.
+type IncidentWorkflowStep struct {
+	ID            string                               `json:"id,omitempty"`
+	Type          string                               `json:"type,omitempty"`
+	Name          string                               `json:"name,omitempty"`
+	Description   *string                              `json:"description,omitempty"`
+	Configuration *IncidentWorkflowActionConfiguration `json:"action_configuration,omitempty"`
+}
+
+// IncidentWorkflowActionConfiguration represents the configuration for an incident workflow action
+type IncidentWorkflowActionConfiguration struct {
+	ActionID    string                         `json:"action_id,omitempty"`
+	Description *string                        `json:"description,omitempty"`
+	Inputs      []*IncidentWorkflowActionInput `json:"inputs,omitempty"`
+}
+
+type IncidentWorkflowActionInput struct {
+	Name  string `json:"name,omitempty"`
+	Value string `json:"value,omitempty"`
+}
+
+// ListIncidentWorkflowResponse represents a list response of incident workflows.
+type ListIncidentWorkflowResponse struct {
+	Total             int                 `json:"total,omitempty"`
+	IncidentWorkflows []*IncidentWorkflow `json:"incident_workflows,omitempty"`
+	Offset            int                 `json:"offset,omitempty"`
+	More              bool                `json:"more,omitempty"`
+	Limit             int                 `json:"limit,omitempty"`
+}
+
+// IncidentWorkflowPayload represents payload with an incident workflow object.
+type IncidentWorkflowPayload struct {
+	IncidentWorkflow *IncidentWorkflow `json:"incident_workflow,omitempty"`
+}
+
+var incidentWorkflowsEarlyAccessHeader = RequestOptions{
+	Type:  "header",
+	Label: "X-EARLY-ACCESS",
+	Value: "incident-workflows-early-access",
+}
+
+// ListIncidentWorkflowOptions represents options when retrieving a list of incident workflows.
+type ListIncidentWorkflowOptions struct {
+	Offset   int      `url:"offset,omitempty"`
+	Limit    int      `url:"limit,omitempty"`
+	Total    bool     `url:"total,omitempty"`
+	Includes []string `url:"include,brackets,omitempty"`
+}
+
+type listIncidentWorkflowOptionsGen struct {
+	options *ListIncidentWorkflowOptions
+}
+
+func (o *listIncidentWorkflowOptionsGen) currentOffset() int {
+	return o.options.Offset
+}
+
+func (o *listIncidentWorkflowOptionsGen) changeOffset(i int) {
+	o.options.Offset = i
+}
+
+func (o *listIncidentWorkflowOptionsGen) buildStruct() interface{} {
+	return o.options
+}
+
+// List lists existing incident workflows. If a non-zero Limit is passed as an option, only a single page of results will be
+// returned. Otherwise, the entire list of incident workflows will be returned.
+func (s *IncidentWorkflowService) List(o *ListIncidentWorkflowOptions) (*ListIncidentWorkflowResponse, *Response, error) {
+	return s.ListContext(context.Background(), o)
+}
+
+// ListContext lists existing incident workflows. If a non-zero Limit is passed as an option, only a single page of results will be
+// returned. Otherwise, the entire list of incident workflows will be returned.
+func (s *IncidentWorkflowService) ListContext(ctx context.Context, o *ListIncidentWorkflowOptions) (*ListIncidentWorkflowResponse, *Response, error) {
+	u := "/incident_workflows"
+	v := new(ListIncidentWorkflowResponse)
+
+	if o == nil {
+		o = &ListIncidentWorkflowOptions{}
+	}
+
+	if o.Limit != 0 {
+		resp, err := s.client.newRequestDoOptionsContext(ctx, "GET", u, o, nil, &v, incidentWorkflowsEarlyAccessHeader)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return v, resp, nil
+	} else {
+		workflows := make([]*IncidentWorkflow, 0)
+
+		// Create a handler closure capable of parsing data from the workflows endpoint
+		// and appending resultant response plays to the return slice.
+		responseHandler := func(response *Response) (ListResp, *Response, error) {
+			var result ListIncidentWorkflowResponse
+
+			if err := s.client.DecodeJSON(response, &result); err != nil {
+				return ListResp{}, response, err
+			}
+
+			workflows = append(workflows, result.IncidentWorkflows...)
+
+			// Return stats on the current page. Caller can use this information to
+			// adjust for requesting additional pages.
+			return ListResp{
+				More:   result.More,
+				Offset: result.Offset,
+				Limit:  result.Limit,
+			}, response, nil
+		}
+		err := s.client.newRequestPagedGetQueryDoContext(ctx, u, responseHandler, &listIncidentWorkflowOptionsGen{
+			options: o,
+		}, incidentWorkflowsEarlyAccessHeader)
+		if err != nil {
+			return nil, nil, err
+		}
+		v.IncidentWorkflows = workflows
+
+		return v, nil, nil
+	}
+}
+
+// Get gets an incident workflow.
+func (s *IncidentWorkflowService) Get(id string) (*IncidentWorkflow, *Response, error) {
+	return s.GetContext(context.Background(), id)
+}
+
+// GetContext gets an incident workflow.
+func (s *IncidentWorkflowService) GetContext(ctx context.Context, id string) (*IncidentWorkflow, *Response, error) {
+	u := fmt.Sprintf("/incident_workflows/%s", id)
+	v := new(IncidentWorkflowPayload)
+
+	resp, err := s.client.newRequestDoOptionsContext(ctx, "GET", u, nil, nil, v, incidentWorkflowsEarlyAccessHeader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.IncidentWorkflow, resp, nil
+}
+
+// Create creates a new incident workflow.
+func (s *IncidentWorkflowService) Create(iw *IncidentWorkflow) (*IncidentWorkflow, *Response, error) {
+	return s.CreateContext(context.Background(), iw)
+}
+
+// CreateContext creates a new incident workflow.
+func (s *IncidentWorkflowService) CreateContext(ctx context.Context, iw *IncidentWorkflow) (*IncidentWorkflow, *Response, error) {
+	u := "/incident_workflows"
+	v := new(IncidentWorkflowPayload)
+
+	resp, err := s.client.newRequestDoOptionsContext(ctx, "POST", u, nil, &IncidentWorkflowPayload{IncidentWorkflow: iw}, &v, incidentWorkflowsEarlyAccessHeader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.IncidentWorkflow, resp, nil
+}
+
+// Delete removes an existing incident workflow.
+func (s *IncidentWorkflowService) Delete(id string) (*Response, error) {
+	return s.DeleteContext(context.Background(), id)
+}
+
+// DeleteContext removes an existing incident workflow.
+func (s *IncidentWorkflowService) DeleteContext(ctx context.Context, id string) (*Response, error) {
+	u := fmt.Sprintf("/incident_workflows/%s", id)
+	return s.client.newRequestDoOptionsContext(ctx, "DELETE", u, nil, nil, nil, incidentWorkflowsEarlyAccessHeader)
+}
+
+// Update updates an existing incident workflow.
+func (s *IncidentWorkflowService) Update(id string, iw *IncidentWorkflow) (*IncidentWorkflow, *Response, error) {
+	return s.UpdateContext(context.Background(), id, iw)
+}
+
+// UpdateContext updates an existing incident workflow.
+func (s *IncidentWorkflowService) UpdateContext(ctx context.Context, id string, iw *IncidentWorkflow) (*IncidentWorkflow, *Response, error) {
+	u := fmt.Sprintf("/incident_workflows/%s", id)
+	v := new(IncidentWorkflowPayload)
+
+	resp, err := s.client.newRequestDoOptionsContext(ctx, "PUT", u, nil, &IncidentWorkflowPayload{IncidentWorkflow: iw}, &v, incidentWorkflowsEarlyAccessHeader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.IncidentWorkflow, resp, nil
+}

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/incident_workflow_trigger.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/incident_workflow_trigger.go
@@ -1,0 +1,180 @@
+package pagerduty
+
+import (
+	"context"
+	"fmt"
+)
+
+// IncidentWorkflowTriggerService handles the communication with incident workflow
+// trigger related methods of the PagerDuty API.
+type IncidentWorkflowTriggerService service
+
+// IncidentWorkflowTrigger represents an incident workflow.
+type IncidentWorkflowTrigger struct {
+	ID                      string                      `json:"id,omitempty"`
+	Type                    string                      `json:"type,omitempty"`
+	TriggerType             IncidentWorkflowTriggerType `json:"trigger_type,omitempty"`
+	Workflow                *IncidentWorkflow           `json:"workflow,omitempty"`
+	Services                []*ServiceReference         `json:"services,omitempty"`
+	Condition               *string                     `json:"condition,omitempty"`
+	SubscribedToAllServices bool                        `json:"is_subscribed_to_all_services,omitempty"`
+}
+
+// ListIncidentWorkflowTriggerResponse represents a list response of incident workflow triggers.
+type ListIncidentWorkflowTriggerResponse struct {
+	Triggers      []*IncidentWorkflowTrigger `json:"triggers,omitempty"`
+	NextPageToken string                     `json:"next_page_token,omitempty"`
+	Limit         int                        `json:"limit,omitempty"`
+}
+
+// IncidentWorkflowTriggerPayload represents payload with an incident workflow trigger object.
+type IncidentWorkflowTriggerPayload struct {
+	Trigger *IncidentWorkflowTrigger `json:"trigger,omitempty"`
+}
+
+// ListIncidentWorkflowTriggerOptions represents options when retrieving a list of incident workflow triggers.
+type ListIncidentWorkflowTriggerOptions struct {
+	IncidentID  string                      `url:"incident_id,omitempty"`
+	WorkflowID  string                      `url:"workflow_id,omitempty"`
+	ServiceID   string                      `url:"service_id,omitempty"`
+	TriggerType IncidentWorkflowTriggerType `url:"trigger_type,omitempty"`
+	Limit       int                         `url:"limit,omitempty"`
+	PageToken   string                      `url:"page_token,omitempty"`
+}
+
+type listIncidentWorkflowTriggerOptionsGen struct {
+	options *ListIncidentWorkflowTriggerOptions
+}
+
+func (o *listIncidentWorkflowTriggerOptionsGen) currentCursor() string {
+	return o.options.PageToken
+}
+
+func (o *listIncidentWorkflowTriggerOptionsGen) changeCursor(s string) {
+	o.options.PageToken = s
+}
+
+func (o *listIncidentWorkflowTriggerOptionsGen) buildStruct() interface{} {
+	return o.options
+}
+
+// List lists existing incident workflow triggers. If a non-zero Limit is passed as an option, only a single page of results will be
+// returned. Otherwise, the entire list of incident workflows will be returned.
+func (s *IncidentWorkflowTriggerService) List(o *ListIncidentWorkflowTriggerOptions) (*ListIncidentWorkflowTriggerResponse, *Response, error) {
+	return s.ListContext(context.Background(), o)
+}
+
+// ListContext lists existing incident workflow triggers. If a non-zero Limit is passed as an option, only a single page of results will be
+// returned. Otherwise, the entire list of incident workflows will be returned.
+func (s *IncidentWorkflowTriggerService) ListContext(ctx context.Context, o *ListIncidentWorkflowTriggerOptions) (*ListIncidentWorkflowTriggerResponse, *Response, error) {
+	u := "/incident_workflows/triggers"
+	v := new(ListIncidentWorkflowTriggerResponse)
+
+	if o == nil {
+		o = &ListIncidentWorkflowTriggerOptions{}
+	}
+
+	if o.Limit != 0 {
+		resp, err := s.client.newRequestDoOptionsContext(ctx, "GET", u, o, nil, &v, incidentWorkflowsEarlyAccessHeader)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return v, resp, nil
+	} else {
+		triggers := make([]*IncidentWorkflowTrigger, 0)
+
+		// Create a handler closure capable of parsing data from the workflows endpoint
+		// and appending resultant response plays to the return slice.
+		responseHandler := func(response *Response) (CursorListResp, *Response, error) {
+			var result ListIncidentWorkflowTriggerResponse
+
+			if err := s.client.DecodeJSON(response, &result); err != nil {
+				return CursorListResp{}, response, err
+			}
+
+			triggers = append(triggers, result.Triggers...)
+
+			// Return stats on the current page. Caller can use this information to
+			// adjust for requesting additional pages.
+			return CursorListResp{
+				Limit:      result.Limit,
+				NextCursor: result.NextPageToken,
+			}, response, nil
+		}
+		err := s.client.newRequestCursorPagedGetQueryDoContext(ctx, u, responseHandler, &listIncidentWorkflowTriggerOptionsGen{
+			options: o,
+		}, incidentWorkflowsEarlyAccessHeader)
+		if err != nil {
+			return nil, nil, err
+		}
+		v.Triggers = triggers
+
+		return v, nil, nil
+	}
+}
+
+// Get gets an incident workflow trigger.
+func (s *IncidentWorkflowTriggerService) Get(id string) (*IncidentWorkflowTrigger, *Response, error) {
+	return s.GetContext(context.Background(), id)
+}
+
+// GetContext gets an incident workflow trigger.
+func (s *IncidentWorkflowTriggerService) GetContext(ctx context.Context, id string) (*IncidentWorkflowTrigger, *Response, error) {
+	u := fmt.Sprintf("/incident_workflows/triggers/%s", id)
+	v := new(IncidentWorkflowTriggerPayload)
+
+	resp, err := s.client.newRequestDoOptionsContext(ctx, "GET", u, nil, nil, v, incidentWorkflowsEarlyAccessHeader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.Trigger, resp, nil
+}
+
+// Create creates a new incident workflow trigger.
+func (s *IncidentWorkflowTriggerService) Create(t *IncidentWorkflowTrigger) (*IncidentWorkflowTrigger, *Response, error) {
+	return s.CreateContext(context.Background(), t)
+}
+
+// CreateContext creates a new incident workflow trigger.
+func (s *IncidentWorkflowTriggerService) CreateContext(ctx context.Context, t *IncidentWorkflowTrigger) (*IncidentWorkflowTrigger, *Response, error) {
+	u := "/incident_workflows/triggers"
+	v := new(IncidentWorkflowTriggerPayload)
+
+	resp, err := s.client.newRequestDoOptionsContext(ctx, "POST", u, nil, &t, &v, incidentWorkflowsEarlyAccessHeader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.Trigger, resp, nil
+}
+
+// Delete removes an existing incident workflow trigger.
+func (s *IncidentWorkflowTriggerService) Delete(id string) (*Response, error) {
+	return s.DeleteContext(context.Background(), id)
+}
+
+// DeleteContext removes an existing incident workflow trigger.
+func (s *IncidentWorkflowTriggerService) DeleteContext(ctx context.Context, id string) (*Response, error) {
+	u := fmt.Sprintf("/incident_workflows/triggers/%s", id)
+	return s.client.newRequestDoOptionsContext(ctx, "DELETE", u, nil, nil, nil, incidentWorkflowsEarlyAccessHeader)
+}
+
+// Update updates an existing incident workflow trigger.
+func (s *IncidentWorkflowTriggerService) Update(id string, t *IncidentWorkflowTrigger) (*IncidentWorkflowTrigger, *Response, error) {
+	return s.UpdateContext(context.Background(), id, t)
+}
+
+// UpdateContext updates an existing incident workflow trigger.
+func (s *IncidentWorkflowTriggerService) UpdateContext(ctx context.Context, id string, t *IncidentWorkflowTrigger) (*IncidentWorkflowTrigger, *Response, error) {
+	u := fmt.Sprintf("/incident_workflows/triggers/%s", id)
+	v := new(IncidentWorkflowTriggerPayload)
+
+	resp, err := s.client.newRequestDoOptionsContext(ctx, "PUT", u, nil, &t, &v, incidentWorkflowsEarlyAccessHeader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.Trigger, resp, nil
+}

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/incident_workflow_trigger_type.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/incident_workflow_trigger_type.go
@@ -1,0 +1,55 @@
+package pagerduty
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// IncidentWorkflowTriggerType is an enumeration of available types for incident workflow triggers.
+type IncidentWorkflowTriggerType int64
+
+const (
+	IncidentWorkflowTriggerTypeUnknown IncidentWorkflowTriggerType = iota
+	IncidentWorkflowTriggerTypeManual
+	IncidentWorkflowTriggerTypeConditional
+)
+
+func (d IncidentWorkflowTriggerType) String() string {
+	return incidentWorkflowTriggerTypeToString[d]
+}
+
+func IncidentWorkflowTriggerTypeFromString(s string) IncidentWorkflowTriggerType {
+	return incidentWorkflowTriggerTypeFromString[s]
+}
+
+var incidentWorkflowTriggerTypeToString = map[IncidentWorkflowTriggerType]string{
+	IncidentWorkflowTriggerTypeUnknown:     "unknown",
+	IncidentWorkflowTriggerTypeManual:      "manual",
+	IncidentWorkflowTriggerTypeConditional: "conditional",
+}
+
+var incidentWorkflowTriggerTypeFromString = map[string]IncidentWorkflowTriggerType{
+	"unknown":     IncidentWorkflowTriggerTypeUnknown,
+	"manual":      IncidentWorkflowTriggerTypeManual,
+	"conditional": IncidentWorkflowTriggerTypeConditional,
+}
+
+func (t IncidentWorkflowTriggerType) MarshalJSON() ([]byte, error) {
+	buffer := bytes.NewBufferString(fmt.Sprintf(`"%v"`, t.String()))
+	return buffer.Bytes(), nil
+}
+
+func (t *IncidentWorkflowTriggerType) UnmarshalJSON(data []byte) error {
+	var str string
+	err := json.Unmarshal(data, &str)
+	if err != nil {
+		return err
+	}
+	*t = IncidentWorkflowTriggerTypeFromString(str)
+	return nil
+}
+
+func (t *IncidentWorkflowTriggerType) IsKnown() bool {
+	return *t != IncidentWorkflowTriggerTypeUnknown
+}

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/pagerduty.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/pagerduty.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -61,6 +62,9 @@ type Client struct {
 	OnCall                     *OnCallService
 	AutomationActionsRunner    *AutomationActionsRunnerService
 	AutomationActionsAction    *AutomationActionsActionService
+	Incidents                  *IncidentService
+	IncidentWorkflows          *IncidentWorkflowService
+	IncidentWorkflowTriggers   *IncidentWorkflowTriggerService
 }
 
 // Response is a wrapper around http.Response
@@ -125,6 +129,9 @@ func NewClient(config *Config) (*Client, error) {
 	c.OnCall = &OnCallService{c}
 	c.AutomationActionsRunner = &AutomationActionsRunnerService{c}
 	c.AutomationActionsAction = &AutomationActionsActionService{c}
+	c.Incidents = &IncidentService{c}
+	c.IncidentWorkflows = &IncidentWorkflowService{c}
+	c.IncidentWorkflowTriggers = &IncidentWorkflowTriggerService{c}
 
 	InitCache(c)
 	PopulateCache()
@@ -133,6 +140,10 @@ func NewClient(config *Config) (*Client, error) {
 }
 
 func (c *Client) newRequest(method, url string, body interface{}, options ...RequestOptions) (*http.Request, error) {
+	return c.newRequestContext(context.Background(), method, url, body, options...)
+}
+
+func (c *Client) newRequestContext(ctx context.Context, method, url string, body interface{}, options ...RequestOptions) (*http.Request, error) {
 	var buf io.ReadWriter
 	if body != nil {
 		buf = new(bytes.Buffer)
@@ -148,7 +159,7 @@ func (c *Client) newRequest(method, url string, body interface{}, options ...Req
 
 	u := c.baseURL.String() + url
 
-	req, err := http.NewRequest(method, u, buf)
+	req, err := http.NewRequestWithContext(ctx, method, u, buf)
 	if err != nil {
 		return nil, err
 	}
@@ -171,6 +182,10 @@ func (c *Client) newRequest(method, url string, body interface{}, options ...Req
 }
 
 func (c *Client) newRequestDo(method, url string, qryOptions, body, v interface{}) (*Response, error) {
+	return c.newRequestDoContext(context.Background(), method, url, qryOptions, body, v)
+}
+
+func (c *Client) newRequestDoContext(ctx context.Context, method, url string, qryOptions, body, v interface{}) (*Response, error) {
 	if qryOptions != nil {
 		values, err := query.Values(qryOptions)
 		if err != nil {
@@ -181,7 +196,7 @@ func (c *Client) newRequestDo(method, url string, qryOptions, body, v interface{
 			url = fmt.Sprintf("%s?%s", url, v)
 		}
 	}
-	req, err := c.newRequest(method, url, body)
+	req, err := c.newRequestContext(ctx, method, url, body)
 	if err != nil {
 		return nil, err
 	}
@@ -189,6 +204,10 @@ func (c *Client) newRequestDo(method, url string, qryOptions, body, v interface{
 }
 
 func (c *Client) newRequestDoOptions(method, url string, qryOptions, body, v interface{}, reqOptions ...RequestOptions) (*Response, error) {
+	return c.newRequestDoOptionsContext(context.Background(), method, url, qryOptions, body, v, reqOptions...)
+}
+
+func (c *Client) newRequestDoOptionsContext(ctx context.Context, method, url string, qryOptions, body, v interface{}, reqOptions ...RequestOptions) (*Response, error) {
 	if qryOptions != nil {
 		values, err := query.Values(qryOptions)
 		if err != nil {
@@ -199,7 +218,7 @@ func (c *Client) newRequestDoOptions(method, url string, qryOptions, body, v int
 			url = fmt.Sprintf("%s?%s", url, v)
 		}
 	}
-	req, err := c.newRequest(method, url, body, reqOptions...)
+	req, err := c.newRequestContext(ctx, method, url, body, reqOptions...)
 	if err != nil {
 		return nil, err
 	}
@@ -249,7 +268,55 @@ type ListResp struct {
 // a specific slice. The responseHandler is responsible for closing the response.
 type responseHandler func(response *Response) (ListResp, *Response, error)
 
+// CursorListResp represents a cursor-paginated list response from the PagerDuty API
+type CursorListResp struct {
+	NextCursor string
+	Limit      int
+}
+
+// cursorResponseHandler is capable of parsing a response. At a minimum it must
+// extract the page information for the current page. It can also execute
+// additional necessary handling; for example, if a closure, it has access
+// to the scope in which it was defined, and can be used to append data to
+// a specific slice. The responseHandler is responsible for closing the response.
+type cursorResponseHandler func(response *Response) (CursorListResp, *Response, error)
+
+// offsetQueryOptionsGen enables updating the offset across multiple
+// pages of a list response while retaining query parameters other than the
+// offset. For list-style functions where the underlying method supports
+// other query parameters, this interface should be implemented to update
+// the offset when fetching subsequent pages of results.
+type offsetQueryOptionsGen interface {
+	currentOffset() int
+	changeOffset(int)
+	buildStruct() interface{}
+}
+
+type simpleOffsetQueryOptionsGen struct {
+	offset int `url:"offset,omitempty"`
+}
+
+func (o *simpleOffsetQueryOptionsGen) currentOffset() int {
+	return o.offset
+}
+
+func (o *simpleOffsetQueryOptionsGen) changeOffset(i int) {
+	o.offset = i
+}
+
+func (o *simpleOffsetQueryOptionsGen) buildStruct() interface{} {
+	return o
+}
+
 func (c *Client) newRequestPagedGetDo(basePath string, handler responseHandler, reqOptions ...RequestOptions) error {
+	return c.newRequestPagedGetQueryDo(basePath, handler, &simpleOffsetQueryOptionsGen{}, reqOptions...)
+}
+
+func (c *Client) newRequestPagedGetQueryDo(basePath string, handler responseHandler, qryOptions offsetQueryOptionsGen, reqOptions ...RequestOptions) error {
+	return c.newRequestPagedGetQueryDoContext(context.Background(), basePath, handler, qryOptions, reqOptions...)
+}
+
+func (c *Client) newRequestPagedGetQueryDoContext(ctx context.Context, basePath string, handler responseHandler, qryOptions offsetQueryOptionsGen, reqOptions ...RequestOptions) error {
 	// Indicates whether there are still additional pages associated with request.
 	var stillMore bool
 
@@ -257,8 +324,9 @@ func (c *Client) newRequestPagedGetDo(basePath string, handler responseHandler, 
 	var nextOffset int
 
 	// While there are more pages, keep adjusting the offset to get all results.
-	for stillMore, nextOffset = true, 0; stillMore; {
-		response, err := c.newRequestDoOptions("GET", fmt.Sprintf("%s?offset=%d", basePath, nextOffset), nil, nil, nil, reqOptions...)
+	for stillMore, nextOffset = true, qryOptions.currentOffset(); stillMore; {
+		qryOptions.changeOffset(nextOffset)
+		response, err := c.newRequestDoOptionsContext(ctx, "GET", basePath, qryOptions.buildStruct(), nil, nil, reqOptions...)
 		if err != nil {
 			return err
 		}
@@ -272,6 +340,50 @@ func (c *Client) newRequestPagedGetDo(basePath string, handler responseHandler, 
 		// Bump the offset as necessary and set whether more results exist.
 		nextOffset = pageInfo.Offset + pageInfo.Limit
 		stillMore = pageInfo.More
+	}
+
+	return nil
+}
+
+// cursorQueryOptionsGen enables updating the cursor across multiple
+// pages of a list response while retaining query parameters other than the
+// cursor. For list-style functions where the underlying method supports
+// other query parameters, this interface should be implemented to update
+// the cursor when fetching subsequent pages of results.
+type cursorQueryOptionsGen interface {
+	currentCursor() string
+	changeCursor(string)
+	buildStruct() interface{}
+}
+
+func (c *Client) newRequestCursorPagedGetQueryDo(basePath string, handler cursorResponseHandler, qryOptions cursorQueryOptionsGen, reqOptions ...RequestOptions) error {
+	return c.newRequestCursorPagedGetQueryDoContext(context.Background(), basePath, handler, qryOptions, reqOptions...)
+}
+
+func (c *Client) newRequestCursorPagedGetQueryDoContext(ctx context.Context, basePath string, handler cursorResponseHandler, qryOptions cursorQueryOptionsGen, reqOptions ...RequestOptions) error {
+	// Indicates whether there are still additional pages associated with request.
+	var stillMore bool
+
+	// Cursor to set for the next page request.
+	var nextCursor string
+
+	// While there are more pages, keep adjusting the offset to get all results.
+	for stillMore, nextCursor = true, qryOptions.currentCursor(); stillMore; {
+		qryOptions.changeCursor(nextCursor)
+		response, err := c.newRequestDoOptionsContext(ctx, "GET", basePath, qryOptions.buildStruct(), nil, nil, reqOptions...)
+		if err != nil {
+			return err
+		}
+
+		// Call handler to extract page information and execute additional necessary handling.
+		pageInfo, _, err := handler(response)
+		if err != nil {
+			return err
+		}
+
+		// Bump the offset as necessary and set whether more results exist.
+		nextCursor = pageInfo.NextCursor
+		stillMore = nextCursor != ""
 	}
 
 	return nil

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/references.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/references.go
@@ -54,3 +54,7 @@ type RulesetReference resourceReference
 
 // SubscriberReference represents a reference to a subscriber schema
 type SubscriberReference resourceReference
+
+// IncidentAttributeReference represents a reference to a Incident
+// Attribute schema
+type IncidentAttributeReference resourceReference

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -37,6 +37,7 @@ github.com/hashicorp/go-checkpoint
 # github.com/hashicorp/go-cleanhttp v0.5.2
 github.com/hashicorp/go-cleanhttp
 # github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
+## explicit
 github.com/hashicorp/go-cty/cty
 github.com/hashicorp/go-cty/cty/convert
 github.com/hashicorp/go-cty/cty/gocty
@@ -122,7 +123,7 @@ github.com/hashicorp/terraform-registry-address
 github.com/hashicorp/terraform-svchost
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20221219143240-8b7c456b23c6
+# github.com/heimweh/go-pagerduty v0.0.0-20221222221341-c1c27ca3744a
 ## explicit
 github.com/heimweh/go-pagerduty/pagerduty
 # github.com/klauspost/compress v1.15.9

--- a/website/docs/d/incident_workflow.html.markdown
+++ b/website/docs/d/incident_workflow.html.markdown
@@ -1,0 +1,42 @@
+---
+layout: "pagerduty"
+page_title: "PagerDuty: pagerduty_incident_workflow"
+sidebar_current: "docs-pagerduty-datasource-incident-workflow"
+description: |-
+  Get information about an incident workflow.
+---
+
+# pagerduty\_incident\_workflow
+
+Use this data source to get information about a specific [Incident Workflow](https://support.pagerduty.com/docs/incident-workflows) so that you can create a trigger for it.
+
+-> The Incident Workflows feature is currently available in Early Access.
+
+## Example Usage
+
+```hcl
+data "pagerduty_incident_workflow" "my_workflow" {
+  name = "Some Workflow Name"
+}
+
+data "pagerduty_service" "first_service" {
+  name = "My First Service"
+}
+
+resource "pagerduty_incident_workflow_trigger" "automatic_trigger" {
+  type       = "conditional"
+  workflow   = data.pagerduty_incident_workflow.my_workflow.id
+  services   = [data.pagerduty_service.first_service.id]
+  condition  = "incident.priority matches 'P1'"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the workflow.
+
+## Attributes Reference
+
+* `id` - The ID of the found workflow.

--- a/website/docs/r/incident_workflow.html.markdown
+++ b/website/docs/r/incident_workflow.html.markdown
@@ -1,0 +1,71 @@
+---
+layout: "pagerduty"
+page_title: "PagerDuty: pagerduty_incident_workflow"
+sidebar_current: "docs-pagerduty-resource-incident-workflow"
+description: |-
+  Creates and manages an incident workflow in PagerDuty.
+---
+
+# pagerduty\_incident\_workflow
+
+An [Incident Workflow](https://support.pagerduty.com/docs/incident-workflows) is a series of steps which can be executed on an incident.
+
+-> The Incident Workflows feature is currently available in Early Access.
+
+## Example Usage
+
+```hcl
+resource "pagerduty_incident_workflow" "my_first_workflow" {
+  name         = "My First Workflow"
+  description  = "Some description"
+  step {
+    name           = "Example Step"
+    action         = "something"
+    input {
+      name = "name"
+      value = "value"
+    }
+  }
+  step {
+    name          = "Another Step"
+    action        = "something_else"
+    input {
+      name  = "name"
+      value = "value"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the workflow.
+* `description` - (Optional) The description of the workflow.
+* `step` - (Optional) The steps in the workflow.
+
+Each incident workflow step (`step`) supports the following:
+
+* `name` - (Required) The name of the workflow step.
+* `action` - (Required) The action id for the workflow step, including the version.
+* `input` - (Optional) The list of inputs for the workflow action.
+
+Each incident workflow step input (`input`) supports the following:
+
+* `name` - (Required) The name of the input.
+* `value` - (Required) The value of the input.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the incident workflow.
+
+## Import
+
+Incident workflows can be imported using the `id`, e.g.
+
+```
+$ terraform import pagerduty_incident_workflow.major_incident_workflow PLBP09X
+```

--- a/website/docs/r/incident_workflow.html.markdown
+++ b/website/docs/r/incident_workflow.html.markdown
@@ -16,22 +16,14 @@ An [Incident Workflow](https://support.pagerduty.com/docs/incident-workflows) is
 
 ```hcl
 resource "pagerduty_incident_workflow" "my_first_workflow" {
-  name         = "My First Workflow"
-  description  = "Some description"
+  name         = "Example Incident Workflow"
+  description  = "This Incident Workflow is an example"
   step {
-    name           = "Example Step"
-    action         = "something"
+    name           = "Send Status Update"
+    action         = "pagerduty.com:incident-workflows:send-status-update:1"
     input {
-      name = "name"
-      value = "value"
-    }
-  }
-  step {
-    name          = "Another Step"
-    action        = "something_else"
-    input {
-      name  = "name"
-      value = "value"
+      name = "Message"
+      value = "Example status message sent on {{current_date}}"
     }
   }
 }
@@ -48,7 +40,7 @@ The following arguments are supported:
 Each incident workflow step (`step`) supports the following:
 
 * `name` - (Required) The name of the workflow step.
-* `action` - (Required) The action id for the workflow step, including the version.
+* `action` - (Required) The action id for the workflow step, including the version. A list of actions available can be retrieved using the [PagerDuty API](https://developer.pagerduty.com/api-reference/aa192a25fac39-list-actions). 
 * `input` - (Optional) The list of inputs for the workflow action.
 
 Each incident workflow step input (`input`) supports the following:

--- a/website/docs/r/incident_workflow_trigger.html.markdown
+++ b/website/docs/r/incident_workflow_trigger.html.markdown
@@ -1,0 +1,86 @@
+---
+layout: "pagerduty"
+page_title: "PagerDuty: pagerduty_incident_workflow_trigger"
+sidebar_current: "docs-pagerduty-resource-incident-workflow-trigger"
+description: |-
+  Creates and manages an incident workflow trigger in PagerDuty.
+---
+
+# pagerduty\_incident\_workflow\_trigger
+
+An [Incident Workflow Trigger](https://support.pagerduty.com/docs/incident-workflows#triggers) defines when and if an [Incident Workflow](https://support.pagerduty.com/docs/incident-workflows) will be triggered.
+
+-> The Incident Workflows feature is currently available in Early Access.
+
+## Example Usage
+
+```hcl
+resource "pagerduty_incident_workflow" "my_first_workflow" {
+  name         = "My First Workflow"
+  description  = "Some description"
+  step {
+    name           = "Example Step"
+    description    = "An example workflow step"
+    action         = "something"
+    input {
+      name = "name"
+      value = "value"
+    }
+  }
+  step {
+    name          = "Another Step"
+    action        = "something_else"
+    input {
+      name  = "name"
+      value = "value"
+    }
+  }
+}
+
+data "pagerduty_service" "first_service" {
+  name = "My First Service"
+}
+
+resource "pagerduty_incident_workflow_trigger" "automatic_trigger" {
+  type                       = "conditional"
+  workflow                   = pagerduty_incident_workflow.my_first_workflow.id
+  services                   = [pagerduty_service.first_service.id]
+  condition                  = "incident.priority matches 'P1'"
+  subscribed_to_all_services = false
+}
+
+data "pagerduty_team" "devops" {
+  name = "devops"
+}
+
+resource "pagerduty_incident_workflow_trigger" "manual_trigger" {
+  type       = "manual"
+  workflow   = pagerduty_incident_workflow.my_first_workflow.id
+  services   = [pagerduty_service.first_service.id]
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `type` - (Required) May be either `manual` or `conditional`.
+* `workflow` - (Required) The workflow ID for the workflow to trigger.
+* `services` - (Optional) A list of service IDs. Incidents in any of the listed services are eligible to fire this trigger.
+* `subscribed_to_all_services` - (Required) Set to `true` if the trigger should be eligible for firing on all services. Only allowed to be `true` if the services list is not defined or empty.
+* `condition` - (Required for `conditional`-type triggers) A [PCL](https://developer.pagerduty.com/docs/ZG9jOjM1NTE0MDc0-pcl-overview) condition string which must be satisfied for the trigger to fire.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the incident workflow.
+
+## Import
+
+Incident workflows can be imported using the `id`, e.g.
+
+```
+$ terraform import pagerduty_incident_workflow.pagerduty_incident_workflow_trigger PLBP09X
+```

--- a/website/docs/r/incident_workflow_trigger.html.markdown
+++ b/website/docs/r/incident_workflow_trigger.html.markdown
@@ -16,23 +16,14 @@ An [Incident Workflow Trigger](https://support.pagerduty.com/docs/incident-workf
 
 ```hcl
 resource "pagerduty_incident_workflow" "my_first_workflow" {
-  name         = "My First Workflow"
-  description  = "Some description"
+  name         = "Example Incident Workflow"
+  description  = "This Incident Workflow is an example"
   step {
-    name           = "Example Step"
-    description    = "An example workflow step"
-    action         = "something"
+    name           = "Send Status Update"
+    action         = "pagerduty.com:incident-workflows:send-status-update:1"
     input {
-      name = "name"
-      value = "value"
-    }
-  }
-  step {
-    name          = "Another Step"
-    action        = "something_else"
-    input {
-      name  = "name"
-      value = "value"
+      name = "Message"
+      value = "Example status message sent on {{current_date}}"
     }
   }
 }


### PR DESCRIPTION
This adds support for the new PagerDuty Incident Workflows (both Data Source and Resource) and Incident Workflow Triggers (Resource only) features. These are currently in Early Access and not available to all accounts.

Acceptance tests are gated behind an environment variable `PAGERDUTY_ACC_INCIDENT_WORKFLOWS`. This can be set to any value, but `1` is recommended for consistency with `TF_ACC`:

```
$ PAGERDUTY_ACC_INCIDENT_WORKFLOWS=1 make testacc TESTARGS="-run PagerDutyIncidentWorkflow"                              
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run PagerDutyIncidentWorkflow -timeout 120m
?       github.com/terraform-providers/terraform-provider-pagerduty     [no test files]
=== RUN   TestAccDataSourcePagerDutyIncidentWorkflow
--- PASS: TestAccDataSourcePagerDutyIncidentWorkflow (7.46s)
=== RUN   TestAccDataSourcePagerDutyIncidentWorkflow_Missing
--- PASS: TestAccDataSourcePagerDutyIncidentWorkflow_Missing (1.46s)
=== RUN   TestAccPagerDutyIncidentWorkflow_import
--- PASS: TestAccPagerDutyIncidentWorkflow_import (7.93s)
=== RUN   TestAccPagerDutyIncidentWorkflowTrigger_import
--- PASS: TestAccPagerDutyIncidentWorkflowTrigger_import (14.32s)
=== RUN   TestAccPagerDutyIncidentWorkflow_Basic
--- PASS: TestAccPagerDutyIncidentWorkflow_Basic (10.26s)
=== RUN   TestAccPagerDutyIncidentWorkflowTrigger_BadType
--- PASS: TestAccPagerDutyIncidentWorkflowTrigger_BadType (1.09s)
=== RUN   TestAccPagerDutyIncidentWorkflowTrigger_ConditionWithManualType
--- PASS: TestAccPagerDutyIncidentWorkflowTrigger_ConditionWithManualType (1.21s)
=== RUN   TestAccPagerDutyIncidentWorkflowTrigger_ConditionalTypeWithoutCondition
--- PASS: TestAccPagerDutyIncidentWorkflowTrigger_ConditionalTypeWithoutCondition (1.39s)
=== RUN   TestAccPagerDutyIncidentWorkflowTrigger_SubscribedToAllWithInvalidServices
--- PASS: TestAccPagerDutyIncidentWorkflowTrigger_SubscribedToAllWithInvalidServices (1.81s)
=== RUN   TestAccPagerDutyIncidentWorkflowTrigger_BasicManual
--- PASS: TestAccPagerDutyIncidentWorkflowTrigger_BasicManual (13.77s)
=== RUN   TestAccPagerDutyIncidentWorkflowTrigger_BasicConditionalAllServices
--- PASS: TestAccPagerDutyIncidentWorkflowTrigger_BasicConditionalAllServices (11.13s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   72.205s
```

As mentioned in https://github.com/heimweh/go-pagerduty/pull/104, I have tried to avoid the use of deprecated APIs which means these resources/datasources use slightly different patterns than the existing ones, e.g. `CreateContext` vs. `Create`. The same applies to the tests, where `ProviderFactories` is used instead of `Providers`. Refactoring existing resources/data sources/tests is a useful exercise but not in scope of this PR.