### PR TITLE
Add support for data.pagerduty_automation_actions_action

### DIFF
--- a/pagerduty/data_source_pagerduty_automation_actions_action.go
+++ b/pagerduty/data_source_pagerduty_automation_actions_action.go
@@ -1,0 +1,145 @@
+package pagerduty
+
+import (
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourcePagerDutyAutomationActionsAction() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourcePagerDutyAutomationActionsActionRead,
+
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"action_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"runner_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"action_data_reference": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"process_automation_job_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"process_automation_job_arguments": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"script": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"invocation_command": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+			"action_classification": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"runner_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"creation_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+			"modify_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourcePagerDutyAutomationActionsActionRead(d *schema.ResourceData, meta interface{}) error {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] Reading PagerDuty AutomationActionsAction")
+
+	return resource.Retry(1*time.Minute, func() *resource.RetryError {
+		automationActionsAction, _, err := client.AutomationActionsAction.Get(d.Get("id").(string))
+		if err != nil {
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
+			return resource.RetryableError(err)
+		}
+
+		d.SetId(automationActionsAction.ID)
+		d.Set("name", automationActionsAction.Name)
+		d.Set("type", automationActionsAction.Type)
+		d.Set("action_type", automationActionsAction.ActionType)
+		d.Set("creation_time", automationActionsAction.CreationTime)
+
+		if automationActionsAction.Description != nil {
+			d.Set("description", &automationActionsAction.Description)
+		}
+
+		f_adr := flattenActionDataReference(automationActionsAction.ActionDataReference)
+		if err := d.Set("action_data_reference", f_adr); err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		if automationActionsAction.ModifyTime != nil {
+			d.Set("modify_time", &automationActionsAction.ModifyTime)
+		}
+
+		if automationActionsAction.RunnerID != nil {
+			d.Set("runner_id", &automationActionsAction.RunnerID)
+		}
+
+		if automationActionsAction.RunnerType != nil {
+			d.Set("runner_type", &automationActionsAction.RunnerType)
+		}
+
+		if automationActionsAction.ActionClassification != nil {
+			d.Set("action_classification", &automationActionsAction.ActionClassification)
+		}
+
+		return nil
+	})
+}

--- a/pagerduty/data_source_pagerduty_automation_actions_action_test.go
+++ b/pagerduty/data_source_pagerduty_automation_actions_action_test.go
@@ -1,0 +1,83 @@
+package pagerduty
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccDataSourcePagerDutyAutomationActionsAction_Basic(t *testing.T) {
+	name := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourcePagerDutyAutomationActionsActionConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourcePagerdutyAutomationActionsAction("pagerduty_automation_actions_action.test", "data.pagerduty_automation_actions_action.foo"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourcePagerdutyAutomationActionsAction(rName, dsName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		srcR := s.RootModule().Resources[rName]
+		srcA := srcR.Primary.Attributes
+
+		ds, ok := s.RootModule().Resources[dsName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", dsName)
+		}
+		dsA := ds.Primary.Attributes
+
+		if dsA["id"] == "" {
+			return fmt.Errorf("No Action ID is set")
+		}
+
+		testAtts := []string{"id", "name", "description", "action_type", "runner_id", "action_data_reference", "type", "action_classification", "runner_type", "creation_time", "modify_time"}
+
+		for _, att := range testAtts {
+			if dsA[att] != srcA[att] {
+				return fmt.Errorf("Expected the action %s to be: %s, but got: %s", att, srcA[att], dsA[att])
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccDataSourcePagerDutyAutomationActionsActionConfig(actionName string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_automation_actions_runner" "foo_runner" {
+	name = "%s runner"
+	description = "Runner created by TF"
+	runner_type = "runbook"
+	runbook_base_uri = "cat-cat"
+	runbook_api_key = "cat-secret"
+}
+
+resource "pagerduty_automation_actions_action" "test" {
+	name = "%s"
+	description = "PA Action created by TF"
+	action_type = "process_automation"
+	action_classification = "diagnostic"
+	runner_id = pagerduty_automation_actions_runner.foo_runner.id
+	action_data_reference {
+		process_automation_job_id = "pa_job_id_123"
+		process_automation_job_arguments = "-arg 1"
+	  }
+}
+
+data "pagerduty_automation_actions_action" "foo" {
+  id = pagerduty_automation_actions_action.test.id
+}
+`, actionName, actionName)
+}

--- a/pagerduty/provider.go
+++ b/pagerduty/provider.go
@@ -62,6 +62,7 @@ func Provider() *schema.Provider {
 			"pagerduty_tag":                       dataSourcePagerDutyTag(),
 			"pagerduty_event_orchestration":       dataSourcePagerDutyEventOrchestration(),
 			"pagerduty_automation_actions_runner": dataSourcePagerDutyAutomationActionsRunner(),
+			"pagerduty_automation_actions_action": dataSourcePagerDutyAutomationActionsAction(),
 			"pagerduty_incident_workflow":         dataSourcePagerDutyIncidentWorkflow(),
 		},
 

--- a/website/docs/d/automation_actions_action.html.markdown
+++ b/website/docs/d/automation_actions_action.html.markdown
@@ -1,0 +1,50 @@
+---
+layout: "pagerduty"
+page_title: "PagerDuty: pagerduty_automation_actions_action"
+sidebar_current: "docs-pagerduty-datasource-automation-actions-action"
+description: |-
+  Get information about an Automation Actions action that you have created.
+---
+
+# pagerduty\_automation\_actions\_action
+
+Use this data source to get information about a specific [automation actions action][1].
+
+## Example Usage
+
+```hcl
+data "pagerduty_automation_actions_action" "example" {
+  id = "01CS1685B2UDM4I3XUUOXPPORM"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `id` - (Required) The id of the automation actions action in the PagerDuty API.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the action.
+* `name` - The name of the action.
+* `type` - The type of object. The value returned will be `action`.
+* `action_type` - The type of the action. The only allowed values are `process_automation` and `script`. 
+* `creation_time` - The time action was created. Represented as an ISO 8601 timestamp.
+* `action_data_reference` - Action Data block. Action Data is documented below.
+* `description` - (Optional) The description of the action.
+* `runner_id` - (Optional) The Process Automation Actions runner to associate the action with. 
+* `runner_type` - (Optional) The type of the runner associated with the action.
+* `action_classification` - (Optional) The category of the action. The only allowed values are `diagnostic` and `remediation`. 
+* `modify_time` - (Optional) The last time action has been modified. Represented as an ISO 8601 timestamp.
+
+Action Data (`action_data_reference`) supports the following:
+
+  * `process_automation_job_id` - (Required for `process_automation` action_type) The ID of the Process Automation job to execute.
+  * `process_automation_job_arguments` - (Optional) The arguments to pass to the Process Automation job execution.
+  * `script` - (Required for `script` action_type) Body of the script to be executed on the Runner. Max length is 16777215 characters.
+  * `invocation_command` - (Optional) The command to execute the script with.
+
+[1]: https://developer.pagerduty.com/api-reference/357ed15419f64-get-an-automation-action


### PR DESCRIPTION
Add support for data.pagerduty_automation_actions_action

New test cases introduced:
```
make testacc TESTARGS="-run TestAccDataSourcePagerDutyAutomationActionsAction_Basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccDataSourcePagerDutyAutomationActionsAction_Basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-pagerduty	[no test files]
=== RUN   TestAccDataSourcePagerDutyAutomationActionsAction_Basic
--- PASS: TestAccDataSourcePagerDutyAutomationActionsAction_Basic (10.13s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	10.471s
```