### PR TITLE
[ORCA-3828] Return warnings when updating Event Orchestration Path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go v0.71.0 // indirect
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.1
+	// TODO: update the version of github.com/heimweh/go-pagerduty once https://github.com/heimweh/go-pagerduty/pull/105 is merged
 	github.com/heimweh/go-pagerduty v0.0.0-20230117201746-310c225f8600
 	github.com/klauspost/compress v1.15.9 // indirect
 	github.com/montanaflynn/stats v0.6.6 // indirect
@@ -17,5 +18,3 @@ require (
 	google.golang.org/genproto v0.0.0-20201109203340-2640f1f9cdfb // indirect
 	google.golang.org/grpc v1.33.2 // indirect
 )
-
-replace github.com/heimweh/go-pagerduty => ../../alenapan/go-pagerduty

--- a/go.mod
+++ b/go.mod
@@ -17,3 +17,5 @@ require (
 	google.golang.org/genproto v0.0.0-20201109203340-2640f1f9cdfb // indirect
 	google.golang.org/grpc v1.33.2 // indirect
 )
+
+replace github.com/heimweh/go-pagerduty => ../../alenapan/go-pagerduty

--- a/pagerduty/event_orchestration_path_util.go
+++ b/pagerduty/event_orchestration_path_util.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/heimweh/go-pagerduty/pagerduty"
 )
@@ -222,4 +223,21 @@ func flattenEventOrchestrationPathExtractions(e []*pagerduty.EventOrchestrationP
 		res = append(res, e)
 	}
 	return res
+}
+
+func convertEventOrchestrationPathWarningsToDiagnostics(warnings []*pagerduty.EventOrchestrationPathWarning, diags diag.Diagnostics) diag.Diagnostics {
+	if warnings == nil {
+		return diags
+	}
+
+	for _, warning := range warnings {
+		diag := diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  warning.Message,
+			Detail:   fmt.Sprintf("Feature: %s\nFeature Type: %s\nRule ID: %s\nWarning Type: %s", warning.Feature, warning.FeatureType, warning.RuleId, warning.WarningType),
+		}
+		diags = append(diags, diag)
+	}
+
+	return diags
 }

