### PR TITLE
replace ValidateValueFunc with ValidateValueDiagFunc due to deprecation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	cloud.google.com/go v0.71.0 // indirect
+	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.1
 	github.com/heimweh/go-pagerduty v0.0.0-20221222221341-c1c27ca3744a
 	github.com/klauspost/compress v1.15.9 // indirect

--- a/pagerduty/event_orchestration_path_util.go
+++ b/pagerduty/event_orchestration_path_util.go
@@ -77,8 +77,8 @@ func invalidExtractionRegexNilSourceConfig() string {
 		}`
 }
 
-func validateEventOrchestrationPathSeverity() schema.SchemaValidateFunc {
-	return validateValueFunc([]string{
+func validateEventOrchestrationPathSeverity() schema.SchemaValidateDiagFunc {
+	return validateValueDiagFunc([]string{
 		"info",
 		"error",
 		"warning",
@@ -86,8 +86,8 @@ func validateEventOrchestrationPathSeverity() schema.SchemaValidateFunc {
 	})
 }
 
-func validateEventOrchestrationPathEventAction() schema.SchemaValidateFunc {
-	return validateValueFunc([]string{
+func validateEventOrchestrationPathEventAction() schema.SchemaValidateDiagFunc {
+	return validateValueDiagFunc([]string{
 		"trigger",
 		"resolve",
 	})

--- a/pagerduty/resource_pagerduty_automation_actions_action.go
+++ b/pagerduty/resource_pagerduty_automation_actions_action.go
@@ -32,7 +32,7 @@ func resourcePagerDutyAutomationActionsAction() *schema.Resource {
 			"action_type": {
 				Type:     schema.TypeString,
 				Required: true,
-				ValidateFunc: validateValueFunc([]string{
+				ValidateDiagFunc: validateValueDiagFunc([]string{
 					"script",
 					"process_automation",
 				}),
@@ -81,7 +81,7 @@ func resourcePagerDutyAutomationActionsAction() *schema.Resource {
 			"action_classification": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ValidateFunc: validateValueFunc([]string{
+				ValidateDiagFunc: validateValueDiagFunc([]string{
 					"diagnostic",
 					"remediation",
 				}),

--- a/pagerduty/resource_pagerduty_automation_actions_runner.go
+++ b/pagerduty/resource_pagerduty_automation_actions_runner.go
@@ -27,7 +27,7 @@ func resourcePagerDutyAutomationActionsRunner() *schema.Resource {
 			"runner_type": {
 				Type:     schema.TypeString,
 				Required: true,
-				ValidateFunc: validateValueFunc([]string{
+				ValidateDiagFunc: validateValueDiagFunc([]string{
 					"sidecar",
 					"runbook",
 				}),

--- a/pagerduty/resource_pagerduty_business_service.go
+++ b/pagerduty/resource_pagerduty_business_service.go
@@ -45,7 +45,7 @@ func resourcePagerDutyBusinessService() *schema.Resource {
 				Optional:   true,
 				Default:    "business_service",
 				Deprecated: "This will change to a computed resource in the next major release.",
-				ValidateFunc: validateValueFunc([]string{
+				ValidateDiagFunc: validateValueDiagFunc([]string{
 					"business_service",
 				}),
 			},

--- a/pagerduty/resource_pagerduty_business_service_subscriber.go
+++ b/pagerduty/resource_pagerduty_business_service_subscriber.go
@@ -29,7 +29,7 @@ func resourcePagerDutyBusinessServiceSubscriber() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-				ValidateFunc: validateValueFunc([]string{
+				ValidateDiagFunc: validateValueDiagFunc([]string{
 					"team",
 					"user",
 				}),

--- a/pagerduty/resource_pagerduty_escalation_policy.go
+++ b/pagerduty/resource_pagerduty_escalation_policy.go
@@ -66,7 +66,7 @@ func resourcePagerDutyEscalationPolicy() *schema.Resource {
 										Type:     schema.TypeString,
 										Optional: true,
 										Default:  "user_reference",
-										ValidateFunc: validateValueFunc([]string{
+										ValidateDiagFunc: validateValueDiagFunc([]string{
 											"user_reference",
 											"schedule_reference",
 										}),

--- a/pagerduty/resource_pagerduty_event_orchestration_path_service.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_service.go
@@ -87,14 +87,14 @@ var eventOrchestrationPathServiceCatchAllActionsSchema = map[string]*schema.Sche
 		},
 	},
 	"severity": {
-		Type:         schema.TypeString,
-		Optional:     true,
-		ValidateFunc: validateEventOrchestrationPathSeverity(),
+		Type:             schema.TypeString,
+		Optional:         true,
+		ValidateDiagFunc: validateEventOrchestrationPathSeverity(),
 	},
 	"event_action": {
-		Type:         schema.TypeString,
-		Optional:     true,
-		ValidateFunc: validateEventOrchestrationPathEventAction(),
+		Type:             schema.TypeString,
+		Optional:         true,
+		ValidateDiagFunc: validateEventOrchestrationPathEventAction(),
 	},
 	"variable": {
 		Type:     schema.TypeList,

--- a/pagerduty/resource_pagerduty_event_orchestration_path_unrouted.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_unrouted.go
@@ -66,14 +66,14 @@ func resourcePagerDutyEventOrchestrationPathUnrouted() *schema.Resource {
 													Optional: true, // If there is only start set we don't need route_to
 												},
 												"severity": {
-													Type:         schema.TypeString,
-													Optional:     true,
-													ValidateFunc: validateEventOrchestrationPathSeverity(),
+													Type:             schema.TypeString,
+													Optional:         true,
+													ValidateDiagFunc: validateEventOrchestrationPathSeverity(),
 												},
 												"event_action": {
-													Type:         schema.TypeString,
-													Optional:     true,
-													ValidateFunc: validateEventOrchestrationPathEventAction(),
+													Type:             schema.TypeString,
+													Optional:         true,
+													ValidateDiagFunc: validateEventOrchestrationPathEventAction(),
 												},
 												"variable": {
 													Type:     schema.TypeList,
@@ -121,7 +121,7 @@ func resourcePagerDutyEventOrchestrationPathUnrouted() *schema.Resource {
 									"severity": {
 										Type:     schema.TypeString,
 										Optional: true,
-										ValidateFunc: validateValueFunc([]string{
+										ValidateDiagFunc: validateValueDiagFunc([]string{
 											"info",
 											"error",
 											"warning",
@@ -131,7 +131,7 @@ func resourcePagerDutyEventOrchestrationPathUnrouted() *schema.Resource {
 									"event_action": {
 										Type:     schema.TypeString,
 										Optional: true,
-										ValidateFunc: validateValueFunc([]string{
+										ValidateDiagFunc: validateValueDiagFunc([]string{
 											"trigger",
 											"resolve",
 										}),

--- a/pagerduty/resource_pagerduty_incident_workflow_trigger.go
+++ b/pagerduty/resource_pagerduty_incident_workflow_trigger.go
@@ -26,7 +26,7 @@ func resourcePagerDutyIncidentWorkflowTrigger() *schema.Resource {
 			"type": {
 				Type:     schema.TypeString,
 				Required: true,
-				ValidateFunc: validateValueFunc([]string{
+				ValidateDiagFunc: validateValueDiagFunc([]string{
 					"manual",
 					"conditional",
 				}),

--- a/pagerduty/resource_pagerduty_incident_workflow_trigger_test.go
+++ b/pagerduty/resource_pagerduty_incident_workflow_trigger_test.go
@@ -72,7 +72,7 @@ resource "pagerduty_incident_workflow_trigger" "my_first_workflow_trigger" {
 		Steps: []resource.TestStep{
 			{
 				Config:      config,
-				ExpectError: regexp.MustCompile(`"dummy" is an invalid value for argument type. Must be one of \[]string{"manual", "conditional"}`),
+				ExpectError: regexp.MustCompile(`"dummy" is an invalid value. Must be one of \[]string{"manual", "conditional"}`),
 			},
 		},
 	})

--- a/pagerduty/resource_pagerduty_ruleset_rule.go
+++ b/pagerduty/resource_pagerduty_ruleset_rule.go
@@ -160,7 +160,7 @@ func resourcePagerDutyRulesetRule() *schema.Resource {
 									"threshold_time_unit": {
 										Type:     schema.TypeString,
 										Optional: true,
-										ValidateFunc: validateValueFunc([]string{
+										ValidateDiagFunc: validateValueDiagFunc([]string{
 											"minutes",
 											"seconds",
 											"hours",
@@ -181,7 +181,7 @@ func resourcePagerDutyRulesetRule() *schema.Resource {
 									"value": {
 										Type:     schema.TypeString,
 										Optional: true,
-										ValidateFunc: validateValueFunc([]string{
+										ValidateDiagFunc: validateValueDiagFunc([]string{
 											"info",
 											"error",
 											"warning",
@@ -235,7 +235,7 @@ func resourcePagerDutyRulesetRule() *schema.Resource {
 									"value": {
 										Type:     schema.TypeString,
 										Optional: true,
-										ValidateFunc: validateValueFunc([]string{
+										ValidateDiagFunc: validateValueDiagFunc([]string{
 											"trigger",
 											"resolve",
 										}),

--- a/pagerduty/resource_pagerduty_schedule.go
+++ b/pagerduty/resource_pagerduty_schedule.go
@@ -134,7 +134,7 @@ func resourcePagerDutySchedule() *schema.Resource {
 									"type": {
 										Type:     schema.TypeString,
 										Required: true,
-										ValidateFunc: validateValueFunc([]string{
+										ValidateDiagFunc: validateValueDiagFunc([]string{
 											"daily_restriction",
 											"weekly_restriction",
 										}),

--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -52,7 +52,7 @@ func resourcePagerDutyService() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "create_incidents",
-				ValidateFunc: validateValueFunc([]string{
+				ValidateDiagFunc: validateValueDiagFunc([]string{
 					"create_alerts_and_incidents",
 					"create_incidents",
 				}),
@@ -61,7 +61,7 @@ func resourcePagerDutyService() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 				Optional: true,
-				ValidateFunc: validateValueFunc([]string{
+				ValidateDiagFunc: validateValueDiagFunc([]string{
 					"time",
 					"intelligent",
 					"rules",
@@ -86,7 +86,7 @@ func resourcePagerDutyService() *schema.Resource {
 						"type": {
 							Type:     schema.TypeString,
 							Optional: true,
-							ValidateFunc: validateValueFunc([]string{
+							ValidateDiagFunc: validateValueDiagFunc([]string{
 								"time",
 								"intelligent",
 								"content_based",
@@ -112,7 +112,7 @@ func resourcePagerDutyService() *schema.Resource {
 									"aggregate": {
 										Type:     schema.TypeString,
 										Optional: true,
-										ValidateFunc: validateValueFunc([]string{
+										ValidateDiagFunc: validateValueDiagFunc([]string{
 											"all",
 											"any",
 										}),

--- a/pagerduty/resource_pagerduty_service_dependency.go
+++ b/pagerduty/resource_pagerduty_service_dependency.go
@@ -42,7 +42,7 @@ func resourcePagerDutyServiceDependency() *schema.Resource {
 										Type:     schema.TypeString,
 										Required: true,
 										ForceNew: true,
-										ValidateFunc: validateValueFunc([]string{
+										ValidateDiagFunc: validateValueDiagFunc([]string{
 											"business_service",
 											"service",
 										}),
@@ -64,7 +64,7 @@ func resourcePagerDutyServiceDependency() *schema.Resource {
 										Type:     schema.TypeString,
 										Required: true,
 										ForceNew: true,
-										ValidateFunc: validateValueFunc([]string{
+										ValidateDiagFunc: validateValueDiagFunc([]string{
 											"business_service",
 											"business_service_reference",
 											"service",

--- a/pagerduty/resource_pagerduty_service_event_rule.go
+++ b/pagerduty/resource_pagerduty_service_event_rule.go
@@ -155,7 +155,7 @@ func resourcePagerDutyServiceEventRule() *schema.Resource {
 									"threshold_time_unit": {
 										Type:     schema.TypeString,
 										Optional: true,
-										ValidateFunc: validateValueFunc([]string{
+										ValidateDiagFunc: validateValueDiagFunc([]string{
 											"minutes",
 											"seconds",
 											"hours",
@@ -176,7 +176,7 @@ func resourcePagerDutyServiceEventRule() *schema.Resource {
 									"value": {
 										Type:     schema.TypeString,
 										Optional: true,
-										ValidateFunc: validateValueFunc([]string{
+										ValidateDiagFunc: validateValueDiagFunc([]string{
 											"info",
 											"error",
 											"warning",
@@ -218,7 +218,7 @@ func resourcePagerDutyServiceEventRule() *schema.Resource {
 									"value": {
 										Type:     schema.TypeString,
 										Optional: true,
-										ValidateFunc: validateValueFunc([]string{
+										ValidateDiagFunc: validateValueDiagFunc([]string{
 											"trigger",
 											"resolve",
 										}),

--- a/pagerduty/resource_pagerduty_service_integration.go
+++ b/pagerduty/resource_pagerduty_service_integration.go
@@ -49,7 +49,7 @@ func resourcePagerDutyServiceIntegration() *schema.Resource {
 				ForceNew:      true,
 				Computed:      true,
 				ConflictsWith: []string{"vendor"},
-				ValidateFunc: validateValueFunc([]string{
+				ValidateDiagFunc: validateValueDiagFunc([]string{
 					"aws_cloudwatch_inbound_integration",
 					"cloudkick_inbound_integration",
 					"event_transformer_api_inbound_integration",
@@ -107,7 +107,7 @@ func resourcePagerDutyServiceIntegration() *schema.Resource {
 						"action": {
 							Type:     schema.TypeString,
 							Required: true,
-							ValidateFunc: validateValueFunc([]string{
+							ValidateDiagFunc: validateValueDiagFunc([]string{
 								"resolve",
 								"trigger",
 							}),
@@ -137,7 +137,7 @@ func resourcePagerDutyServiceIntegration() *schema.Resource {
 												"part": {
 													Type:     schema.TypeString,
 													Optional: true,
-													ValidateFunc: validateValueFunc([]string{
+													ValidateDiagFunc: validateValueDiagFunc([]string{
 														"body",
 														"from_addresses",
 														"subject",
@@ -156,7 +156,7 @@ func resourcePagerDutyServiceIntegration() *schema.Resource {
 															"part": {
 																Type:     schema.TypeString,
 																Required: true,
-																ValidateFunc: validateValueFunc([]string{
+																ValidateDiagFunc: validateValueDiagFunc([]string{
 																	"body",
 																	"from_addresses",
 																	"subject",
@@ -165,7 +165,7 @@ func resourcePagerDutyServiceIntegration() *schema.Resource {
 															"type": {
 																Type:     schema.TypeString,
 																Required: true,
-																ValidateFunc: validateValueFunc([]string{
+																ValidateDiagFunc: validateValueDiagFunc([]string{
 																	"contains",
 																	"exactly",
 																	"regex",
@@ -177,7 +177,7 @@ func resourcePagerDutyServiceIntegration() *schema.Resource {
 												"type": {
 													Type:     schema.TypeString,
 													Required: true,
-													ValidateFunc: validateValueFunc([]string{
+													ValidateDiagFunc: validateValueDiagFunc([]string{
 														"contains",
 														"exactly",
 														"not",
@@ -190,7 +190,7 @@ func resourcePagerDutyServiceIntegration() *schema.Resource {
 									"type": {
 										Type:     schema.TypeString,
 										Required: true,
-										ValidateFunc: validateValueFunc([]string{
+										ValidateDiagFunc: validateValueDiagFunc([]string{
 											"all",
 											"any",
 										}),
@@ -211,7 +211,7 @@ func resourcePagerDutyServiceIntegration() *schema.Resource {
 									"part": {
 										Type:     schema.TypeString,
 										Required: true,
-										ValidateFunc: validateValueFunc([]string{
+										ValidateDiagFunc: validateValueDiagFunc([]string{
 											"body",
 											"subject",
 										}),
@@ -227,7 +227,7 @@ func resourcePagerDutyServiceIntegration() *schema.Resource {
 									"type": {
 										Type:     schema.TypeString,
 										Required: true,
-										ValidateFunc: validateValueFunc([]string{
+										ValidateDiagFunc: validateValueDiagFunc([]string{
 											"between",
 											"entire",
 											"regex",
@@ -256,7 +256,7 @@ func resourcePagerDutyServiceIntegration() *schema.Resource {
 						"subject_mode": {
 							Type:     schema.TypeString,
 							Optional: true,
-							ValidateFunc: validateValueFunc([]string{
+							ValidateDiagFunc: validateValueDiagFunc([]string{
 								"always",
 								"match",
 								"no-match",
@@ -269,7 +269,7 @@ func resourcePagerDutyServiceIntegration() *schema.Resource {
 						"body_mode": {
 							Type:     schema.TypeString,
 							Optional: true,
-							ValidateFunc: validateValueFunc([]string{
+							ValidateDiagFunc: validateValueDiagFunc([]string{
 								"always",
 								"match",
 								"no-match",
@@ -282,7 +282,7 @@ func resourcePagerDutyServiceIntegration() *schema.Resource {
 						"from_email_mode": {
 							Type:     schema.TypeString,
 							Optional: true,
-							ValidateFunc: validateValueFunc([]string{
+							ValidateDiagFunc: validateValueDiagFunc([]string{
 								"always",
 								"match",
 								"no-match",

--- a/pagerduty/resource_pagerduty_slack_connection.go
+++ b/pagerduty/resource_pagerduty_slack_connection.go
@@ -35,7 +35,7 @@ func resourcePagerDutySlackConnection() *schema.Resource {
 			"source_type": {
 				Type:     schema.TypeString,
 				Required: true,
-				ValidateFunc: validateValueFunc([]string{
+				ValidateDiagFunc: validateValueDiagFunc([]string{
 					"service_reference",
 					"team_reference",
 				}),
@@ -56,7 +56,7 @@ func resourcePagerDutySlackConnection() *schema.Resource {
 			"notification_type": {
 				Type:     schema.TypeString,
 				Required: true,
-				ValidateFunc: validateValueFunc([]string{
+				ValidateDiagFunc: validateValueDiagFunc([]string{
 					"responder",
 					"stakeholder",
 				}),
@@ -83,7 +83,7 @@ func resourcePagerDutySlackConnection() *schema.Resource {
 						"urgency": {
 							Type:     schema.TypeString,
 							Optional: true,
-							ValidateFunc: validateValueFunc([]string{
+							ValidateDiagFunc: validateValueDiagFunc([]string{
 								"high",
 								"low",
 							}),

--- a/pagerduty/resource_pagerduty_tag_assignment.go
+++ b/pagerduty/resource_pagerduty_tag_assignment.go
@@ -24,7 +24,7 @@ func resourcePagerDutyTagAssignment() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-				ValidateFunc: validateValueFunc([]string{
+				ValidateDiagFunc: validateValueDiagFunc([]string{
 					"users",
 					"teams",
 					"escalation_policies",

--- a/pagerduty/resource_pagerduty_team_membership.go
+++ b/pagerduty/resource_pagerduty_team_membership.go
@@ -34,7 +34,7 @@ func resourcePagerDutyTeamMembership() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "manager",
-				ValidateFunc: validateValueFunc([]string{
+				ValidateDiagFunc: validateValueDiagFunc([]string{
 					"observer",
 					"responder",
 					"manager",

--- a/pagerduty/resource_pagerduty_user.go
+++ b/pagerduty/resource_pagerduty_user.go
@@ -44,7 +44,7 @@ func resourcePagerDutyUser() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "user",
-				ValidateFunc: validateValueFunc([]string{
+				ValidateDiagFunc: validateValueDiagFunc([]string{
 					"admin",
 					"limited_user",
 					"observer",

--- a/pagerduty/resource_pagerduty_user_contact_method.go
+++ b/pagerduty/resource_pagerduty_user_contact_method.go
@@ -45,7 +45,7 @@ func resourcePagerDutyUserContactMethod() *schema.Resource {
 			"type": {
 				Type:     schema.TypeString,
 				Required: true,
-				ValidateFunc: validateValueFunc([]string{
+				ValidateDiagFunc: validateValueDiagFunc([]string{
 					"email_contact_method",
 					"phone_contact_method",
 					"push_notification_contact_method",

--- a/pagerduty/resource_pagerduty_user_notification_rule.go
+++ b/pagerduty/resource_pagerduty_user_notification_rule.go
@@ -36,7 +36,7 @@ func resourcePagerDutyUserNotificationRule() *schema.Resource {
 			"urgency": {
 				Type:     schema.TypeString,
 				Required: true,
-				ValidateFunc: validateValueFunc([]string{
+				ValidateDiagFunc: validateValueDiagFunc([]string{
 					"high",
 					"low",
 				}),

--- a/pagerduty/resource_pagerduty_webhook_subscription.go
+++ b/pagerduty/resource_pagerduty_webhook_subscription.go
@@ -33,7 +33,7 @@ func resourcePagerDutyWebhookSubscription() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							Default:  "http_delivery_method",
-							ValidateFunc: validateValueFunc([]string{
+							ValidateDiagFunc: validateValueDiagFunc([]string{
 								"http_delivery_method",
 							}),
 						},
@@ -73,7 +73,7 @@ func resourcePagerDutyWebhookSubscription() *schema.Resource {
 				Type:     schema.TypeString,
 				Default:  "webhook_subscription",
 				Optional: true,
-				ValidateFunc: validateValueFunc([]string{
+				ValidateDiagFunc: validateValueDiagFunc([]string{
 					"webhook_subscription",
 				}),
 			},
@@ -105,7 +105,7 @@ func resourcePagerDutyWebhookSubscription() *schema.Resource {
 						"type": {
 							Type:     schema.TypeString,
 							Required: true,
-							ValidateFunc: validateValueFunc([]string{
+							ValidateDiagFunc: validateValueDiagFunc([]string{
 								"service_reference",
 								"team_reference",
 								"account_reference",

--- a/pagerduty/util.go
+++ b/pagerduty/util.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -83,8 +85,10 @@ func suppressCaseDiff(k, old, new string, d *schema.ResourceData) bool {
 }
 
 // Validate a value against a set of possible values
-func validateValueFunc(values []string) schema.SchemaValidateFunc {
-	return func(v interface{}, k string) (we []string, errors []error) {
+func validateValueDiagFunc(values []string) schema.SchemaValidateDiagFunc {
+	return func(v interface{}, p cty.Path) diag.Diagnostics {
+		var diags diag.Diagnostics
+
 		value := v.(string)
 		valid := false
 		for _, val := range values {
@@ -95,9 +99,13 @@ func validateValueFunc(values []string) schema.SchemaValidateFunc {
 		}
 
 		if !valid {
-			errors = append(errors, fmt.Errorf("%#v is an invalid value for argument %s. Must be one of %#v", value, k, values))
+			diags = append(diags, diag.Diagnostic{
+				Severity:      diag.Error,
+				Summary:       fmt.Sprintf("%#v is an invalid value. Must be one of %#v", value, values),
+				AttributePath: p,
+			})
 		}
-		return
+		return diags
 	}
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -37,6 +37,7 @@ github.com/hashicorp/go-checkpoint
 # github.com/hashicorp/go-cleanhttp v0.5.2
 github.com/hashicorp/go-cleanhttp
 # github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
+## explicit
 github.com/hashicorp/go-cty/cty
 github.com/hashicorp/go-cty/cty/convert
 github.com/hashicorp/go-cty/cty/gocty


### PR DESCRIPTION
`schema.SchemaValidateFunc` has been deprecated and the recommendation is to use `schema.SchemaValidateDiagFunc` instead. This pull request replaces all usages of `schema.SchemaValidateFunc` with a diag-based function.