### PR TITLE
EF-3964 Address `team_membership` inconsistency after `create` and `update`

### DIFF
--- a/pagerduty/resource_pagerduty_team_membership_test.go
+++ b/pagerduty/resource_pagerduty_team_membership_test.go
@@ -49,6 +49,37 @@ func TestAccPagerDutyTeamMembership_WithRole(t *testing.T) {
 	})
 }
 
+func TestAccPagerDutyTeamMembership_WithRoleConsistentlyAssigned(t *testing.T) {
+	user := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	team := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	firstRole := "observer"
+	secondRole := "responder"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyTeamMembershipDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyTeamMembershipWithRoleConfig(user, team, firstRole),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyTeamMembershipExists("pagerduty_team_membership.foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_team_membership.foo", "role", firstRole),
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyTeamMembershipWithRoleConfig(user, team, secondRole),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyTeamMembershipExists("pagerduty_team_membership.foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_team_membership.foo", "role", secondRole),
+				),
+			},
+		},
+	})
+}
+
 func TestAccPagerDutyTeamMembership_DestroyWithEscalationPolicyDependant(t *testing.T) {
 	user := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	team := fmt.Sprintf("tf-%s", acctest.RandString(5))


### PR DESCRIPTION
Addresses the issue with `pagerduty_team_membership` that causes a permanent diff on TF state with the user **role**. So now the introduction of a few conditional retries to the GET call to validate the change when needed, the state diff can be remediated.

## Test cases introduced...
![Screenshot 2023-01-25 at 17 26 42](https://user-images.githubusercontent.com/24704624/214682665-e6f12921-eca8-4d46-aebd-1b1eadf1c605.png)