--- a/pagerduty/resource_pagerduty_event_orchestration_path_service_test.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_service_test.go
@@ -650,7 +650,6 @@ func testAccCheckPagerDutyEventOrchestrationPathServiceAllActionsUpdateConfig(ep
 			catch_all {
 				actions {
 					suspend = 360
-					suppress = true
 					priority = "P0IN2KX"
 					annotate = "[UPD] Routed through an event orchestration - catch-all rule"
 					pagerduty_automation_action {

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/event_orchestration_path.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/event_orchestration_path.go
@@ -97,8 +97,17 @@ type EventOrchestrationPathCatchAll struct {
 	Actions *EventOrchestrationPathRuleActions `json:"actions,omitempty"`
 }
 
+type EventOrchestrationPathWarning struct {
+	Feature string `json:"feature"`
+	FeatureType string `json:"feature_type"`
+	Message string `json:"message"`
+	RuleId string `json:"rule_id"`
+	WarningType string `json:"warning_type"`
+}
+
 type EventOrchestrationPathPayload struct {
 	OrchestrationPath *EventOrchestrationPath `json:"orchestration_path,omitempty"`
+	Warnings []*EventOrchestrationPathWarning `json:"warnings"`
 }
 
 const PathTypeRouter string = "router"
@@ -133,7 +142,7 @@ func (s *EventOrchestrationPathService) Get(id string, pathType string) (*EventO
 }
 
 // Update for EventOrchestrationPath
-func (s *EventOrchestrationPathService) Update(id string, pathType string, orchestration_path *EventOrchestrationPath) (*EventOrchestrationPath, *Response, error) {
+func (s *EventOrchestrationPathService) Update(id string, pathType string, orchestration_path *EventOrchestrationPath) (*EventOrchestrationPathPayload, *Response, error) {
 	u := orchestrationPathUrlBuilder(id, pathType)
 	v := new(EventOrchestrationPathPayload)
 	p := EventOrchestrationPathPayload{OrchestrationPath: orchestration_path}
@@ -143,5 +152,5 @@ func (s *EventOrchestrationPathService) Update(id string, pathType string, orche
 		return nil, nil, err
 	}
 
-	return v.OrchestrationPath, resp, nil
+	return v, resp, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -350,3 +350,4 @@ google.golang.org/protobuf/types/known/anypb
 google.golang.org/protobuf/types/known/durationpb
 google.golang.org/protobuf/types/known/emptypb
 google.golang.org/protobuf/types/known/timestamppb
+# github.com/heimweh/go-pagerduty => ../../alenapan/go-pagerduty

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -350,4 +350,3 @@ google.golang.org/protobuf/types/known/anypb
 google.golang.org/protobuf/types/known/durationpb
 google.golang.org/protobuf/types/known/emptypb
 google.golang.org/protobuf/types/known/timestamppb
-# github.com/heimweh/go-pagerduty => ../../alenapan/go-pagerduty


### PR DESCRIPTION
## Changes
This PR updates the following resources to display a list of warnings returned by the Event Orchestration Path Update endpoint to the Provider user:
- pagerduty_event_orchestration_router
- pagerduty_event_orchestration_unrouted
- pagerduty_event_orchestration_service

The following changes have been made to each of the aforementioned resources:
- Switched the resource to using context-aware methods (ReadContext, CreateContext, UpdateContext, DeleteContext). We need to use these methods in order to return a collection of [Diagnostics](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/diag)
- Updated signatures of the CRUD handler functions to accept `context.Context` as the first argument and return diag.Diagnostics (this is what the new methods require)
- Modified the bodies of the CRUD handler functions to return `diag.Diagnostics` instead of `error` or `nil`

## Before Merging
⚠️ We need to update the version of the API Client after https://github.com/heimweh/go-pagerduty/pull/105 is merged


## Testing
### Acceptance Tests
- [x] Event Orchestration Acceptance Tests are passing
<img width="1025" alt="image" src="https://user-images.githubusercontent.com/47909261/207728001-fdcad6b8-98b5-494a-9717-1aa09ee067a4.png">


### Testing Event Orchestration Config with the Local Copy of the Provider

https://github.com/PagerDuty/terraform-provider-pagerduty-internal/pull/3

**Account that should see no warnings (used the personal account in prod)**

- [x] Creating a new service, orchestration, router, unrouted, and service paths works:
```cmd
Plan: 5 to add, 0 to change, 0 to destroy.
pagerduty_event_orchestration.orca_3828_test_tf_warning: Creating...
pagerduty_service.orca_3828: Creating...
pagerduty_service.orca_3828: Creation complete after 1s [id=P3RJ6G4]
pagerduty_event_orchestration.orca_3828_test_tf_warning: Creation complete after 1s [id=4399925b-3c90-44b5-a104-91b7b28b7475]
data.pagerduty_event_orchestration.data_orca_3828_test_tf_warning: Reading...
pagerduty_event_orchestration_router.orca_3828_test_tf_warning_router: Creating...
pagerduty_event_orchestration_unrouted.orca_3828_test_tf_warning_unrouted: Creating...
data.pagerduty_event_orchestration.data_orca_3828_test_tf_warning: Read complete after 0s [id=4399925b-3c90-44b5-a104-91b7b28b7475]
pagerduty_event_orchestration_unrouted.orca_3828_test_tf_warning_unrouted: Creation complete after 0s [id=4399925b-3c90-44b5-a104-91b7b28b7475]
pagerduty_event_orchestration_router.orca_3828_test_tf_warning_router: Creation complete after 0s [id=4399925b-3c90-44b5-a104-91b7b28b7475]
pagerduty_event_orchestration_service.orca_3828_test_tf_warning_service: Creating...
pagerduty_event_orchestration_service.orca_3828_test_tf_warning_service: Creation complete after 0s [id=P3RJ6G4]

Apply complete! Resources: 5 added, 0 changed, 0 destroyed.
```
Orchestration:
<img width="1150" alt="image" src="https://user-images.githubusercontent.com/47909261/207714999-c51f5404-577d-44c6-9a40-17510788b70e.png">

Router:
<img width="1171" alt="image" src="https://user-images.githubusercontent.com/47909261/207715247-a542003d-480f-48b3-980a-55ae79c1644f.png">

Unrouted:
<img width="1163" alt="image" src="https://user-images.githubusercontent.com/47909261/207717425-11004d79-7275-47bc-a15b-070f2e555ede.png">

Service:
<img width="1174" alt="image" src="https://user-images.githubusercontent.com/47909261/207717727-fe0a8769-4af8-4738-884f-1faff4116814.png">

- [ ] Updating orchestration, router, unrouted, and service paths works:

```cmd
Plan: 0 to add, 4 to change, 0 to destroy.
pagerduty_event_orchestration.orca_3828_test_tf_warning: Modifying... [id=4399925b-3c90-44b5-a104-91b7b28b7475]
pagerduty_event_orchestration.orca_3828_test_tf_warning: Modifications complete after 1s [id=4399925b-3c90-44b5-a104-91b7b28b7475]
data.pagerduty_event_orchestration.data_orca_3828_test_tf_warning: Reading... [id=4399925b-3c90-44b5-a104-91b7b28b7475]
pagerduty_event_orchestration_router.orca_3828_test_tf_warning_router: Modifying... [id=4399925b-3c90-44b5-a104-91b7b28b7475]
pagerduty_event_orchestration_unrouted.orca_3828_test_tf_warning_unrouted: Modifying... [id=4399925b-3c90-44b5-a104-91b7b28b7475]
pagerduty_event_orchestration_router.orca_3828_test_tf_warning_router: Modifications complete after 0s [id=4399925b-3c90-44b5-a104-91b7b28b7475]
pagerduty_event_orchestration_unrouted.orca_3828_test_tf_warning_unrouted: Modifications complete after 0s [id=4399925b-3c90-44b5-a104-91b7b28b7475]
data.pagerduty_event_orchestration.data_orca_3828_test_tf_warning: Read complete after 1s [id=4399925b-3c90-44b5-a104-91b7b28b7475]
pagerduty_event_orchestration_service.orca_3828_test_tf_warning_service: Modifying... [id=P3RJ6G4]
pagerduty_event_orchestration_service.orca_3828_test_tf_warning_service: Modifications complete after 0s [id=P3RJ6G4]

Apply complete! Resources: 0 added, 4 changed, 0 destroyed.
```


**Account that should see warnings (used the personal account in staging and pointed local copy of the provider to staging)**

```hcl
# Configure the PagerDuty provider
provider "pagerduty" {
  token = var.pagerduty_token
  api_url_override = "https://api.pd-staging.com"
}
```

- [x] Creating a new service, orchestration, router, unrouted, and service paths works:
```cmd
Plan: 9 to add, 0 to change, 0 to destroy.
pagerduty_team.tf_team: Creating...
pagerduty_team.tf_team: Creation complete after 1s [id=PAFN6U0]
pagerduty_escalation_policy.tf_escalation: Creating...
pagerduty_event_orchestration.orca_3828_test_tf_warning: Creating...
pagerduty_event_orchestration.orca_3828_test_tf_warning: Creation complete after 1s [id=3fb77ba2-959d-46a7-9690-a4e65fc89115]
data.pagerduty_event_orchestration.data_orca_3828_test_tf_warning: Reading...
pagerduty_event_orchestration_unrouted.orca_3828_test_tf_warning_unrouted: Creating...
pagerduty_escalation_policy.tf_escalation: Creation complete after 1s [id=P1S05CE]
pagerduty_service.orca_3828: Creating...
pagerduty_service.web: Creating...
pagerduty_service.db: Creating...
pagerduty_event_orchestration_unrouted.orca_3828_test_tf_warning_unrouted: Creation complete after 0s [id=3fb77ba2-959d-46a7-9690-a4e65fc89115]
data.pagerduty_event_orchestration.data_orca_3828_test_tf_warning: Read complete after 0s [id=3fb77ba2-959d-46a7-9690-a4e65fc89115]
pagerduty_service.web: Creation complete after 0s [id=P9PBKUK]
pagerduty_service.orca_3828: Creation complete after 0s [id=P5DQJFX]
pagerduty_event_orchestration_service.orca_3828_test_tf_warning_service: Creating...
pagerduty_event_orchestration_service.orca_3828_test_tf_warning_service: Creation complete after 0s [id=P5DQJFX]
pagerduty_service.db: Creation complete after 1s [id=P242J37]
pagerduty_event_orchestration_router.orca_3828_test_tf_warning_router: Creating...
pagerduty_event_orchestration_router.orca_3828_test_tf_warning_router: Creation complete after 0s [id=3fb77ba2-959d-46a7-9690-a4e65fc89115]
╷
│ Warning: This rule uses Dynamic Field Enrichment & Extraction, which is an action not available on your account plan. The rule will be updated, but the action will not be fired when the rule is evaluated
│ 
│   with pagerduty_event_orchestration_unrouted.orca_3828_test_tf_warning_unrouted,
│   on main.tf line 97, in resource "pagerduty_event_orchestration_unrouted" "orca_3828_test_tf_warning_unrouted":
│   97: resource "pagerduty_event_orchestration_unrouted" "orca_3828_test_tf_warning_unrouted" {
│ 
│ Feature: variables
│ Feature Type: actions
│ Rule ID: catch_all
│ Warning Type: forbidden_feature
│ 
│ (and 11 more similar warnings elsewhere)
╵
╷
│ Warning: This rule uses Alert Suppression, which is an action not available on your account plan. The rule will be updated, but the action will not be fired when the rule is evaluated
│ 
│   with pagerduty_event_orchestration_service.orca_3828_test_tf_warning_service,
│   on main.tf line 210, in resource "pagerduty_event_orchestration_service" "orca_3828_test_tf_warning_service":
│  210: resource "pagerduty_event_orchestration_service" "orca_3828_test_tf_warning_service" {
│ 
│ Feature: suppress
│ Feature Type: actions
│ Rule ID: catch_all
│ Warning Type: forbidden_feature
│ 
│ (and one more similar warning elsewhere)
╵
╷
│ Warning: This rule uses PagerDuty Automation Actions, which is an action not available on your account plan. The rule will be updated, but the action will not be fired when the rule is evaluated
│ 
│   with pagerduty_event_orchestration_service.orca_3828_test_tf_warning_service,
│   on main.tf line 210, in resource "pagerduty_event_orchestration_service" "orca_3828_test_tf_warning_service":
│  210: resource "pagerduty_event_orchestration_service" "orca_3828_test_tf_warning_service" {
│ 
│ Feature: pagerduty_automation_actions
│ Feature Type: actions
│ Rule ID: catch_all
│ Warning Type: forbidden_feature
│ 
│ (and one more similar warning elsewhere)
╵

Apply complete! Resources: 9 added, 0 changed, 0 destroyed.
```

Orchestration:
<img width="1138" alt="image" src="https://user-images.githubusercontent.com/47909261/207735932-720db120-aa45-4ead-904a-2e9ee115ae43.png">

Router:
<img width="1152" alt="image" src="https://user-images.githubusercontent.com/47909261/207736023-db4db6ab-80e9-482c-a327-b82185e9ed56.png">

Unrouted:
<img width="1138" alt="image" src="https://user-images.githubusercontent.com/47909261/207736137-428619bc-fe55-48e7-ab87-fedccccad42c.png">

Service:
<img width="1172" alt="image" src="https://user-images.githubusercontent.com/47909261/207736309-1f3b8c2d-19a4-41b7-b8dd-7a807bdbe2ff.png">



- [x] Updating orchestration, router, unrouted, and service paths works:
```hcl
Plan: 0 to add, 4 to change, 0 to destroy.
pagerduty_event_orchestration.orca_3828_test_tf_warning: Modifying... [id=3fb77ba2-959d-46a7-9690-a4e65fc89115]
pagerduty_event_orchestration.orca_3828_test_tf_warning: Modifications complete after 1s [id=3fb77ba2-959d-46a7-9690-a4e65fc89115]
data.pagerduty_event_orchestration.data_orca_3828_test_tf_warning: Reading... [id=3fb77ba2-959d-46a7-9690-a4e65fc89115]
pagerduty_event_orchestration_router.orca_3828_test_tf_warning_router: Modifying... [id=3fb77ba2-959d-46a7-9690-a4e65fc89115]
pagerduty_event_orchestration_unrouted.orca_3828_test_tf_warning_unrouted: Modifying... [id=3fb77ba2-959d-46a7-9690-a4e65fc89115]
pagerduty_event_orchestration_router.orca_3828_test_tf_warning_router: Modifications complete after 0s [id=3fb77ba2-959d-46a7-9690-a4e65fc89115]
data.pagerduty_event_orchestration.data_orca_3828_test_tf_warning: Read complete after 0s [id=3fb77ba2-959d-46a7-9690-a4e65fc89115]
pagerduty_event_orchestration_service.orca_3828_test_tf_warning_service: Modifying... [id=P5DQJFX]
pagerduty_event_orchestration_unrouted.orca_3828_test_tf_warning_unrouted: Modifications complete after 0s [id=3fb77ba2-959d-46a7-9690-a4e65fc89115]
pagerduty_event_orchestration_service.orca_3828_test_tf_warning_service: Modifications complete after 0s [id=P5DQJFX]
╷
│ Warning: This rule uses Dynamic Field Enrichment & Extraction, which is an action not available on your account plan. The rule will be updated, but the action will not be fired when the rule is evaluated
│ 
│   with pagerduty_event_orchestration_unrouted.orca_3828_test_tf_warning_unrouted,
│   on main.tf line 97, in resource "pagerduty_event_orchestration_unrouted" "orca_3828_test_tf_warning_unrouted":
│   97: resource "pagerduty_event_orchestration_unrouted" "orca_3828_test_tf_warning_unrouted" {
│ 
│ Feature: variables
│ Feature Type: actions
│ Rule ID: catch_all
│ Warning Type: forbidden_feature
│ 
│ (and 11 more similar warnings elsewhere)
╵
╷
│ Warning: This rule uses Alert Suppression, which is an action not available on your account plan. The rule will be updated, but the action will not be fired when the rule is evaluated
│ 
│   with pagerduty_event_orchestration_service.orca_3828_test_tf_warning_service,
│   on main.tf line 210, in resource "pagerduty_event_orchestration_service" "orca_3828_test_tf_warning_service":
│  210: resource "pagerduty_event_orchestration_service" "orca_3828_test_tf_warning_service" {
│ 
│ Feature: suppress
│ Feature Type: actions
│ Rule ID: catch_all
│ Warning Type: forbidden_feature
│ 
│ (and one more similar warning elsewhere)
╵
╷
│ Warning: This rule uses PagerDuty Automation Actions, which is an action not available on your account plan. The rule will be updated, but the action will not be fired when the rule is evaluated
│ 
│   with pagerduty_event_orchestration_service.orca_3828_test_tf_warning_service,
│   on main.tf line 210, in resource "pagerduty_event_orchestration_service" "orca_3828_test_tf_warning_service":
│  210: resource "pagerduty_event_orchestration_service" "orca_3828_test_tf_warning_service" {
│ 
│ Feature: pagerduty_automation_actions
│ Feature Type: actions
│ Rule ID: catch_all
│ Warning Type: forbidden_feature
│ 
│ (and one more similar warning elsewhere)
╵

Apply complete! Resources: 0 added, 4 changed, 0 destroyed.
```