### PR TITLE
Fix go module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/terraform-providers/terraform-provider-pagerduty
+module github.com/PagerDuty/terraform-provider-pagerduty
 
 go 1.20
 

--- a/main.go
+++ b/main.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server"
 	"github.com/hashicorp/terraform-plugin-mux/tf5muxserver"
 
-	"github.com/terraform-providers/terraform-provider-pagerduty/pagerduty"
-	pagerdutyplugin "github.com/terraform-providers/terraform-provider-pagerduty/pagerdutyplugin"
+	"github.com/PagerDuty/terraform-provider-pagerduty/pagerduty"
+	pagerdutyplugin "github.com/PagerDuty/terraform-provider-pagerduty/pagerdutyplugin"
 )
 
 func main() {

--- a/pagerduty/util.go
+++ b/pagerduty/util.go
@@ -6,8 +6,8 @@ package pagerduty
 import (
 	"time"
 
+	"github.com/PagerDuty/terraform-provider-pagerduty/util"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-pagerduty/util"
 )
 
 func timeToUTC(v string) (time.Time, error) {

--- a/pagerdutyplugin/config.go
+++ b/pagerdutyplugin/config.go
@@ -11,9 +11,9 @@ import (
 	"time"
 
 	"github.com/PagerDuty/go-pagerduty"
+	"github.com/PagerDuty/terraform-provider-pagerduty/util"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
-	"github.com/terraform-providers/terraform-provider-pagerduty/util"
 )
 
 // Config defines the configuration options for the PagerDuty client

--- a/pagerdutyplugin/provider_test.go
+++ b/pagerdutyplugin/provider_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	pd "github.com/terraform-providers/terraform-provider-pagerduty/pagerduty"
+	pd "github.com/PagerDuty/terraform-provider-pagerduty/pagerduty"
 )
 
 func testAccPreCheck(t *testing.T) {


### PR DESCRIPTION
Go suggests that modules correspond with version control paths. Since terraform-provider-pagerduty is hosted under PagerDuty, go suggests calling the module github.com/PagerDuty/terraform-provider-pagerduty.

Fixes #811