### PR TITLE
add team support for incident workflows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	cloud.google.com/go v0.71.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.1
-	github.com/heimweh/go-pagerduty v0.0.0-20230106163906-1866a667c56b
+	github.com/heimweh/go-pagerduty v0.0.0-20230109193609-65eb8c4b0164
 	github.com/klauspost/compress v1.15.9 // indirect
 	github.com/montanaflynn/stats v0.6.6 // indirect
 	go.mongodb.org/mongo-driver v1.10.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -224,8 +224,8 @@ github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/heimweh/go-pagerduty v0.0.0-20230106163906-1866a667c56b h1:lapOAMT0BgxVCtW7SzPNnH2Q1qlPeO/+ue+zXbahpMg=
-github.com/heimweh/go-pagerduty v0.0.0-20230106163906-1866a667c56b/go.mod h1:t9vftsO1IjYHGdgJXeemZtomCWnxi2SRgu0PRcRb2oY=
+github.com/heimweh/go-pagerduty v0.0.0-20230109193609-65eb8c4b0164 h1:awa7jI+gTGZ1vxoQVZPlf6grkP2L2uBtFPtYiwDJevM=
+github.com/heimweh/go-pagerduty v0.0.0-20230109193609-65eb8c4b0164/go.mod h1:t9vftsO1IjYHGdgJXeemZtomCWnxi2SRgu0PRcRb2oY=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/pagerduty/resource_pagerduty_incident_workflow.go
+++ b/pagerduty/resource_pagerduty_incident_workflow.go
@@ -33,6 +33,10 @@ func resourcePagerDutyIncidentWorkflow() *schema.Resource {
 				Optional: true,
 				Default:  "Managed by Terraform",
 			},
+			"team": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"step": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -308,6 +312,9 @@ func flattenIncidentWorkflow(d *schema.ResourceData, iw *pagerduty.IncidentWorkf
 	if iw.Description != nil {
 		d.Set("description", *(iw.Description))
 	}
+	if iw.Team != nil {
+		d.Set("team", iw.Team.ID)
+	}
 
 	if includeSteps {
 		steps := flattenIncidentWorkflowSteps(iw, nonGeneratedInputNames)
@@ -369,6 +376,11 @@ func buildIncidentWorkflowStruct(d *schema.ResourceData) (*pagerduty.IncidentWor
 	if desc, ok := d.GetOk("description"); ok {
 		str := desc.(string)
 		iw.Description = &str
+	}
+	if team, ok := d.GetOk("team"); ok {
+		iw.Team = &pagerduty.TeamReference{
+			ID: team.(string),
+		}
 	}
 
 	if steps, ok := d.GetOk("step"); ok {

--- a/pagerduty/resource_pagerduty_incident_workflow_test.go
+++ b/pagerduty/resource_pagerduty_incident_workflow_test.go
@@ -91,6 +91,43 @@ func TestAccPagerDutyIncidentWorkflow_Basic(t *testing.T) {
 	})
 }
 
+func TestAccPagerDutyIncidentWorkflow_Team(t *testing.T) {
+	workflowName := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	teamName := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckIncidentWorkflows(t)
+		},
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckPagerDutyIncidentWorkflowDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyIncidentWorkflowConfigWithTeam(workflowName, teamName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyIncidentWorkflowExists("pagerduty_incident_workflow.test"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_incident_workflow.test", "name", workflowName),
+					resource.TestCheckResourceAttr("pagerduty_incident_workflow.test", "description", "Managed by Terraform"),
+					resource.TestCheckResourceAttrSet("pagerduty_incident_workflow.test", "team"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckPagerDutyIncidentWorkflowConfigWithTeam(name, team string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "pagerduty_incident_workflow" "test" {
+  name = "%s"
+  team = pagerduty_team.foo.id
+}
+`, testAccCheckPagerDutyTeamConfig(team), name)
+}
+
 func testAccCheckPagerDutyIncidentWorkflowConfig(name string) string {
 	return fmt.Sprintf(`
 resource "pagerduty_incident_workflow" "test" {

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/incident_workflow.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/incident_workflow.go
@@ -17,6 +17,7 @@ type IncidentWorkflow struct {
 	Description *string                 `json:"description,omitempty"`
 	Self        string                  `json:"self,omitempty"`
 	Steps       []*IncidentWorkflowStep `json:"steps,omitempty"`
+	Team        *TeamReference          `json:"team,omitempty"`
 }
 
 // IncidentWorkflowStep represents a step in an incident workflow.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -122,7 +122,7 @@ github.com/hashicorp/terraform-registry-address
 github.com/hashicorp/terraform-svchost
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20230106163906-1866a667c56b
+# github.com/heimweh/go-pagerduty v0.0.0-20230109193609-65eb8c4b0164
 ## explicit
 github.com/heimweh/go-pagerduty/pagerduty
 # github.com/klauspost/compress v1.15.9

--- a/website/docs/r/incident_workflow.html.markdown
+++ b/website/docs/r/incident_workflow.html.markdown
@@ -35,6 +35,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the workflow.
 * `description` - (Optional) The description of the workflow.
+* `team` - (Optional) A team ID. If specified then workflow edit permissions will be scoped to members of this team.
 * `step` - (Optional) The steps in the workflow.
 
 Each incident workflow step (`step`) supports the following:


### PR DESCRIPTION
This is an addition to the support for incident workflows added in https://github.com/PagerDuty/terraform-provider-pagerduty/pull/596. Workflows may optionally have a team assigned to them which limits which users can edit that workflow. See https://developer.pagerduty.com/api-reference/2d183500bb4fb-create-an-incident-workflow for more information.

As with #596 , acceptance test is guarded behind the `PAGERDUTY_ACC_INCIDENT_WORKFLOWS` environment variable.