### PR TITLE
teams: add support for private teams

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-exec v0.16.0
 	github.com/hashicorp/terraform-json v0.13.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.11.0
-	github.com/heimweh/go-pagerduty v0.0.0-20230908205257-a96e6c05f7ea
+	github.com/heimweh/go-pagerduty v0.0.0-20231025174125-1492ec59406f
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/heimweh/go-pagerduty v0.0.0-20230908205257-a96e6c05f7ea h1:8SGdS666zcEi1jY34UmJXNXkRD+w2ebQhc5/ok8cY2k=
-github.com/heimweh/go-pagerduty v0.0.0-20230908205257-a96e6c05f7ea/go.mod h1:r59w5iyN01Qvi734yA5hZldbSeJJmsJzee/1kQ/MK7s=
+github.com/heimweh/go-pagerduty v0.0.0-20231025174125-1492ec59406f h1:aKlHoRz5VjwQbc5aH8hIMMmdXZIYEJvyIw3DAiHPolc=
+github.com/heimweh/go-pagerduty v0.0.0-20231025174125-1492ec59406f/go.mod h1:r59w5iyN01Qvi734yA5hZldbSeJJmsJzee/1kQ/MK7s=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/pagerduty/data_source_pagerduty_team.go
+++ b/pagerduty/data_source_pagerduty_team.go
@@ -29,6 +29,10 @@ func dataSourcePagerDutyTeam() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"default_role": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -79,6 +83,7 @@ func dataSourcePagerDutyTeamRead(d *schema.ResourceData, meta interface{}) error
 		d.Set("name", found.Name)
 		d.Set("description", found.Description)
 		d.Set("parent", found.Parent)
+		d.Set("default_role", found.DefaultRole)
 
 		return nil
 	})

--- a/pagerduty/resource_pagerduty_team.go
+++ b/pagerduty/resource_pagerduty_team.go
@@ -37,6 +37,10 @@ func resourcePagerDutyTeam() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"default_role": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -54,6 +58,9 @@ func buildTeamStruct(d *schema.ResourceData) *pagerduty.Team {
 			ID:   attr.(string),
 			Type: "team_reference",
 		}
+	}
+	if attr, ok := d.GetOk("default_role"); ok {
+		team.DefaultRole = attr.(string)
 	}
 	return team
 }
@@ -115,6 +122,7 @@ func resourcePagerDutyTeamRead(d *schema.ResourceData, meta interface{}) error {
 			d.Set("name", team.Name)
 			d.Set("description", team.Description)
 			d.Set("html_url", team.HTMLURL)
+			d.Set("default_role", team.DefaultRole)
 		}
 		return nil
 	})

--- a/pagerduty/resource_pagerduty_team.go
+++ b/pagerduty/resource_pagerduty_team.go
@@ -40,6 +40,7 @@ func resourcePagerDutyTeam() *schema.Resource {
 			"default_role": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 		},
 	}

--- a/pagerduty/resource_pagerduty_team_test.go
+++ b/pagerduty/resource_pagerduty_team_test.go
@@ -105,6 +105,39 @@ func TestAccPagerDutyTeam_Basic(t *testing.T) {
 	})
 }
 
+func TestAccPagerDutyTeam_DefaultRole(t *testing.T) {
+	team := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	defaultRole := "manager"
+	defaultRoleUpdated := "none"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyTeamDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyTeamDefaultRoleConfig(team, defaultRole),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyTeamExists("pagerduty_team.foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_team.foo", "name", team),
+					resource.TestCheckResourceAttr(
+						"pagerduty_team.foo", "default_role", defaultRole),
+					resource.TestCheckResourceAttrSet(
+						"pagerduty_team.foo", "html_url"),
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyTeamDefaultRoleConfig(team, defaultRoleUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"pagerduty_team.foo", "default_role", defaultRoleUpdated),
+				),
+			},
+		},
+	})
+}
+
 func TestAccPagerDutyTeam_Parent(t *testing.T) {
 	team := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	parent := fmt.Sprintf("tf-%s", acctest.RandString(5))
@@ -177,6 +210,17 @@ resource "pagerduty_team" "foo" {
 	name        = "%s"
 	description = "bar"
 }`, team)
+}
+
+func testAccCheckPagerDutyTeamDefaultRoleConfig(team, defaultRole string) string {
+	return fmt.Sprintf(`
+
+resource "pagerduty_team" "foo" {
+  name         = "%s"
+  description  = "foo"
+  default_role = "%s"
+}
+`, team, defaultRole)
 }
 
 func testAccCheckPagerDutyTeamWithParentConfig(team, parent string) string {

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/team.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/team.go
@@ -19,6 +19,7 @@ type Team struct {
 	Summary     string         `json:"summary,omitempty"`
 	Type        string         `json:"type,omitempty"`
 	Parent      *TeamReference `json:"parent,omitempty"`
+	DefaultRole string         `json:"default_role,omitempty"`
 }
 
 // Member represents a team member.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -182,7 +182,7 @@ github.com/hashicorp/terraform-svchost
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 ## explicit
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20230908205257-a96e6c05f7ea
+# github.com/heimweh/go-pagerduty v0.0.0-20231025174125-1492ec59406f
 ## explicit; go 1.17
 github.com/heimweh/go-pagerduty/pagerduty
 github.com/heimweh/go-pagerduty/persistentconfig

--- a/website/docs/d/team.html.markdown
+++ b/website/docs/d/team.html.markdown
@@ -49,5 +49,6 @@ The following arguments are supported:
 * `name` - The name of the found team.
 * `description` - A description of the found team.
 * `parent` - ID of the parent team. This is available to accounts with the Team Hierarchy feature enabled. Please contact your account manager for more information.
+* `default_role` - (Optional) The team is private if the value is "none", or public if it is "manager" (the default permissions for a non-member of the team are either "none", or their base role up until "manager").
 
 [1]: https://developer.pagerduty.com/api-reference/b3A6Mjc0ODIyMw-list-teams

--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -35,6 +35,7 @@ The following arguments are supported:
   * `description` - (Optional) A human-friendly description of the team.
     If not set, a placeholder of "Managed by Terraform" will be set.
   * `parent` - (Optional) ID of the parent team. This is available to accounts with the Team Hierarchy feature enabled. Please contact your account manager for more information.
+  * `default_role` - (Optional) The team is private if the value is "none", or public if it is "manager" (the default permissions for a non-member of the team are either "none", or their base role up until "manager").
 
 ## Attributes Reference
 


### PR DESCRIPTION
## WHAT
Adds support for creation of private teams.

## WHY
We cannot create permissions with the current provider the underlying and provider needs to be updates to add support for creating private teams.

Ref:
- Depends on... https://github.com/heimweh/go-pagerduty/pull/116
- Closes https://github.com/PagerDuty/terraform-provider-pagerduty/issues/611