### PR TITLE
Add support for Automation Actions' Runner association with a Team

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	cloud.google.com/go v0.71.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.1
-	github.com/heimweh/go-pagerduty v0.0.0-20230105172716-6955a6ecfb5f
+	github.com/heimweh/go-pagerduty v0.0.0-20230106163906-1866a667c56b
 	github.com/klauspost/compress v1.15.9 // indirect
 	github.com/montanaflynn/stats v0.6.6 // indirect
 	go.mongodb.org/mongo-driver v1.10.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -224,8 +224,8 @@ github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/heimweh/go-pagerduty v0.0.0-20230105172716-6955a6ecfb5f h1:HXMmCTplCGB443iiQyMaUpVKuUfZ9HmUPBM8SAO/E2A=
-github.com/heimweh/go-pagerduty v0.0.0-20230105172716-6955a6ecfb5f/go.mod h1:t9vftsO1IjYHGdgJXeemZtomCWnxi2SRgu0PRcRb2oY=
+github.com/heimweh/go-pagerduty v0.0.0-20230106163906-1866a667c56b h1:lapOAMT0BgxVCtW7SzPNnH2Q1qlPeO/+ue+zXbahpMg=
+github.com/heimweh/go-pagerduty v0.0.0-20230106163906-1866a667c56b/go.mod h1:t9vftsO1IjYHGdgJXeemZtomCWnxi2SRgu0PRcRb2oY=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/pagerduty/import_pagerduty_automation_actions_runner_team_association_test.go
+++ b/pagerduty/import_pagerduty_automation_actions_runner_team_association_test.go
@@ -1,0 +1,30 @@
+package pagerduty
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccPagerDutyAutomationActionsRunnerTeamAssociation_import(t *testing.T) {
+	runnerName := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	teamName := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyAutomationActionsRunnerTeamAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyAutomationActionsRunnerTeamAssociationConfig(runnerName, teamName),
+			},
+			{
+				ResourceName:      "pagerduty_automation_actions_runner_team_association.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/pagerduty/provider.go
+++ b/pagerduty/provider.go
@@ -99,6 +99,7 @@ func Provider() *schema.Provider {
 			"pagerduty_automation_actions_runner":                  resourcePagerDutyAutomationActionsRunner(),
 			"pagerduty_automation_actions_action":                  resourcePagerDutyAutomationActionsAction(),
 			"pagerduty_automation_actions_action_team_association": resourcePagerDutyAutomationActionsActionTeamAssociation(),
+			"pagerduty_automation_actions_runner_team_association": resourcePagerDutyAutomationActionsRunnerTeamAssociation(),
 			"pagerduty_incident_workflow":                          resourcePagerDutyIncidentWorkflow(),
 			"pagerduty_incident_workflow_trigger":                  resourcePagerDutyIncidentWorkflowTrigger(),
 		},

--- a/pagerduty/resource_pagerduty_automation_actions_runner_team_association.go
+++ b/pagerduty/resource_pagerduty_automation_actions_runner_team_association.go
@@ -1,0 +1,127 @@
+package pagerduty
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourcePagerDutyAutomationActionsRunnerTeamAssociation() *schema.Resource {
+	return &schema.Resource{
+		Create: resourcePagerDutyAutomationActionsRunnerTeamAssociationCreate,
+		Read:   resourcePagerDutyAutomationActionsRunnerTeamAssociationRead,
+		Delete: resourcePagerDutyAutomationActionsRunnerTeamAssociationDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"runner_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"team_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourcePagerDutyAutomationActionsRunnerTeamAssociationCreate(d *schema.ResourceData, meta interface{}) error {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
+
+	runnerID := d.Get("runner_id").(string)
+	teamID := d.Get("team_id").(string)
+
+	log.Printf("[INFO] Creating PagerDuty AutomationActionsRunnerTeamAssociation %s:%s", d.Get("runner_id").(string), d.Get("team_id").(string))
+
+	retryErr := resource.Retry(10*time.Second, func() *resource.RetryError {
+		if teamRef, _, err := client.AutomationActionsRunner.AssociateToTeam(runnerID, teamID); err != nil {
+			if isErrCode(err, 429) {
+				time.Sleep(2 * time.Second)
+				return resource.RetryableError(err)
+			}
+
+			return resource.NonRetryableError(err)
+		} else if teamRef != nil {
+			d.SetId(fmt.Sprintf("%s:%s", runnerID, teamID))
+		}
+		return nil
+	})
+
+	if retryErr != nil {
+		return retryErr
+	}
+
+	return fetchPagerDutyAutomationActionsRunnerTeamAssociation(d, meta, handleNotFoundError)
+}
+
+func fetchPagerDutyAutomationActionsRunnerTeamAssociation(d *schema.ResourceData, meta interface{}, errCallback func(error, *schema.ResourceData) error) error {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
+
+	runnerID, teamID := resourcePagerDutyParseColonCompoundID(d.Id())
+	return resource.Retry(30*time.Second, func() *resource.RetryError {
+		resp, _, err := client.AutomationActionsRunner.GetAssociationToTeam(runnerID, teamID)
+		if err != nil {
+			errResp := errCallback(err, d)
+			if errResp != nil {
+				time.Sleep(2 * time.Second)
+				return resource.RetryableError(errResp)
+			}
+
+			return nil
+		}
+
+		if resp.Team.ID != teamID {
+			log.Printf("[WARN] Removing %s since the user: %s is not a member of: %s", d.Id(), runnerID, teamID)
+			d.SetId("")
+			return nil
+		}
+
+		d.Set("runner_id", runnerID)
+		d.Set("team_id", resp.Team.ID)
+
+		return nil
+	})
+}
+
+func resourcePagerDutyAutomationActionsRunnerTeamAssociationRead(d *schema.ResourceData, meta interface{}) error {
+	return fetchPagerDutyAutomationActionsRunnerTeamAssociation(d, meta, handleNotFoundError)
+}
+
+func resourcePagerDutyAutomationActionsRunnerTeamAssociationDelete(d *schema.ResourceData, meta interface{}) error {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
+
+	runnerID, teamID := resourcePagerDutyParseColonCompoundID(d.Id())
+	log.Printf("[INFO] Deleting PagerDuty AutomationActionsRunnerTeamAssociation %s", d.Id())
+
+	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
+		if _, err := client.AutomationActionsRunner.DissociateFromTeam(runnerID, teamID); err != nil {
+			return resource.RetryableError(err)
+		}
+		return nil
+	})
+	if retryErr != nil {
+		time.Sleep(2 * time.Second)
+		return retryErr
+	}
+	d.SetId("")
+
+	// giving the API time to catchup
+	time.Sleep(time.Second)
+	return nil
+}

--- a/pagerduty/resource_pagerduty_automation_actions_runner_team_association_test.go
+++ b/pagerduty/resource_pagerduty_automation_actions_runner_team_association_test.go
@@ -1,0 +1,103 @@
+package pagerduty
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func init() {
+	resource.AddTestSweepers("pagerduty_automation_actions_runner_team_association", &resource.Sweeper{
+		Name: "pagerduty_automation_actions_runner_team_association",
+		F:    testSweepAutomationActionsRunnerTeamAssociation,
+	})
+}
+
+func testSweepAutomationActionsRunnerTeamAssociation(region string) error {
+	return nil
+}
+
+func TestAccPagerDutyAutomationActionsRunnerTeamAssociation_Basic(t *testing.T) {
+	runnerName := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	teamName := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyAutomationActionsRunnerTeamAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyAutomationActionsRunnerTeamAssociationConfig(runnerName, teamName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyAutomationActionsRunnerTeamAssociationExists("pagerduty_automation_actions_runner_team_association.foo"),
+					resource.TestCheckResourceAttrSet("pagerduty_automation_actions_runner_team_association.foo", "runner_id"),
+					resource.TestCheckResourceAttrSet("pagerduty_automation_actions_runner_team_association.foo", "team_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckPagerDutyAutomationActionsRunnerTeamAssociationDestroy(s *terraform.State) error {
+	client, _ := testAccProvider.Meta().(*Config).Client()
+	for _, r := range s.RootModule().Resources {
+		if r.Type != "pagerduty_automation_actions_runner_team_association" {
+			continue
+		}
+		runnerID, teamID := resourcePagerDutyParseColonCompoundID(r.Primary.ID)
+		if _, _, err := client.AutomationActionsRunner.GetAssociationToTeam(runnerID, teamID); err == nil {
+			return fmt.Errorf("Automation Actions Runner Team association still exists")
+		}
+	}
+	return nil
+}
+
+func testAccCheckPagerDutyAutomationActionsRunnerTeamAssociationExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Automation Actions Runner ID is set")
+		}
+
+		client, _ := testAccProvider.Meta().(*Config).Client()
+		runnerID, teamID := resourcePagerDutyParseColonCompoundID(rs.Primary.ID)
+		found, _, err := client.AutomationActionsRunner.GetAssociationToTeam(runnerID, teamID)
+		if err != nil {
+			return err
+		}
+		if fmt.Sprintf("%s:%s", runnerID, found.Team.ID) != rs.Primary.ID {
+			return fmt.Errorf("Automation Actions Runner association to team not found: %v - %v", rs.Primary.ID, found)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckPagerDutyAutomationActionsRunnerTeamAssociationConfig(teamName, runnerName string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_team" "foo" {
+  name        = "%s"
+  description = "foo"
+}
+
+resource "pagerduty_automation_actions_runner" "foo" {
+	name = "%s runner"
+	description = "Runner created by TF"
+	runner_type = "runbook"
+	runbook_base_uri = "cat-cat"
+	runbook_api_key = "cat-secret"
+}
+
+resource "pagerduty_automation_actions_runner_team_association" "foo" {
+  runner_id = pagerduty_automation_actions_runner.foo.id
+  team_id = pagerduty_team.foo.id
+}
+
+`, teamName, runnerName)
+}

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/automation_actions_action.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/automation_actions_action.go
@@ -38,6 +38,10 @@ type AutomationActionsActionTeamAssociationPayload struct {
 	Team *TeamReference `json:"team,omitempty"`
 }
 
+type AutomationActionsActionServiceAssociationPayload struct {
+	Service *ServiceReference `json:"service,omitempty"`
+}
+
 var automationActionsActionBaseUrl = "/automation_actions/actions"
 
 // Create creates a new action
@@ -114,6 +118,42 @@ func (s *AutomationActionsActionService) DissociateToTeam(actionID, teamID strin
 func (s *AutomationActionsActionService) GetAssociationToTeam(actionID, teamID string) (*AutomationActionsActionTeamAssociationPayload, *Response, error) {
 	u := fmt.Sprintf("%s/%s/teams/%s", automationActionsActionBaseUrl, actionID, teamID)
 	v := new(AutomationActionsActionTeamAssociationPayload)
+
+	resp, err := s.client.newRequestDoOptions("GET", u, nil, nil, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v, resp, nil
+}
+
+// Associate an Automation Action with a service
+func (s *AutomationActionsActionService) AssociateToService(actionID, serviceID string) (*AutomationActionsActionServiceAssociationPayload, *Response, error) {
+	u := fmt.Sprintf("%s/%s/services", automationActionsActionBaseUrl, actionID)
+	v := new(AutomationActionsActionServiceAssociationPayload)
+	p := &AutomationActionsActionServiceAssociationPayload{
+		Service: &ServiceReference{ID: serviceID, Type: "service_reference"},
+	}
+
+	resp, err := s.client.newRequestDoOptions("POST", u, nil, p, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v, resp, nil
+}
+
+// Dissociate an Automation Action with a service
+func (s *AutomationActionsActionService) DissociateFromService(actionID, serviceID string) (*Response, error) {
+	u := fmt.Sprintf("%s/%s/services/%s", automationActionsActionBaseUrl, actionID, serviceID)
+
+	return s.client.newRequestDoOptions("DELETE", u, nil, nil, nil)
+}
+
+// Gets the details of an Automation Action / service relation
+func (s *AutomationActionsActionService) GetAssociationToService(actionID, serviceID string) (*AutomationActionsActionServiceAssociationPayload, *Response, error) {
+	u := fmt.Sprintf("%s/%s/services/%s", automationActionsActionBaseUrl, actionID, serviceID)
+	v := new(AutomationActionsActionServiceAssociationPayload)
 
 	resp, err := s.client.newRequestDoOptions("GET", u, nil, nil, &v)
 	if err != nil {

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/automation_actions_runner.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/automation_actions_runner.go
@@ -29,6 +29,10 @@ type AutomationActionsRunnerPayload struct {
 	Runner *AutomationActionsRunner `json:"runner,omitempty"`
 }
 
+type AutomationActionsRunnerTeamAssociationPayload struct {
+	Team *TeamReference `json:"team,omitempty"`
+}
+
 var automationActionsRunnerBaseUrl = "/automation_actions/runners"
 
 // Create creates a new runner
@@ -76,4 +80,40 @@ func (s *AutomationActionsRunnerService) Delete(id string) (*Response, error) {
 	u := fmt.Sprintf("%s/%s", automationActionsRunnerBaseUrl, id)
 
 	return s.client.newRequestDoOptions("DELETE", u, nil, nil, nil)
+}
+
+// Associate a Runner with a team
+func (s *AutomationActionsRunnerService) AssociateToTeam(runnerID, teamID string) (*AutomationActionsRunnerTeamAssociationPayload, *Response, error) {
+	u := fmt.Sprintf("%s/%s/teams", automationActionsRunnerBaseUrl, runnerID)
+	v := new(AutomationActionsRunnerTeamAssociationPayload)
+	p := &AutomationActionsRunnerTeamAssociationPayload{
+		Team: &TeamReference{ID: teamID, Type: "team_reference"},
+	}
+
+	resp, err := s.client.newRequestDoOptions("POST", u, nil, p, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v, resp, nil
+}
+
+// Dissociate an Runner with a team
+func (s *AutomationActionsRunnerService) DissociateFromTeam(runnerID, teamID string) (*Response, error) {
+	u := fmt.Sprintf("%s/%s/teams/%s", automationActionsRunnerBaseUrl, runnerID, teamID)
+
+	return s.client.newRequestDoOptions("DELETE", u, nil, nil, nil)
+}
+
+// Gets the details of a Runner / team relation
+func (s *AutomationActionsRunnerService) GetAssociationToTeam(runnerID, teamID string) (*AutomationActionsRunnerTeamAssociationPayload, *Response, error) {
+	u := fmt.Sprintf("%s/%s/teams/%s", automationActionsRunnerBaseUrl, runnerID, teamID)
+	v := new(AutomationActionsRunnerTeamAssociationPayload)
+
+	resp, err := s.client.newRequestDoOptions("GET", u, nil, nil, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v, resp, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -122,7 +122,7 @@ github.com/hashicorp/terraform-registry-address
 github.com/hashicorp/terraform-svchost
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20230105172716-6955a6ecfb5f
+# github.com/heimweh/go-pagerduty v0.0.0-20230106163906-1866a667c56b
 ## explicit
 github.com/heimweh/go-pagerduty/pagerduty
 # github.com/klauspost/compress v1.15.9

--- a/website/docs/r/automation_actions_action_team_association.html.markdown
+++ b/website/docs/r/automation_actions_action_team_association.html.markdown
@@ -3,7 +3,7 @@ layout: "pagerduty"
 page_title: "PagerDuty: pagerduty_automation_actions_action_team_association"
 sidebar_current: "docs-pagerduty-resource-automation-actions-action"
 description: |-
-  Creates and manages an Automation Actions action assciation with a Team in PagerDuty.
+  Creates and manages an Automation Actions action association with a Team in PagerDuty.
 ---
 
 # pagerduty\_automation\_actions\_action_team_association
@@ -43,7 +43,6 @@ The following arguments are supported:
 
 ## Import
 
-Actions can be imported using the `id`, e.g.
 Action team association can be imported using the `action_id` and `team_id` separated by a colon, e.g.
 
 ```

--- a/website/docs/r/automation_actions_runner_team_association.html.markdown
+++ b/website/docs/r/automation_actions_runner_team_association.html.markdown
@@ -1,0 +1,49 @@
+---
+layout: "pagerduty"
+page_title: "PagerDuty: pagerduty_automation_actions_runner_team_association"
+sidebar_current: "docs-pagerduty-resource-automation-actions-runner"
+description: |-
+  Creates and manages an Automation Actions runner association with a Team in PagerDuty.
+---
+
+# pagerduty\_automation\_actions\_runner_team_association
+
+An Automation Actions [runner association with a team](https://developer.pagerduty.com/api-reference/f662de6271a6e-associate-a-runner-with-a-team) configures the relation of a specific Runner with a Team.
+
+## Example Usage
+
+```hcl
+resource "pagerduty_team" "team_ent_eng" {
+  name        = "Enterprise Engineering"
+  description = "Enterprise engineering"
+}
+
+resource "pagerduty_automation_actions_runner" "pa_runbook_runner" {
+	name = "Runner created via TF"
+	description = "Description of the Runner created via TF"
+	runner_type = "runbook"
+	runbook_base_uri = "cat-cat"
+	runbook_api_key = "cat-secret"
+}
+
+resource "pagerduty_automation_actions_runner_team_association" "pa_runner_ent_eng_assoc" {
+  runner_id = pagerduty_automation_actions_runner.pa_runbook_runner.id
+  team_id   = pagerduty_team.team_ent_eng.id
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+  * `runner_id` - (Required) Id of the runner.
+  * `team_id` - (Required) Id of the team associated with the runner.
+
+## Import
+
+Runner team association can be imported using the `runner_id` and `team_id` separated by a colon, e.g.
+
+```
+$ terraform import pagerduty_automation_actions_runner_team_association.example 01DER7CUUBF7TH4116K0M4WKPU:PLB09Z
+```


### PR DESCRIPTION
Add support for resource pagerduty_automation_actions_runner_team_association

New tests cases introduced:

```
$ make testacc TESTARGS="-run TestAccPagerDutyAutomationActionsRunnerTeamAssociation"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccPagerDutyAutomationActionsRunnerTeamAssociation -timeout 120m
?   	github.com/terraform-providers/terraform-provider-pagerduty	[no test files]
=== RUN   TestAccPagerDutyAutomationActionsRunnerTeamAssociation_import
--- PASS: TestAccPagerDutyAutomationActionsRunnerTeamAssociation_import (9.80s)
=== RUN   TestAccPagerDutyAutomationActionsRunnerTeamAssociation_Basic
--- PASS: TestAccPagerDutyAutomationActionsRunnerTeamAssociation_Basic (7.75s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	(cached)
```

Depends on: https://github.com/heimweh/go-pagerduty/pull/114