### PR TITLE
implementation of custom fields for terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,3 +139,4 @@ PAGERDUTY_ACC_SERVICE_INTEGRATION_GENERIC_EMAIL_NO_FILTERS="user@<your_domain>.p
 | ----------------------------------------------------------- | ------------------- |
 | `PAGERDUTY_ACC_INCIDENT_WORKFLOWS`                          | Incident Workflows  |
 | `PAGERDUTY_ACC_SERVICE_INTEGRATION_GENERIC_EMAIL_NO_FILTERS` | Service Integration |
+| `PAGERDUTY_ACC_CUSTOM_FIELDS`                                | Custom Fields       |

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go v0.71.0 // indirect
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.1
-	github.com/heimweh/go-pagerduty v0.0.0-20230117201746-310c225f8600
+	github.com/heimweh/go-pagerduty v0.0.0-20230213205146-a7761402c92d
 	github.com/klauspost/compress v1.15.9 // indirect
 	github.com/montanaflynn/stats v0.6.6 // indirect
 	go.mongodb.org/mongo-driver v1.10.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -226,6 +226,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/heimweh/go-pagerduty v0.0.0-20230117201746-310c225f8600 h1:mf9awB4qvSXN6fIo94bd/MnG2n3ts+i2KA+mZ3N92z4=
 github.com/heimweh/go-pagerduty v0.0.0-20230117201746-310c225f8600/go.mod h1:t9vftsO1IjYHGdgJXeemZtomCWnxi2SRgu0PRcRb2oY=
+github.com/heimweh/go-pagerduty v0.0.0-20230213205146-a7761402c92d h1:9OZp5Bgl1WDswugwBKLiTcxeCT/t0c293zUtXLL6OUc=
+github.com/heimweh/go-pagerduty v0.0.0-20230213205146-a7761402c92d/go.mod h1:t9vftsO1IjYHGdgJXeemZtomCWnxi2SRgu0PRcRb2oY=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/pagerduty/custom_field_util.go
+++ b/pagerduty/custom_field_util.go
@@ -1,0 +1,154 @@
+package pagerduty
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/url"
+	"reflect"
+	"strconv"
+	"time"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+func validateCustomFieldDataType() schema.SchemaValidateDiagFunc {
+	return func(v interface{}, p cty.Path) diag.Diagnostics {
+		var diags diag.Diagnostics
+
+		dt := pagerduty.CustomFieldDataTypeFromString(v.(string))
+		if !dt.IsKnown() {
+			diags = append(diags, diag.Diagnostic{
+				Severity:      diag.Error,
+				Summary:       fmt.Sprintf("Unknown datatype %v", v),
+				AttributePath: p,
+			})
+		}
+		if !dt.IsAllowedOnField() {
+			diags = append(diags, diag.Diagnostic{
+				Severity:      diag.Error,
+				Summary:       fmt.Sprintf("Datatype %v is not allowed on fields", v),
+				AttributePath: p,
+			})
+		}
+		return diags
+	}
+}
+
+func validateCustomFieldValue(value string, datatype pagerduty.CustomFieldDataType, multiValue bool, generateError func() error) error {
+	noopValidator := func(v interface{}) error {
+		return nil
+	}
+	datetimeValidator := func(v interface{}) error {
+		_, err := time.Parse(time.RFC3339, v.(string))
+		return err
+	}
+	urlValidator := func(v interface{}) error {
+		u, err := url.Parse(v.(string))
+		if err != nil {
+			return err
+		}
+		if !u.IsAbs() {
+			return fmt.Errorf(`parsed url default value "%v" is not an absolute url`, v)
+		}
+		return nil
+	}
+
+	parsedValue, err := convertCustomFieldValueForBuild(value, datatype, multiValue)
+	if err != nil {
+		return generateError()
+	}
+
+	switch datatype {
+	case pagerduty.CustomFieldDataTypeString:
+		return validatedConvertedCustomFieldValue(reflect.TypeOf(""), parsedValue, multiValue, noopValidator, generateError)
+	case pagerduty.CustomFieldDataTypeFieldOption:
+		return validatedConvertedCustomFieldValue(reflect.TypeOf(""), parsedValue, multiValue, noopValidator, generateError)
+	case pagerduty.CustomFieldDataTypeInt:
+		var i int64
+		return validatedConvertedCustomFieldValue(reflect.TypeOf(i), parsedValue, multiValue, noopValidator, generateError)
+	case pagerduty.CustomFieldDataTypeFloat:
+		var f float64
+		return validatedConvertedCustomFieldValue(reflect.TypeOf(f), parsedValue, multiValue, noopValidator, generateError)
+	case pagerduty.CustomFieldDataTypeBool:
+		var b bool
+		return validatedConvertedCustomFieldValue(reflect.TypeOf(b), parsedValue, multiValue, noopValidator, generateError)
+	case pagerduty.CustomFieldDataTypeDateTime:
+		return validatedConvertedCustomFieldValue(reflect.TypeOf(""), parsedValue, multiValue, datetimeValidator, generateError)
+	case pagerduty.CustomFieldDataTypeUrl:
+		return validatedConvertedCustomFieldValue(reflect.TypeOf(""), parsedValue, multiValue, urlValidator, generateError)
+	default:
+		return fmt.Errorf("unrecognized datatype: %v", datatype)
+	}
+}
+
+func validatedConvertedCustomFieldValue(t reflect.Type, valueToValidate interface{}, expectSlice bool, valueValidator func(interface{}) error, errorGenerator func() error) error {
+	if expectSlice {
+		arr, ok := valueToValidate.([]interface{})
+		if !ok {
+			return errorGenerator()
+		}
+		for _, v := range arr {
+			err := validatedConvertedCustomFieldValue(t, v, false, valueValidator, errorGenerator)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	} else {
+		if reflect.TypeOf(valueToValidate) != t {
+			return errorGenerator()
+		}
+		return valueValidator(valueToValidate)
+	}
+}
+
+func convertCustomFieldValueForBuild(value string, datatype pagerduty.CustomFieldDataType, multiValue bool) (interface{}, error) {
+	if multiValue {
+		var v []interface{}
+		err := json.Unmarshal([]byte(value), &v)
+		if err != nil {
+			return nil, err
+		} else {
+			if datatype == pagerduty.CustomFieldDataTypeInt {
+				var iv []interface{}
+				for _, ev := range v {
+					fv, ok := ev.(float64)
+					if !ok {
+						return nil, fmt.Errorf("value %v not parseable as a number", ev)
+					}
+					iv = append(iv, int64(math.Round(fv)))
+				}
+				v = iv
+			}
+			return v, nil
+		}
+	} else {
+		switch datatype {
+		case pagerduty.CustomFieldDataTypeBool:
+			return strconv.ParseBool(value)
+		case pagerduty.CustomFieldDataTypeFloat:
+			return strconv.ParseFloat(value, 64)
+		case pagerduty.CustomFieldDataTypeInt:
+			return strconv.ParseInt(value, 10, 64)
+		default:
+			return value, nil
+		}
+	}
+}
+
+func convertCustomFieldValueForFlatten(value interface{}, multiValue bool) (string, error) {
+	if multiValue {
+		b, err := json.Marshal(value)
+		if err != nil {
+			return "", err
+		} else {
+			return string(b), nil
+		}
+	} else {
+		return fmt.Sprintf("%v", value), nil
+	}
+}

--- a/pagerduty/custom_field_util_test.go
+++ b/pagerduty/custom_field_util_test.go
@@ -1,0 +1,72 @@
+package pagerduty
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+func TestPagerDutyCustomField_ConvertValueForBuild(t *testing.T) {
+	v, _ := convertCustomFieldValueForBuild("5", pagerduty.CustomFieldDataTypeInt, false)
+	if v != int64(5) {
+		t.Errorf("Unexpected parse int value")
+	}
+
+	v, _ = convertCustomFieldValueForBuild("[5, 6]", pagerduty.CustomFieldDataTypeInt, true)
+	if !reflect.DeepEqual(v, []interface{}{int64(5), int64(6)}) {
+		t.Errorf("Unexpected parse []int value")
+	}
+
+	v, _ = convertCustomFieldValueForBuild("5.4", pagerduty.CustomFieldDataTypeFloat, false)
+	if v != 5.4 {
+		t.Errorf("Unexpected parse float value")
+	}
+
+	v, _ = convertCustomFieldValueForBuild("[5.4, 6.7]", pagerduty.CustomFieldDataTypeFloat, true)
+	if !reflect.DeepEqual(v, []interface{}{5.4, 6.7}) {
+		t.Errorf("Unexpected parse []float value")
+	}
+
+	v, _ = convertCustomFieldValueForBuild("false", pagerduty.CustomFieldDataTypeBool, false)
+	if v != false {
+		t.Errorf("Unexpected parse bool value")
+	}
+
+	v, _ = convertCustomFieldValueForBuild(`["foo","bar"]`, pagerduty.CustomFieldDataTypeString, true)
+	if !reflect.DeepEqual(v, []interface{}{"foo", "bar"}) {
+		t.Errorf("Unexpected parse []string value")
+	}
+}
+
+func TestPagerDutyCustomField_ConvertDefaultValueForFlatten(t *testing.T) {
+	v, _ := convertCustomFieldValueForFlatten(5, false)
+	if v != "5" {
+		t.Errorf("Unexpected flatten int value")
+	}
+
+	v, _ = convertCustomFieldValueForFlatten([]int{5, 6}, true)
+	if v != "[5,6]" {
+		t.Errorf("Unexpected flatten []int value")
+	}
+
+	v, _ = convertCustomFieldValueForFlatten(5.4, false)
+	if v != "5.4" {
+		t.Errorf("Unexpected flatten float value")
+	}
+
+	v, _ = convertCustomFieldValueForFlatten([]float64{5.4, 6.7}, true)
+	if v != "[5.4,6.7]" {
+		t.Errorf("Unexpected flatten []float value")
+	}
+
+	v, _ = convertCustomFieldValueForFlatten(false, false)
+	if v != "false" {
+		t.Errorf("Unexpected flatten bool value")
+	}
+
+	v, _ = convertCustomFieldValueForFlatten([]string{"foo", "bar"}, true)
+	if v != `["foo","bar"]` {
+		t.Errorf("Unexpected flatten []string value")
+	}
+}

--- a/pagerduty/data_source_pagerduty_custom_field.go
+++ b/pagerduty/data_source_pagerduty_custom_field.go
@@ -1,0 +1,93 @@
+package pagerduty
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+func dataSourcePagerDutyField() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourcePagerDutyCustomFieldRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"display_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"datatype": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"multi_value": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"fixed_options": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourcePagerDutyCustomFieldRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO] Reading PagerDuty data source")
+
+	searchName := d.Get("name").(string)
+
+	err = resource.RetryContext(ctx, 5*time.Minute, func() *resource.RetryError {
+		resp, _, err := client.CustomFields.ListContext(ctx, nil)
+		if err != nil {
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
+			return resource.RetryableError(err)
+		}
+
+		var found *pagerduty.CustomField
+
+		for _, field := range resp.Fields {
+			if field.Name == searchName {
+				found = field
+				break
+			}
+		}
+
+		if found == nil {
+			return resource.NonRetryableError(
+				fmt.Errorf("unable to locate any field with name: %s", searchName),
+			)
+		}
+
+		err = flattenCustomField(d, found)
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}

--- a/pagerduty/data_source_pagerduty_custom_field_test.go
+++ b/pagerduty/data_source_pagerduty_custom_field_test.go
@@ -1,0 +1,45 @@
+package pagerduty
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourcePagerDutyCustomField(t *testing.T) {
+	fieldName := fmt.Sprintf("tf_%s", acctest.RandString(5))
+	dataSourceName := fmt.Sprintf("data.pagerduty_custom_field.%s", fieldName)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckCustomFieldTests(t)
+		},
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourcePagerDutyCustomFieldConfig(fieldName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "id"),
+					resource.TestCheckResourceAttr(dataSourceName, "name", fieldName),
+					resource.TestCheckResourceAttr(dataSourceName, "datatype", "string"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourcePagerDutyCustomFieldConfig(name string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_custom_field" "input" {
+  name = "%[1]s"
+  display_name = "%[1]s"
+  datatype = "string"
+}
+
+data "pagerduty_custom_field" "%[1]s" {
+  name = pagerduty_custom_field.input.name
+}
+`, name)
+}

--- a/pagerduty/data_source_pagerduty_field_schema.go
+++ b/pagerduty/data_source_pagerduty_field_schema.go
@@ -1,0 +1,77 @@
+package pagerduty
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+func dataSourcePagerDutyFieldSchema() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourcePagerDutyFieldSchemaRead,
+		Schema: map[string]*schema.Schema{
+			"title": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourcePagerDutyFieldSchemaRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO] Reading PagerDuty data source")
+
+	search := d.Get("title").(string)
+
+	err = resource.RetryContext(ctx, 5*time.Minute, func() *resource.RetryError {
+		resp, _, err := client.CustomFieldSchemas.ListContext(ctx, nil)
+		if err != nil {
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
+			return resource.RetryableError(err)
+		}
+
+		var found *pagerduty.CustomFieldSchema
+
+		for _, fs := range resp.Schemas {
+			if fs.Title == search {
+				found = fs
+				break
+			}
+		}
+
+		if found == nil {
+			return resource.NonRetryableError(
+				fmt.Errorf("unable to locate any field schema with title: %s", search),
+			)
+		}
+
+		err = flattenFieldSchema(d, found)
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}

--- a/pagerduty/data_source_pagerduty_field_schema_test.go
+++ b/pagerduty/data_source_pagerduty_field_schema_test.go
@@ -1,0 +1,44 @@
+package pagerduty
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourcePagerDutyCustomFieldSchema(t *testing.T) {
+	schemaTitle := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	dataSourceName := fmt.Sprintf("data.pagerduty_custom_field_schema.%s", schemaTitle)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckCustomFieldTests(t)
+		},
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourcePagerDutyFieldSchemaConfig(schemaTitle),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "id"),
+					resource.TestCheckResourceAttr(dataSourceName, "title", schemaTitle),
+					resource.TestCheckResourceAttr(dataSourceName, "description", "some description"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourcePagerDutyFieldSchemaConfig(title string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_custom_field_schema" "input" {
+  title = "%[1]s"
+  description = "some description"
+}
+
+data "pagerduty_custom_field_schema" "%[1]s" {
+  title = pagerduty_custom_field_schema.input.title
+}
+`, title)
+}

--- a/pagerduty/import_pagerduty_custom_field_schema_test.go
+++ b/pagerduty/import_pagerduty_custom_field_schema_test.go
@@ -1,0 +1,32 @@
+package pagerduty
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccPagerDutyFieldSchema_import(t *testing.T) {
+	schemaTitle := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckCustomFieldTests(t)
+		},
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckPagerDutyCustomFieldDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyCustomFieldSchemaConfigBasic(schemaTitle),
+			},
+			{
+				ResourceName:      "pagerduty_custom_field_schema.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/pagerduty/import_pagerduty_custom_field_test.go
+++ b/pagerduty/import_pagerduty_custom_field_test.go
@@ -1,0 +1,32 @@
+package pagerduty
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccPagerDutyField_import(t *testing.T) {
+	fieldName := fmt.Sprintf("tf_%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckCustomFieldTests(t)
+		},
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckPagerDutyCustomFieldDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyCustomFieldConfig(fieldName, "", "string"),
+			},
+			{
+				ResourceName:      "pagerduty_custom_field.input",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/pagerduty/provider.go
+++ b/pagerduty/provider.go
@@ -65,6 +65,8 @@ func Provider() *schema.Provider {
 			"pagerduty_automation_actions_runner": dataSourcePagerDutyAutomationActionsRunner(),
 			"pagerduty_automation_actions_action": dataSourcePagerDutyAutomationActionsAction(),
 			"pagerduty_incident_workflow":         dataSourcePagerDutyIncidentWorkflow(),
+			"pagerduty_custom_field":              dataSourcePagerDutyField(),
+			"pagerduty_custom_field_schema":       dataSourcePagerDutyFieldSchema(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -104,6 +106,11 @@ func Provider() *schema.Provider {
 			"pagerduty_incident_workflow":                             resourcePagerDutyIncidentWorkflow(),
 			"pagerduty_incident_workflow_trigger":                     resourcePagerDutyIncidentWorkflowTrigger(),
 			"pagerduty_automation_actions_action_service_association": resourcePagerDutyAutomationActionsActionServiceAssociation(),
+			"pagerduty_custom_field":                                  resourcePagerDutyCustomField(),
+			"pagerduty_custom_field_option":                           resourcePagerDutyCustomFieldOption(),
+			"pagerduty_custom_field_schema":                           resourcePagerDutyCustomFieldSchema(),
+			"pagerduty_custom_field_schema_field_configuration":       resourcePagerDutyCustomFieldSchemaFieldConfiguration(),
+			"pagerduty_custom_field_schema_assignment":                resourcePagerDutyCustomFieldSchemaAssignment(),
 		},
 	}
 

--- a/pagerduty/resource_pagerduty_custom_field.go
+++ b/pagerduty/resource_pagerduty_custom_field.go
@@ -1,0 +1,180 @@
+package pagerduty
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+func resourcePagerDutyCustomField() *schema.Resource {
+	return &schema.Resource{
+		ReadContext:   resourcePagerDutyCustomFieldRead,
+		UpdateContext: resourcePagerDutyCustomFieldUpdate,
+		DeleteContext: resourcePagerDutyCustomFieldDelete,
+		CreateContext: resourcePagerDutyCustomFieldCreate,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"display_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"datatype": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateDiagFunc: validateCustomFieldDataType(),
+			},
+			"multi_value": {
+				Type:     schema.TypeBool,
+				Default:  false,
+				Optional: true,
+			},
+			"fixed_options": {
+				Type:     schema.TypeBool,
+				Default:  false,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourcePagerDutyCustomFieldCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	field, err := buildFieldStruct(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO] Creating PagerDuty field %s", field.Name)
+
+	createdField, _, err := client.CustomFields.CreateContext(ctx, field)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = flattenCustomField(d, createdField)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func resourcePagerDutyCustomFieldDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	_, err = client.CustomFields.DeleteContext(ctx, d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func resourcePagerDutyCustomFieldUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	field, err := buildFieldStruct(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO] Updating PagerDuty field %s", d.Id())
+
+	updatedField, _, err := client.CustomFields.UpdateContext(ctx, d.Id(), field)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = flattenCustomField(d, updatedField)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func resourcePagerDutyCustomFieldRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[INFO] Reading PagerDuty field %s", d.Id())
+	err := fetchField(ctx, d, meta, handleNotFoundError)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func fetchField(ctx context.Context, d *schema.ResourceData, meta interface{}, errorCallback func(error, *schema.ResourceData) error) error {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
+
+	return resource.RetryContext(ctx, 2*time.Minute, func() *resource.RetryError {
+		field, _, err := client.CustomFields.GetContext(ctx, d.Id(), nil)
+		if err != nil {
+			log.Printf("[WARN] Field read error")
+			errResp := errorCallback(err, d)
+			if errResp != nil {
+				time.Sleep(2 * time.Second)
+				return resource.RetryableError(errResp)
+			}
+
+			return nil
+		}
+
+		if err := flattenCustomField(d, field); err != nil {
+			return resource.NonRetryableError(err)
+		}
+		return nil
+
+	})
+}
+
+func flattenCustomField(d *schema.ResourceData, field *pagerduty.CustomField) error {
+	d.SetId(field.ID)
+	d.Set("name", field.Name)
+	if field.Description != nil {
+		d.Set("description", *(field.Description))
+	}
+	d.Set("display_name", field.DisplayName)
+	d.Set("datatype", field.DataType.String())
+	d.Set("multi_value", field.MultiValue)
+	d.Set("fixed_options", field.FixedOptions)
+	return nil
+}
+
+func buildFieldStruct(d *schema.ResourceData) (*pagerduty.CustomField, error) {
+	field := pagerduty.CustomField{
+		Name:         d.Get("name").(string),
+		DisplayName:  d.Get("display_name").(string),
+		DataType:     pagerduty.CustomFieldDataTypeFromString(d.Get("datatype").(string)),
+		MultiValue:   d.Get("multi_value").(bool),
+		FixedOptions: d.Get("fixed_options").(bool),
+	}
+	if desc, ok := d.GetOk("description"); ok {
+		str := desc.(string)
+		field.Description = &str
+	}
+	return &field, nil
+}

--- a/pagerduty/resource_pagerduty_custom_field_option.go
+++ b/pagerduty/resource_pagerduty_custom_field_option.go
@@ -1,0 +1,184 @@
+package pagerduty
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+func resourcePagerDutyCustomFieldOption() *schema.Resource {
+	return &schema.Resource{
+		ReadContext:   resourcePagerDutyCustomFieldOptionRead,
+		UpdateContext: resourcePagerDutyCustomFieldOptionUpdate,
+		DeleteContext: resourcePagerDutyCustomFieldOptionDelete,
+		CreateContext: resourcePagerDutyCustomFieldOptionCreate,
+		// this function does not actually customize the diff but uses this hook
+		// to validate the combination of datatype and value.
+		CustomizeDiff: validateCustomFieldOptionValue,
+		Schema: map[string]*schema.Schema{
+			"field": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"datatype": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateDiagFunc: validateCustomFieldDataType(),
+			},
+			"value": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func validateCustomFieldOptionValue(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+	datatype := pagerduty.CustomFieldDataTypeFromString(diff.Get("datatype").(string))
+	value := diff.Get("value").(string)
+
+	generateError := func() error {
+		return fmt.Errorf("invalid value for datatype %v: %v", datatype, value)
+	}
+
+	return validateCustomFieldValue(value, datatype, false, generateError)
+}
+
+func resourcePagerDutyCustomFieldOptionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	fieldID, fieldOption, err := buildFieldOptionStruct(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO] Creating PagerDuty field option %s: %s", fieldID, fieldOption.Data.Value)
+
+	createdFieldOption, _, err := client.CustomFields.CreateFieldOptionContext(ctx, fieldID, fieldOption)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = flattenFieldOption(d, fieldID, createdFieldOption)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func resourcePagerDutyCustomFieldOptionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	fieldID := d.Get("field").(string)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	_, err = client.CustomFields.DeleteFieldOptionContext(ctx, fieldID, d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func resourcePagerDutyCustomFieldOptionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	fieldID, fieldOption, err := buildFieldOptionStruct(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO] Updating PagerDuty field Option %s:%s", fieldID, d.Id())
+
+	updatedFieldOption, _, err := client.CustomFields.UpdateFieldOptionContext(ctx, fieldID, d.Id(), fieldOption)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = flattenFieldOption(d, fieldID, updatedFieldOption)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func resourcePagerDutyCustomFieldOptionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	fieldID := d.Get("field").(string)
+	log.Printf("[INFO] Reading PagerDuty field option %s:%s", fieldID, d.Id())
+	err := fetchFieldOption(ctx, fieldID, d, meta, handleNotFoundError)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func flattenFieldOption(d *schema.ResourceData, fieldID string, fieldOption *pagerduty.CustomFieldOption) error {
+	value, err := convertCustomFieldValueForFlatten(fieldOption.Data.Value, false)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(fieldOption.ID)
+	d.Set("field", fieldID)
+	d.Set("datatype", fieldOption.Data.DataType.String())
+	d.Set("value", value)
+	return nil
+}
+
+func buildFieldOptionStruct(d *schema.ResourceData) (string, *pagerduty.CustomFieldOption, error) {
+	fieldID := d.Get("field").(string)
+
+	dt := pagerduty.CustomFieldDataTypeFromString(d.Get("datatype").(string))
+	v, err := convertCustomFieldValueForBuild(d.Get("value").(string), dt, false)
+	if err != nil {
+		return fieldID, nil, err
+	}
+
+	fieldOption := pagerduty.CustomFieldOption{
+		Data: &pagerduty.CustomFieldOptionData{
+			DataType: dt,
+			Value:    v,
+		},
+	}
+
+	return fieldID, &fieldOption, nil
+}
+
+func fetchFieldOption(ctx context.Context, fieldID string, d *schema.ResourceData, meta interface{}, errorCallback func(error, *schema.ResourceData) error) error {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
+
+	return resource.RetryContext(ctx, 2*time.Minute, func() *resource.RetryError {
+		fieldOption, _, err := client.CustomFields.GetFieldOptionContext(ctx, fieldID, d.Id())
+		if err != nil {
+			log.Printf("[WARN] Field option read error")
+			errResp := errorCallback(err, d)
+			if errResp != nil {
+				time.Sleep(2 * time.Second)
+				return resource.RetryableError(errResp)
+			}
+
+			return nil
+		}
+
+		if err := flattenFieldOption(d, fieldID, fieldOption); err != nil {
+			return resource.NonRetryableError(err)
+		}
+		return nil
+
+	})
+}

--- a/pagerduty/resource_pagerduty_custom_field_option_test.go
+++ b/pagerduty/resource_pagerduty_custom_field_option_test.go
@@ -1,0 +1,243 @@
+package pagerduty
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+func TestAccPagerDutyCustomFieldOptions_Basic(t *testing.T) {
+	fieldName := fmt.Sprintf("tf_%s", acctest.RandString(5))
+	fieldOptionValue := fmt.Sprintf("tf_%s", acctest.RandString(5))
+	fieldOptionValue2 := fmt.Sprintf("tf_%s", acctest.RandString(5))
+	dataType := pagerduty.CustomFieldDataTypeString
+
+	testAccExecuteCustomFieldOptionTest(t, fieldName, dataType, fieldOptionValue, fieldOptionValue2)
+}
+
+func TestAccPagerDutyCustomFieldOptions_Integer(t *testing.T) {
+	fieldName := fmt.Sprintf("tf_%s", acctest.RandString(5))
+	fieldOptionValue := fmt.Sprintf("%v", acctest.RandIntRange(1, 500))
+	fieldOptionValue2 := fmt.Sprintf("%v", acctest.RandIntRange(1, 500))
+	dataType := pagerduty.CustomFieldDataTypeInt
+
+	testAccExecuteCustomFieldOptionTest(t, fieldName, dataType, fieldOptionValue, fieldOptionValue2)
+}
+
+func TestAccPagerDutyCustomFieldOptions_Integer_Bad(t *testing.T) {
+	fieldName := fmt.Sprintf("tf_%s", acctest.RandString(5))
+	fieldOptionValue := fmt.Sprintf("tf_%s", acctest.RandString(5))
+	dataType := pagerduty.CustomFieldDataTypeInt
+
+	testAccExecuteCustomFieldOptionTestError(t, fieldName, dataType, fieldOptionValue,
+		regexp.MustCompile(fmt.Sprintf("invalid value for datatype integer: %s", fieldOptionValue)))
+}
+
+func TestAccPagerDutyCustomFieldOptions_Integer_Bad_Float(t *testing.T) {
+	fieldName := fmt.Sprintf("tf_%s", acctest.RandString(5))
+	floatValue := float64(acctest.RandIntRange(1, 500)) + 0.5
+	fieldOptionValue := fmt.Sprintf("%v", floatValue)
+	dataType := pagerduty.CustomFieldDataTypeInt
+
+	testAccExecuteCustomFieldOptionTestError(t, fieldName, dataType, fieldOptionValue,
+		regexp.MustCompile(fmt.Sprintf("invalid value for datatype integer: %s", fieldOptionValue)))
+}
+
+func TestAccPagerDutyCustomFieldOptions_Float(t *testing.T) {
+	fieldName := fmt.Sprintf("tf_%s", acctest.RandString(5))
+	floatValue := float64(acctest.RandIntRange(1, 500)) + 0.5
+	fieldOptionValue := fmt.Sprintf("%v", floatValue)
+	floatValue2 := float64(acctest.RandIntRange(1, 500)) + 0.5
+	fieldOptionValue2 := fmt.Sprintf("%v", floatValue2)
+	dataType := pagerduty.CustomFieldDataTypeFloat
+
+	testAccExecuteCustomFieldOptionTest(t, fieldName, dataType, fieldOptionValue, fieldOptionValue2)
+}
+
+func TestAccPagerDutyCustomFieldOptions_Float_Bad(t *testing.T) {
+	fieldName := fmt.Sprintf("tf_%s", acctest.RandString(5))
+	fieldOptionValue := fmt.Sprintf("tf_%s", acctest.RandString(5))
+	dataType := pagerduty.CustomFieldDataTypeFloat
+
+	testAccExecuteCustomFieldOptionTestError(t, fieldName, dataType, fieldOptionValue,
+		regexp.MustCompile(fmt.Sprintf("invalid value for datatype float: %s", fieldOptionValue)))
+}
+
+func testAccExecuteCustomFieldOptionTest(t *testing.T, fieldName string, dataType pagerduty.CustomFieldDataType, fieldOptionValue, fieldOptionValueForUpdate string) {
+	var fieldID string
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckCustomFieldTests(t)
+
+			field := testAccCreateTestPagerDutyCustomFieldForFieldOption(fieldName, dataType)
+			fieldID = field.ID
+		},
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy: func(state *terraform.State) error {
+			err := testAccCheckPagerDutyCustomFieldOptionDestroy(state)
+			if err != nil {
+				return err
+			}
+			return testAccDeleteTestPagerDutyCustomFieldForFieldOption(fieldID)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyCustomFieldOptionConfig(fieldName, dataType, fieldOptionValue),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyCustomFieldOptionExists("pagerduty_custom_field_option.test"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_custom_field_option.test", "datatype", dataType.String()),
+					func(state *terraform.State) error {
+						return (resource.TestCheckResourceAttr(
+							"pagerduty_custom_field_option.test", "field", fieldID))(state)
+					},
+					resource.TestCheckResourceAttr(
+						"pagerduty_custom_field_option.test", "value", fieldOptionValue),
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyCustomFieldOptionConfig(fieldName, dataType, fieldOptionValueForUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyCustomFieldOptionExists("pagerduty_custom_field_option.test"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_custom_field_option.test", "datatype", dataType.String()),
+					func(state *terraform.State) error {
+						return (resource.TestCheckResourceAttr(
+							"pagerduty_custom_field_option.test", "field", fieldID))(state)
+					},
+					resource.TestCheckResourceAttr(
+						"pagerduty_custom_field_option.test", "value", fieldOptionValueForUpdate),
+				),
+			},
+		},
+	})
+}
+
+func testAccExecuteCustomFieldOptionTestError(t *testing.T, fieldName string, dataType pagerduty.CustomFieldDataType, fieldOptionValue string, errorRegex *regexp.Regexp) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckCustomFieldTests(t)
+		},
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckPagerDutyCustomFieldOptionConfigForErrorCases(fieldName, dataType, fieldOptionValue),
+				ExpectError: errorRegex,
+			},
+		},
+	})
+}
+
+func testAccCreateTestPagerDutyCustomFieldForFieldOption(fieldName string, dataType pagerduty.CustomFieldDataType) *pagerduty.CustomField {
+	config := Config{
+		Token:     os.Getenv("PAGERDUTY_TOKEN"),
+		UserToken: os.Getenv("PAGERDUTY_USER_TOKEN"),
+	}
+	client, _ := (&config).Client()
+
+	field, _, err := client.CustomFields.Create(&pagerduty.CustomField{
+		DataType:     dataType,
+		Name:         fieldName,
+		DisplayName:  fieldName,
+		FixedOptions: true,
+	})
+	if err != nil {
+		panic("Unable to create test field to contain option")
+	}
+	return field
+}
+
+func testAccDeleteTestPagerDutyCustomFieldForFieldOption(fieldID string) error {
+	config := Config{
+		Token:     os.Getenv("PAGERDUTY_TOKEN"),
+		UserToken: os.Getenv("PAGERDUTY_USER_TOKEN"),
+	}
+	client, _ := (&config).Client()
+
+	_, err := client.CustomFields.Delete(fieldID)
+	return err
+}
+
+func testAccCheckPagerDutyCustomFieldOptionConfig(name string, dataType pagerduty.CustomFieldDataType, fieldOptionValue string) string {
+	return fmt.Sprintf(`
+data "pagerduty_custom_field" "input" {
+  name = "%s"
+}
+
+resource "pagerduty_custom_field_option" "test" {
+  field = data.pagerduty_custom_field.input.id
+  datatype = "%s"
+  value = "%s"
+}
+
+`, name, dataType.String(), fieldOptionValue)
+}
+
+func testAccCheckPagerDutyCustomFieldOptionConfigForErrorCases(name string, dataType pagerduty.CustomFieldDataType, fieldOptionValue string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_custom_field" "input" {
+  name = "%[1]s"
+  display_name = "%[1]s"
+  datatype = "%[2]s"
+  fixed_options = true
+}
+
+resource "pagerduty_custom_field_option" "test" {
+  field = pagerduty_custom_field.input.id
+  datatype = "%[2]s"
+  value = "%[3]s"
+}
+
+`, name, dataType.String(), fieldOptionValue)
+}
+
+func testAccCheckPagerDutyCustomFieldOptionDestroy(s *terraform.State) error {
+	client, _ := testAccProvider.Meta().(*Config).Client()
+	for _, r := range s.RootModule().Resources {
+		if r.Type != "pagerduty_custom_field_option" {
+			continue
+		}
+
+		fieldID := r.Primary.Attributes["field"]
+		if _, _, err := client.CustomFields.GetFieldOption(fieldID, r.Primary.ID); err == nil {
+			return fmt.Errorf("field still exists")
+		}
+
+	}
+	return nil
+}
+
+func testAccCheckPagerDutyCustomFieldOptionExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no field option ID is set")
+		}
+
+		client, _ := testAccProvider.Meta().(*Config).Client()
+
+		fieldID := rs.Primary.Attributes["field"]
+		found, _, err := client.CustomFields.GetFieldOption(fieldID, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("field option not found: %v/%v - %v", fieldID, rs.Primary.ID, found)
+		}
+
+		return nil
+	}
+}

--- a/pagerduty/resource_pagerduty_custom_field_schema.go
+++ b/pagerduty/resource_pagerduty_custom_field_schema.go
@@ -1,0 +1,153 @@
+package pagerduty
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+func resourcePagerDutyCustomFieldSchema() *schema.Resource {
+	return &schema.Resource{
+		ReadContext:   resourcePagerDutyCustomFieldSchemaRead,
+		UpdateContext: resourcePagerDutyCustomFieldSchemaUpdate,
+		DeleteContext: resourcePagerDutyCustomFieldSchemaDelete,
+		CreateContext: resourcePagerDutyCustomFieldSchemaCreate,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"title": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourcePagerDutyCustomFieldSchemaCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	fieldSchema, err := buildFieldSchemaStruct(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO] Creating PagerDuty field schema %s.", fieldSchema.Title)
+
+	createdFieldSchema, _, err := client.CustomFieldSchemas.CreateContext(ctx, fieldSchema)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = flattenFieldSchema(d, createdFieldSchema)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func resourcePagerDutyCustomFieldSchemaDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	_, err = client.CustomFieldSchemas.DeleteContext(ctx, d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func resourcePagerDutyCustomFieldSchemaUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	fieldSchema, err := buildFieldSchemaStruct(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO] Updating PagerDuty field schema %s", d.Id())
+
+	updatedFieldSchema, _, err := client.CustomFieldSchemas.UpdateContext(ctx, d.Id(), fieldSchema)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = flattenFieldSchema(d, updatedFieldSchema)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func resourcePagerDutyCustomFieldSchemaRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[INFO] Reading PagerDuty field schema %s", d.Id())
+	err := fetchFieldSchema(ctx, d, meta, handleNotFoundError)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func fetchFieldSchema(ctx context.Context, d *schema.ResourceData, meta interface{}, errorCallback func(error, *schema.ResourceData) error) error {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
+
+	return resource.RetryContext(ctx, 2*time.Minute, func() *resource.RetryError {
+		fieldSchema, _, err := client.CustomFieldSchemas.GetContext(ctx, d.Id(), nil)
+		if err != nil {
+			log.Printf("[WARN] Field Schema read error")
+			errResp := errorCallback(err, d)
+			if errResp != nil {
+				time.Sleep(2 * time.Second)
+				return resource.RetryableError(errResp)
+			}
+
+			return nil
+		}
+
+		if err := flattenFieldSchema(d, fieldSchema); err != nil {
+			return resource.NonRetryableError(err)
+		}
+		return nil
+
+	})
+}
+
+func flattenFieldSchema(d *schema.ResourceData, fs *pagerduty.CustomFieldSchema) error {
+	d.SetId(fs.ID)
+	d.Set("title", fs.Title)
+	if fs.Description != nil {
+		d.Set("description", *(fs.Description))
+	}
+	return nil
+}
+
+func buildFieldSchemaStruct(d *schema.ResourceData) (*pagerduty.CustomFieldSchema, error) {
+	fieldSchema := pagerduty.CustomFieldSchema{
+		Title: d.Get("title").(string),
+	}
+	if desc, ok := d.GetOk("description"); ok {
+		str := desc.(string)
+		fieldSchema.Description = &str
+	}
+	return &fieldSchema, nil
+}

--- a/pagerduty/resource_pagerduty_custom_field_schema_assignment.go
+++ b/pagerduty/resource_pagerduty_custom_field_schema_assignment.go
@@ -1,0 +1,114 @@
+package pagerduty
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+func resourcePagerDutyCustomFieldSchemaAssignment() *schema.Resource {
+	return &schema.Resource{
+		ReadContext:   resourcePagerDutyCustomFieldSchemaAssignmentRead,
+		CreateContext: resourcePagerDutyCustomFieldSchemaAssignmentCreate,
+		DeleteContext: resourcePagerDutyCustomFieldSchemaAssignmentDelete,
+		Schema: map[string]*schema.Schema{
+			"schema": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"service": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourcePagerDutyCustomFieldSchemaAssignmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	serviceID := d.Get("service")
+	resp, _, err := client.CustomFieldSchemaAssignments.ListForServiceContext(ctx, serviceID.(string), nil)
+	if err != nil {
+		return diag.FromErr(err)
+	} else {
+		for _, fsa := range resp.SchemaAssignments {
+			if fsa.ID == d.Id() {
+				return nil
+			}
+		}
+		log.Printf("[WARN] Removing %s because it's gone", d.Id())
+		d.SetId("")
+		return nil
+	}
+}
+
+func resourcePagerDutyCustomFieldSchemaAssignmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO] Removing PagerDuty field schema assignment %s", d.Id())
+
+	_, err = client.CustomFieldSchemaAssignments.DeleteContext(ctx, d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func resourcePagerDutyCustomFieldSchemaAssignmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	a, err := buildFieldSchemaAssignmentStruct(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO] Creating PagerDuty field schema assignment %s -> %s", a.Service.ID, a.Schema.ID)
+
+	createdAssignment, _, err := client.CustomFieldSchemaAssignments.CreateContext(ctx, a)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = flattenFieldSchemaAssignment(d, createdAssignment)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func flattenFieldSchemaAssignment(d *schema.ResourceData, a *pagerduty.CustomFieldSchemaAssignment) error {
+	d.SetId(a.ID)
+	d.Set("schema", a.Schema.ID)
+	d.Set("service", a.Service.ID)
+	return nil
+}
+
+func buildFieldSchemaAssignmentStruct(d *schema.ResourceData) (*pagerduty.CustomFieldSchemaAssignment, error) {
+	a := pagerduty.CustomFieldSchemaAssignment{
+		Schema: &pagerduty.CustomFieldSchemaReference{
+			ID:   d.Get("schema").(string),
+			Type: "schema_reference",
+		},
+		Service: &pagerduty.ServiceReference{
+			ID:   d.Get("service").(string),
+			Type: "service_reference",
+		},
+	}
+
+	return &a, nil
+}

--- a/pagerduty/resource_pagerduty_custom_field_schema_assignment_test.go
+++ b/pagerduty/resource_pagerduty_custom_field_schema_assignment_test.go
@@ -1,0 +1,134 @@
+package pagerduty
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+func init() {
+	resource.AddTestSweepers("pagerduty_custom_field_schema_assignments", &resource.Sweeper{
+		Name: "pagerduty_custom_field_schema_assignments",
+		F:    testSweepCustomFieldSchemaAssignment,
+	})
+}
+
+func testSweepCustomFieldSchemaAssignment(region string) error {
+	return testSweepForEachCustomFieldSchema(region, func(client *pagerduty.Client, fieldSchema *pagerduty.CustomFieldSchema) error {
+		resp, _, err := client.CustomFieldSchemaAssignments.ListForSchema(fieldSchema.ID, nil)
+		if err != nil {
+			return err
+		}
+		for _, a := range resp.SchemaAssignments {
+			_, err = client.CustomFieldSchemaAssignments.Delete(a.ID)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func TestAccPagerDutyCustomFieldSchemaAssignment(t *testing.T) {
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.test", username)
+	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	schemaTitle := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckCustomFieldTests(t)
+		},
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckPagerDutyCustomFieldSchemaAssignmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyCustomFieldSchemaAssignment(schemaTitle, username, email, escalationPolicy, service),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyCustomFieldSchemaAssignmentExists("pagerduty_custom_field_schema.test", "pagerduty_service.foo"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckPagerDutyCustomFieldSchemaAssignment(schemaTitle, username, email, escalationPolicy, service string) string {
+	serviceConfig := testAccCheckPagerDutyServiceConfig(username, email, escalationPolicy, service)
+	schemaConfig := testAccCheckPagerDutyCustomFieldSchemaConfigBasic(schemaTitle)
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "pagerduty_custom_field_schema_assignment" "test" {
+  schema        = pagerduty_custom_field_schema.test.id
+  service   = pagerduty_service.foo.id
+}
+`, serviceConfig, schemaConfig)
+}
+
+func testAccCheckPagerDutyCustomFieldSchemaAssignmentDestroy(s *terraform.State) error {
+	client, _ := testAccProvider.Meta().(*Config).Client()
+	for _, r := range s.RootModule().Resources {
+		if r.Type != "pagerduty_custom_field_schema_assignment" {
+			continue
+		}
+		schemaId := r.Primary.Attributes["schema"]
+		serviceID := r.Primary.Attributes["service"]
+
+		if as, _, err := client.CustomFieldSchemaAssignments.ListForService(serviceID, nil); err == nil && len(as.SchemaAssignments) != 0 &&
+			testAccCustomFieldSchemaAssignmentsContainSchema(as.SchemaAssignments, schemaId) {
+			return fmt.Errorf("field schema assignment still exists")
+		}
+
+	}
+	return nil
+}
+
+func testAccCheckPagerDutyCustomFieldSchemaAssignmentExists(schemaName, serviceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		schemaResource, ok := s.RootModule().Resources[schemaName]
+		if !ok {
+			return fmt.Errorf("schema not found: %s", schemaName)
+		}
+		if schemaResource.Primary.ID == "" {
+			return fmt.Errorf("no field schema ID is set")
+		}
+
+		serviceResource, ok := s.RootModule().Resources[serviceName]
+		if !ok {
+			return fmt.Errorf("service not found: %s", serviceName)
+		}
+		if serviceResource.Primary.ID == "" {
+			return fmt.Errorf("no service ID is set")
+		}
+
+		client, _ := testAccProvider.Meta().(*Config).Client()
+
+		as, _, err := client.CustomFieldSchemaAssignments.ListForService(serviceResource.Primary.ID, nil)
+		if err != nil {
+			return err
+		}
+
+		if !testAccCustomFieldSchemaAssignmentsContainSchema(as.SchemaAssignments, schemaResource.Primary.ID) {
+			return fmt.Errorf("field schema %v not found in associations of %v", schemaResource.Primary.ID, serviceResource.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccCustomFieldSchemaAssignmentsContainSchema(as []*pagerduty.CustomFieldSchemaAssignment, id string) bool {
+	for _, a := range as {
+		if a.Schema.ID == id {
+			return true
+		}
+	}
+	return false
+}

--- a/pagerduty/resource_pagerduty_custom_field_schema_field_configuration.go
+++ b/pagerduty/resource_pagerduty_custom_field_schema_field_configuration.go
@@ -1,0 +1,261 @@
+package pagerduty
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+func resourcePagerDutyCustomFieldSchemaFieldConfiguration() *schema.Resource {
+	return &schema.Resource{
+		ReadContext:   resourcePagerDutyCustomFieldSchemaFieldConfigurationRead,
+		UpdateContext: resourcePagerDutyCustomFieldSchemaFieldConfigurationUpdate,
+		DeleteContext: resourcePagerDutyCustomFieldSchemaFieldConfigurationDelete,
+		CreateContext: resourcePagerDutyCustomFieldSchemaFieldConfigurationCreate,
+		// this function does not actually customize the diff but uses this hook
+		// to validate the combination of required and the default_value prefixed
+		// attributes
+		CustomizeDiff: validateCustomFieldsForSchema,
+		Schema: map[string]*schema.Schema{
+			"schema": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"field": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"required": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"default_value": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"default_value_multi_value": {
+				Type:     schema.TypeBool,
+				Default:  false,
+				Optional: true,
+			},
+			"default_value_datatype": {
+				Type:             schema.TypeString,
+				ValidateDiagFunc: validateCustomFieldDataTypeForFieldConfiguration(),
+				Optional:         true,
+			},
+		},
+	}
+}
+
+func resourcePagerDutyCustomFieldSchemaFieldConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	schemaID, fieldConfiguration, err := buildFieldSchemaFieldConfigurationStruct(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO] Creating PagerDuty field configuration %s %s.", schemaID, fieldConfiguration.Field.ID)
+
+	createdFieldConfiguration, _, err := client.CustomFieldSchemas.CreateFieldConfigurationContext(ctx, schemaID, fieldConfiguration)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = flattenFieldSchemaFieldConfiguration(d, schemaID, createdFieldConfiguration)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func resourcePagerDutyCustomFieldSchemaFieldConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	schemaID := d.Get("schema").(string)
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	_, err = client.CustomFieldSchemas.DeleteFieldConfigurationContext(ctx, schemaID, d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func resourcePagerDutyCustomFieldSchemaFieldConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	schemaID, fieldConfiguration, err := buildFieldSchemaFieldConfigurationStruct(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO] Updating PagerDuty field schema field configuration %s", d.Id())
+
+	updatedFieldConfiguration, _, err := client.CustomFieldSchemas.UpdateFieldConfigurationContext(ctx, schemaID, d.Id(), fieldConfiguration)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = flattenFieldSchemaFieldConfiguration(d, schemaID, updatedFieldConfiguration)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func resourcePagerDutyCustomFieldSchemaFieldConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	schemaID := d.Get("schema").(string)
+	log.Printf("[INFO] Reading PagerDuty field schema field configuration %s %s", schemaID, d.Id())
+	err := fetchFieldSchemaFieldConfiguration(ctx, schemaID, d, meta, handleNotFoundError)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func fetchFieldSchemaFieldConfiguration(ctx context.Context, schemaID string, d *schema.ResourceData, meta interface{}, errorCallback func(error, *schema.ResourceData) error) error {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
+
+	return resource.RetryContext(ctx, 2*time.Minute, func() *resource.RetryError {
+		fieldConfiguration, _, err := client.CustomFieldSchemas.GetFieldConfigurationContext(ctx, schemaID, d.Id(), nil)
+		if err != nil {
+			log.Printf("[WARN] Field Schema Field Configuration read error")
+			errResp := errorCallback(err, d)
+			if errResp != nil {
+				time.Sleep(2 * time.Second)
+				return resource.RetryableError(errResp)
+			}
+
+			return nil
+		}
+
+		if err := flattenFieldSchemaFieldConfiguration(d, schemaID, fieldConfiguration); err != nil {
+			return resource.NonRetryableError(err)
+		}
+		return nil
+
+	})
+}
+
+func flattenFieldSchemaFieldConfiguration(d *schema.ResourceData, schemaID string, fc *pagerduty.CustomFieldSchemaFieldConfiguration) error {
+	if fc.DefaultValue != nil {
+		v, err := convertCustomFieldValueForFlatten(fc.DefaultValue.Value, fc.DefaultValue.MultiValue)
+		if err != nil {
+			return err
+		}
+		d.Set("default_value_datatype", fc.DefaultValue.DataType.String())
+		d.Set("default_value_multi_value", fc.DefaultValue.MultiValue)
+		d.Set("default_value", v)
+	}
+
+	d.SetId(fc.ID)
+	d.Set("schema", schemaID)
+	d.Set("required", fc.Required)
+
+	return nil
+}
+
+func buildFieldSchemaFieldConfigurationStruct(d *schema.ResourceData) (string, *pagerduty.CustomFieldSchemaFieldConfiguration, error) {
+	schemaID := d.Get("schema").(string)
+	fieldConfiguration := pagerduty.CustomFieldSchemaFieldConfiguration{
+		Field: &pagerduty.CustomField{
+			ID: d.Get("field").(string),
+		},
+	}
+
+	required, hadRequired := d.GetOk("required")
+
+	if hadRequired && required.(bool) {
+		fieldConfiguration.Required = true
+
+		dt := pagerduty.CustomFieldDataTypeFromString(d.Get("default_value_datatype").(string))
+		mv := d.Get("default_value_multi_value").(bool)
+		v, err := convertCustomFieldValueForBuild(d.Get("default_value").(string), dt, mv)
+		if err == nil {
+			fieldConfiguration.DefaultValue = &pagerduty.CustomFieldDefaultValue{
+				DataType:   dt,
+				MultiValue: mv,
+				Value:      v,
+			}
+		} else {
+			return schemaID, nil, err
+		}
+	}
+
+	return schemaID, &fieldConfiguration, nil
+}
+
+func validateCustomFieldsForSchema(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
+	defaultValue, hadDefaultValue := d.GetOk("default_value")
+	required, hadRequired := d.GetOk("required")
+	if hadRequired && required.(bool) {
+		if !hadDefaultValue || defaultValue == "" {
+			return fmt.Errorf("required field without default value")
+		}
+	}
+
+	if hadDefaultValue {
+		defaultValueDataType, hadDefaultValueDataType := d.GetOk("default_value_datatype")
+		if !hadDefaultValueDataType || defaultValueDataType == "" {
+			return fmt.Errorf("required field without default value datatype")
+		}
+		dt := pagerduty.CustomFieldDataTypeFromString(defaultValueDataType.(string))
+		if !dt.IsKnown() {
+			// this is essentially impossible since default_value_datatype is validated
+			return fmt.Errorf("unknown default value datatype: %s", defaultValueDataType)
+		}
+		defaultValueMultiValue, hadDefaultValueMultiValue := d.GetOk("default_value_multi_value")
+		err := validateDefaultFieldValue(defaultValue.(string), dt, hadDefaultValueMultiValue && defaultValueMultiValue.(bool))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateDefaultFieldValue(value string, datatype pagerduty.CustomFieldDataType, multiValue bool) error {
+	generateError := func() error {
+		if multiValue {
+			return fmt.Errorf("invalid default value for datatype %v (multi-value): %v", datatype, value)
+		} else {
+			return fmt.Errorf("invalid default value for datatype %v: %v", datatype, value)
+		}
+	}
+
+	return validateCustomFieldValue(value, datatype, multiValue, generateError)
+
+}
+
+func validateCustomFieldDataTypeForFieldConfiguration() schema.SchemaValidateDiagFunc {
+	return func(v interface{}, p cty.Path) diag.Diagnostics {
+		var diags diag.Diagnostics
+
+		dt := pagerduty.CustomFieldDataTypeFromString(v.(string))
+		if !dt.IsKnown() {
+			diags = append(diags, diag.Diagnostic{
+				Severity:      diag.Error,
+				Summary:       fmt.Sprintf("Unknown datatype %v", v),
+				AttributePath: p,
+			})
+		}
+		return diags
+	}
+}

--- a/pagerduty/resource_pagerduty_custom_field_schema_field_configuration_test.go
+++ b/pagerduty/resource_pagerduty_custom_field_schema_field_configuration_test.go
@@ -1,0 +1,631 @@
+package pagerduty
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+func TestPagerDutyCustomField_ValidateDefaultFieldValue(t *testing.T) {
+	var testData = []struct {
+		datatype         pagerduty.CustomFieldDataType
+		multiValue       bool
+		value            string
+		expectError      bool
+		expectedErrorStr string
+	}{{
+		datatype:         pagerduty.CustomFieldDataTypeInt,
+		multiValue:       false,
+		value:            "default!!!",
+		expectedErrorStr: `invalid default value for datatype integer: default!!!`,
+		expectError:      true,
+	}, {
+		datatype:    pagerduty.CustomFieldDataTypeInt,
+		multiValue:  false,
+		value:       "42",
+		expectError: false,
+	}, {
+		datatype:         pagerduty.CustomFieldDataTypeInt,
+		multiValue:       true,
+		value:            "42",
+		expectedErrorStr: `invalid default value for datatype integer (multi-value): 42`,
+		expectError:      true,
+	}, {
+		datatype:         pagerduty.CustomFieldDataTypeInt,
+		multiValue:       true,
+		value:            `[42,"foo"]`,
+		expectedErrorStr: `invalid default value for datatype integer (multi-value): [42,"foo"]`,
+		expectError:      true,
+	}, {
+		datatype:         pagerduty.CustomFieldDataTypeFloat,
+		multiValue:       true,
+		value:            `[50.5,"foo"]`,
+		expectedErrorStr: `invalid default value for datatype float (multi-value): [50.5,"foo"]`,
+		expectError:      true,
+	}, {
+		datatype:    pagerduty.CustomFieldDataTypeFloat,
+		multiValue:  true,
+		value:       `[50.5,42.3]`,
+		expectError: false,
+	}, {
+		datatype:         pagerduty.CustomFieldDataTypeFloat,
+		multiValue:       false,
+		value:            "default!!!",
+		expectedErrorStr: `invalid default value for datatype float: default!!!`,
+		expectError:      true,
+	}, {
+		datatype:    pagerduty.CustomFieldDataTypeFloat,
+		multiValue:  false,
+		value:       "50.5",
+		expectError: false,
+	}, {
+		datatype:         pagerduty.CustomFieldDataTypeFloat,
+		multiValue:       true,
+		value:            "50.5",
+		expectedErrorStr: `invalid default value for datatype float (multi-value): 50.5`,
+		expectError:      true,
+	}, {
+		datatype:         pagerduty.CustomFieldDataTypeFloat,
+		multiValue:       true,
+		value:            `[50.5,"foo"]`,
+		expectedErrorStr: `invalid default value for datatype float (multi-value): [50.5,"foo"]`,
+		expectError:      true,
+	}, {
+		datatype:    pagerduty.CustomFieldDataTypeFloat,
+		multiValue:  true,
+		value:       `[50.5,42.3]`,
+		expectError: false,
+	}, {
+		datatype:         pagerduty.CustomFieldDataTypeBool,
+		multiValue:       false,
+		value:            "default!!!",
+		expectedErrorStr: `invalid default value for datatype boolean: default!!!`,
+		expectError:      true,
+	}, {
+		datatype:    pagerduty.CustomFieldDataTypeBool,
+		multiValue:  false,
+		value:       "True",
+		expectError: false,
+	}, {
+		datatype:    pagerduty.CustomFieldDataTypeBool,
+		multiValue:  false,
+		value:       "true",
+		expectError: false,
+	}, {
+		datatype:    pagerduty.CustomFieldDataTypeBool,
+		multiValue:  false,
+		value:       "false",
+		expectError: false,
+	}, {
+		datatype:         pagerduty.CustomFieldDataTypeUrl,
+		multiValue:       false,
+		value:            "default!!!",
+		expectedErrorStr: `parsed url default value "default!!!" is not an absolute url`,
+		expectError:      true,
+	}, {
+		datatype:         pagerduty.CustomFieldDataTypeUrl,
+		multiValue:       false,
+		value:            "\x01",
+		expectedErrorStr: "invalid control character in URL",
+		expectError:      true,
+	}, {
+		datatype:    pagerduty.CustomFieldDataTypeUrl,
+		multiValue:  false,
+		value:       "https://www.pagerduty.com/",
+		expectError: false,
+	}, {
+		datatype:         pagerduty.CustomFieldDataTypeDateTime,
+		multiValue:       false,
+		value:            "default!!!",
+		expectedErrorStr: `parsing time "default!!!"`,
+		expectError:      true,
+	}, {
+		datatype:    pagerduty.CustomFieldDataTypeDateTime,
+		multiValue:  false,
+		value:       "2022-01-03T15:04:05Z",
+		expectError: false,
+	}, {
+		datatype:    pagerduty.CustomFieldDataTypeFieldOption,
+		multiValue:  false,
+		value:       "anything goes -- validated server-side",
+		expectError: false,
+	}, {
+		datatype:    pagerduty.CustomFieldDataTypeFieldOption,
+		multiValue:  true,
+		value:       "something",
+		expectError: true,
+	}}
+
+	for _, td := range testData {
+		name := fmt.Sprintf("Test value: %s for type %v, multi-value: %v", td.value, td.datatype, td.multiValue)
+		t.Run(name, func(t *testing.T) {
+			err := validateDefaultFieldValue(td.value, td.datatype, td.multiValue)
+			if td.expectError {
+				if err == nil {
+					t.Errorf("expected error, but did not receive one")
+				} else if !strings.Contains(err.Error(), td.expectedErrorStr) {
+					t.Errorf("expected error to contain %s but did not. was %s", td.expectedErrorStr, err.Error())
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+		})
+	}
+}
+
+func TestAccPagerDutyCustomFieldConfiguration_Basic(t *testing.T) {
+	fieldName := fmt.Sprintf("tf_%s", acctest.RandString(5))
+	schemaTitle := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	var fieldID string
+	var schemaID string
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckCustomFieldTests(t)
+
+			field := testAccCreateTestPagerDutyCustomFieldForFieldConfiguration(fieldName)
+			fieldID = field.ID
+
+			schema := testAccCreateTestPagerDutyCustomFieldSchemaForFieldConfiguration(schemaTitle)
+			schemaID = schema.ID
+		},
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy: func(state *terraform.State) error {
+			err := testAccCheckPagerDutyCustomFieldConfigurationDestroy(state)
+			if err != nil {
+				return err
+			}
+			err = testAccDeleteTestPagerDutyCustomFieldForFieldConfiguration(fieldID)
+			if err != nil {
+				return err
+			}
+			return testAccDeleteTestPagerDutyCustomFieldSchemaForFieldConfiguration(schemaID)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyCustomFieldConfigurationConfigBasic(fieldName, schemaTitle),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyCustomFieldSchemaFieldConfigurationExists("pagerduty_custom_field_schema_field_configuration.test"),
+					func(state *terraform.State) error {
+						return (resource.TestCheckResourceAttr(
+							"pagerduty_custom_field_schema_field_configuration.test", "field", fieldID))(state)
+					},
+					func(state *terraform.State) error {
+						return (resource.TestCheckResourceAttr(
+							"pagerduty_custom_field_schema_field_configuration.test", "schema", schemaID))(state)
+					},
+				),
+			},
+		},
+	})
+}
+
+func TestAccPagerDutyCustomFieldConfiguration_Required(t *testing.T) {
+	fieldName := fmt.Sprintf("tf_%s", acctest.RandString(5))
+	schemaTitle := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	var fieldID string
+	var schemaID string
+
+	config := fmt.Sprintf(`
+data "pagerduty_custom_field" "input" {
+  name = "%s"
+}
+
+data "pagerduty_custom_field_schema" "input" {
+  title = "%s"
+}
+
+resource "pagerduty_custom_field_schema_field_configuration" "test" {
+  field                  = data.pagerduty_custom_field.input.id
+  schema                 = data.pagerduty_custom_field_schema.input.id
+  required               = true
+  default_value          = "test"
+  default_value_datatype = "string"
+}
+
+`, fieldName, schemaTitle)
+
+	configForUpdate := fmt.Sprintf(`
+data "pagerduty_custom_field" "input" {
+  name = "%s"
+}
+
+data "pagerduty_custom_field_schema" "input" {
+  title = "%s"
+}
+
+resource "pagerduty_custom_field_schema_field_configuration" "test" {
+  field                  = data.pagerduty_custom_field.input.id
+  schema                 = data.pagerduty_custom_field_schema.input.id
+  required               = true
+  default_value          = "updated"
+  default_value_datatype = "string"
+}
+
+`, fieldName, schemaTitle)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckCustomFieldTests(t)
+
+			field := testAccCreateTestPagerDutyCustomFieldForFieldConfiguration(fieldName)
+			fieldID = field.ID
+
+			schema := testAccCreateTestPagerDutyCustomFieldSchemaForFieldConfiguration(schemaTitle)
+			schemaID = schema.ID
+		},
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy: func(state *terraform.State) error {
+			err := testAccCheckPagerDutyCustomFieldConfigurationDestroy(state)
+			if err != nil {
+				return err
+			}
+			err = testAccDeleteTestPagerDutyCustomFieldForFieldConfiguration(fieldID)
+			if err != nil {
+				return err
+			}
+			return testAccDeleteTestPagerDutyCustomFieldSchemaForFieldConfiguration(schemaID)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyCustomFieldSchemaFieldConfigurationExists("pagerduty_custom_field_schema_field_configuration.test"),
+					func(state *terraform.State) error {
+						return (resource.TestCheckResourceAttr(
+							"pagerduty_custom_field_schema_field_configuration.test", "field", fieldID))(state)
+					},
+					func(state *terraform.State) error {
+						return (resource.TestCheckResourceAttr(
+							"pagerduty_custom_field_schema_field_configuration.test", "schema", schemaID))(state)
+					},
+					resource.TestCheckResourceAttr(
+						"pagerduty_custom_field_schema_field_configuration.test", "required", "true"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_custom_field_schema_field_configuration.test", "default_value", "test"),
+				),
+			},
+			{
+				Config: configForUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyCustomFieldSchemaFieldConfigurationExists("pagerduty_custom_field_schema_field_configuration.test"),
+					func(state *terraform.State) error {
+						return (resource.TestCheckResourceAttr(
+							"pagerduty_custom_field_schema_field_configuration.test", "field", fieldID))(state)
+					},
+					func(state *terraform.State) error {
+						return (resource.TestCheckResourceAttr(
+							"pagerduty_custom_field_schema_field_configuration.test", "schema", schemaID))(state)
+					},
+					resource.TestCheckResourceAttr(
+						"pagerduty_custom_field_schema_field_configuration.test", "required", "true"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_custom_field_schema_field_configuration.test", "default_value", "updated"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPagerDutyCustomFieldConfiguration_Required_BadDataType(t *testing.T) {
+	fieldName := fmt.Sprintf("tf_%s", acctest.RandString(5))
+	schemaTitle := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	config := fmt.Sprintf(`
+resource "pagerduty_custom_field" "input" {
+  name = "%[1]s"
+  display_name = "%[1]s"
+  datatype = "string"
+}
+
+resource "pagerduty_custom_field_schema" "input" {
+  title = "%[2]s"
+}
+
+resource "pagerduty_custom_field_schema_field_configuration" "test" {
+  field                  = pagerduty_custom_field.input.id
+  schema                 = pagerduty_custom_field_schema.input.id
+  required               = true
+  default_value          = "test"
+  default_value_datatype = "garbage"
+}
+
+`, fieldName, schemaTitle)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckCustomFieldTests(t)
+		},
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile("Unknown datatype garbage"),
+			},
+		},
+	})
+}
+
+func TestAccPagerDutyCustomFieldConfiguration_Required_Without_Default(t *testing.T) {
+	fieldName := fmt.Sprintf("tf_%s", acctest.RandString(5))
+	schemaTitle := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	config := fmt.Sprintf(`
+resource "pagerduty_custom_field" "input" {
+  name = "%[1]s"
+  display_name = "%[1]s"
+  datatype = "string"
+}
+
+resource "pagerduty_custom_field_schema" "input" {
+  title = "%[2]s"
+}
+
+resource "pagerduty_custom_field_schema_field_configuration" "test" {
+  field                  = pagerduty_custom_field.input.id
+  schema                 = pagerduty_custom_field_schema.input.id
+  required               = true
+  default_value          = "test"
+}
+
+`, fieldName, schemaTitle)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckCustomFieldTests(t)
+		},
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile("required field without default value"),
+			},
+		},
+	})
+}
+
+func TestAccPagerDutyCustomFieldConfiguration_Required_Without_DefaultDataType(t *testing.T) {
+	fieldName := fmt.Sprintf("tf_%s", acctest.RandString(5))
+	schemaTitle := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	config := fmt.Sprintf(`
+resource "pagerduty_custom_field" "input" {
+  name = "%[1]s"
+  display_name = "%[1]s"
+  datatype = "string"
+}
+
+resource "pagerduty_custom_field_schema" "input" {
+  title = "%[2]s"
+}
+
+resource "pagerduty_custom_field_schema_field_configuration" "test" {
+  field                  = pagerduty_custom_field.input.id
+  schema                 = pagerduty_custom_field_schema.input.id
+  required               = true
+}
+
+`, fieldName, schemaTitle)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckCustomFieldTests(t)
+		},
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile("required field without default value"),
+			},
+		},
+	})
+}
+
+func TestAccPagerDutyFieldConfiguration_Required_InvalidValue(t *testing.T) {
+	fieldName := fmt.Sprintf("tf_%s", acctest.RandString(5))
+	schemaTitle := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	config := fmt.Sprintf(`
+resource "pagerduty_custom_field" "input" {
+  name = "%[1]s"
+  display_name = "%[1]s"
+  datatype = "string"
+}
+
+resource "pagerduty_custom_field_schema" "input" {
+  title = "%[2]s"
+}
+
+resource "pagerduty_custom_field_schema_field_configuration" "test" {
+  field                  = pagerduty_custom_field.input.id
+  schema                 = pagerduty_custom_field_schema.input.id
+  required               = true
+  default_value          = "garbage"
+  default_value_datatype = "integer"
+}
+
+`, fieldName, schemaTitle)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckCustomFieldTests(t)
+		},
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile("invalid default value for datatype integer: garbage"),
+			},
+		},
+	})
+}
+
+func TestAccPagerDutyCustomFieldConfiguration_Required_InvalidValue_MultiValue(t *testing.T) {
+	fieldName := fmt.Sprintf("tf_%s", acctest.RandString(5))
+	schemaTitle := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	config := fmt.Sprintf(`
+resource "pagerduty_custom_field" "input" {
+  name = "%[1]s"
+  display_name = "%[1]s"
+  datatype = "string"
+}
+
+resource "pagerduty_custom_field_schema" "input" {
+  title = "%[2]s"
+}
+
+resource "pagerduty_custom_field_schema_field_configuration" "test" {
+  field                     = pagerduty_custom_field.input.id
+  schema                    = pagerduty_custom_field_schema.input.id
+  required                  = true
+  default_value             = "garbage"
+  default_value_datatype    = "integer"
+  default_value_multi_value = true
+}
+
+`, fieldName, schemaTitle)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckCustomFieldTests(t)
+		},
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile("invalid default value for datatype integer \\(multi-value\\): garbage"),
+			},
+		},
+	})
+}
+
+func testAccCheckPagerDutyCustomFieldSchemaFieldConfigurationExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no field configuration ID is set")
+		}
+
+		client, _ := testAccProvider.Meta().(*Config).Client()
+
+		schemaID := rs.Primary.Attributes["schema"]
+		found, _, err := client.CustomFieldSchemas.GetFieldConfiguration(schemaID, rs.Primary.ID, nil)
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("field configuration not found: %v/%v - %v", schemaID, rs.Primary.ID, found)
+		}
+
+		return nil
+	}
+}
+
+func testAccCreateTestPagerDutyCustomFieldForFieldConfiguration(fieldName string) *pagerduty.CustomField {
+	config := Config{
+		Token:     os.Getenv("PAGERDUTY_TOKEN"),
+		UserToken: os.Getenv("PAGERDUTY_USER_TOKEN"),
+	}
+	client, _ := (&config).Client()
+
+	field, _, err := client.CustomFields.Create(&pagerduty.CustomField{
+		DataType:    pagerduty.CustomFieldDataTypeString,
+		Name:        fieldName,
+		DisplayName: fieldName,
+	})
+	if err != nil {
+		panic("Unable to create test field to use as field configuration")
+	}
+	return field
+}
+
+func testAccDeleteTestPagerDutyCustomFieldForFieldConfiguration(fieldID string) error {
+	config := Config{
+		Token:     os.Getenv("PAGERDUTY_TOKEN"),
+		UserToken: os.Getenv("PAGERDUTY_USER_TOKEN"),
+	}
+	client, _ := (&config).Client()
+
+	_, err := client.CustomFields.Delete(fieldID)
+	return err
+}
+
+func testAccCreateTestPagerDutyCustomFieldSchemaForFieldConfiguration(schemaTitle string) *pagerduty.CustomFieldSchema {
+	config := Config{
+		Token:     os.Getenv("PAGERDUTY_TOKEN"),
+		UserToken: os.Getenv("PAGERDUTY_USER_TOKEN"),
+	}
+	client, _ := (&config).Client()
+
+	field, _, err := client.CustomFieldSchemas.Create(&pagerduty.CustomFieldSchema{
+		Title: schemaTitle,
+	})
+	if err != nil {
+		panic("Unable to create test field schema to use as field configuration")
+	}
+	return field
+}
+
+func testAccDeleteTestPagerDutyCustomFieldSchemaForFieldConfiguration(schemaID string) error {
+	config := Config{
+		Token:     os.Getenv("PAGERDUTY_TOKEN"),
+		UserToken: os.Getenv("PAGERDUTY_USER_TOKEN"),
+	}
+	client, _ := (&config).Client()
+
+	_, err := client.CustomFieldSchemas.Delete(schemaID)
+	return err
+}
+
+func testAccCheckPagerDutyCustomFieldConfigurationDestroy(s *terraform.State) error {
+	client, _ := testAccProvider.Meta().(*Config).Client()
+	for _, r := range s.RootModule().Resources {
+		if r.Type != "pagerduty_custom_field_configuration" {
+			continue
+		}
+
+		schemaID := r.Primary.Attributes["schema"]
+		if _, _, err := client.CustomFieldSchemas.GetFieldConfiguration(schemaID, r.Primary.ID, nil); err == nil {
+			return fmt.Errorf("field configuration still exists")
+		}
+
+	}
+	return nil
+}
+
+func testAccCheckPagerDutyCustomFieldConfigurationConfigBasic(name string, schemaTitle string) string {
+	return fmt.Sprintf(`
+data "pagerduty_custom_field" "input" {
+  name = "%s"
+}
+
+data "pagerduty_custom_field_schema" "input" {
+  title = "%s"
+}
+
+resource "pagerduty_custom_field_schema_field_configuration" "test" {
+  field  = data.pagerduty_custom_field.input.id
+  schema = data.pagerduty_custom_field_schema.input.id
+}
+
+`, name, schemaTitle)
+}

--- a/pagerduty/resource_pagerduty_custom_field_schema_test.go
+++ b/pagerduty/resource_pagerduty_custom_field_schema_test.go
@@ -1,0 +1,145 @@
+package pagerduty
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+func init() {
+	resource.AddTestSweepers("pagerduty_custom_field_schemas", &resource.Sweeper{
+		Name:         "pagerduty_custom_field_schemas",
+		Dependencies: []string{"pagerduty_custom_field_schema_assignments"},
+		F:            testSweepCustomFieldSchema,
+	})
+}
+
+func testSweepCustomFieldSchema(region string) error {
+	return testSweepForEachCustomFieldSchema(region, func(client *pagerduty.Client, fieldSchema *pagerduty.CustomFieldSchema) error {
+		log.Printf("Destroying field schema %s. (%s)", fieldSchema.Title, fieldSchema.ID)
+		if _, err := client.CustomFieldSchemas.Delete(fieldSchema.ID); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func testSweepForEachCustomFieldSchema(region string, handler func(client *pagerduty.Client, fieldSchema *pagerduty.CustomFieldSchema) error) error {
+	config, err := sharedConfigForRegion(region)
+	if err != nil {
+		return err
+	}
+
+	client, err := config.Client()
+	if err != nil {
+		return err
+	}
+
+	resp, _, err := client.CustomFieldSchemas.List(nil)
+	if err != nil {
+		return err
+	}
+
+	for _, fieldSchema := range resp.Schemas {
+		if strings.HasPrefix(fieldSchema.Title, "tf-") {
+			err = handler(client, fieldSchema)
+			if err != nil {
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func TestAccPagerDutyCustomFieldSchemas_Basic(t *testing.T) {
+	schemaTitle := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	schemaTitleForUpdate := fmt.Sprintf("tf_%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckCustomFieldTests(t)
+		},
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckPagerDutyCustomFieldSchemaDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyCustomFieldSchemaConfigBasic(schemaTitle),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyCustomFieldSchemaExists("pagerduty_custom_field_schema.test"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_custom_field_schema.test", "title", schemaTitle),
+					resource.TestCheckResourceAttr(
+						"pagerduty_custom_field_schema.test", "description", "some description"),
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyCustomFieldSchemaConfigBasic(schemaTitleForUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyCustomFieldSchemaExists("pagerduty_custom_field_schema.test"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_custom_field_schema.test", "title", schemaTitleForUpdate),
+					resource.TestCheckResourceAttr(
+						"pagerduty_custom_field_schema.test", "description", "some description"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckPagerDutyCustomFieldSchemaConfigBasic(title string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_custom_field_schema" "test" {
+  title = "%[1]s"
+  description = "some description"
+}
+`, title)
+}
+
+func testAccCheckPagerDutyCustomFieldSchemaDestroy(s *terraform.State) error {
+	client, _ := testAccProvider.Meta().(*Config).Client()
+	for _, r := range s.RootModule().Resources {
+		if r.Type != "pagerduty_custom_field_schema" {
+			continue
+		}
+
+		if _, _, err := client.CustomFieldSchemas.Get(r.Primary.ID, nil); err == nil {
+			return fmt.Errorf("custom field schema still exists")
+		}
+
+	}
+	return nil
+}
+
+func testAccCheckPagerDutyCustomFieldSchemaExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no custom field schema ID is set")
+		}
+
+		client, _ := testAccProvider.Meta().(*Config).Client()
+
+		found, _, err := client.CustomFieldSchemas.Get(rs.Primary.ID, nil)
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("custom field schema not found: %v - %v", rs.Primary.ID, found)
+		}
+
+		return nil
+	}
+}

--- a/pagerduty/resource_pagerduty_custom_field_test.go
+++ b/pagerduty/resource_pagerduty_custom_field_test.go
@@ -1,0 +1,224 @@
+package pagerduty
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+func init() {
+	resource.AddTestSweepers("pagerduty_custom_fields", &resource.Sweeper{
+		Name:         "pagerduty_custom_fields",
+		Dependencies: []string{"pagerduty_custom_field_schemas"},
+		F:            testSweepCustomField,
+	})
+}
+
+func testSweepCustomField(region string) error {
+	config, err := sharedConfigForRegion(region)
+	if err != nil {
+		return err
+	}
+
+	client, err := config.Client()
+	if err != nil {
+		return err
+	}
+
+	resp, _, err := client.CustomFields.List(nil)
+	if err != nil {
+		return err
+	}
+
+	for _, customField := range resp.Fields {
+		if strings.HasPrefix(customField.Name, "tf_") {
+			log.Printf("Destroying field %s (%s)", customField.Name, customField.ID)
+			if _, err := client.CustomFields.Delete(customField.ID); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func TestAccPagerDutyCustomFields_Basic(t *testing.T) {
+	fieldName := fmt.Sprintf("tf_%s", acctest.RandString(5))
+	description1 := acctest.RandString(10)
+	description2 := acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckCustomFieldTests(t)
+		},
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckPagerDutyCustomFieldDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyCustomFieldConfig(fieldName, description1, "string"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyCustomFieldExists("pagerduty_custom_field.input"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_custom_field.input", "name", fieldName),
+					resource.TestCheckResourceAttr(
+						"pagerduty_custom_field.input", "description", description1),
+					resource.TestCheckResourceAttr(
+						"pagerduty_custom_field.input", "datatype", "string"),
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyCustomFieldConfig(fieldName, description2, "string"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyCustomFieldExists("pagerduty_custom_field.input"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_custom_field.input", "description", description2),
+					resource.TestCheckResourceAttr(
+						"pagerduty_custom_field.input", "datatype", "string"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPagerDutyCustomField_BasicWithDescription(t *testing.T) {
+	fieldName := fmt.Sprintf("tf_%s", acctest.RandString(5))
+	description := acctest.RandString(30)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckCustomFieldTests(t)
+		},
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckPagerDutyCustomFieldDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyCustomFieldConfigWithDescription(fieldName, description, "string"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyCustomFieldExists("pagerduty_custom_field.input"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_custom_field.input", "name", fieldName),
+					resource.TestCheckResourceAttr(
+						"pagerduty_custom_field.input", "datatype", "string"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_custom_field.input", "description", description),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPagerDutyCustomFields_UnknownDataType(t *testing.T) {
+	fieldName := fmt.Sprintf("tf_%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckCustomFieldTests(t)
+		},
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckPagerDutyCustomFieldDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckPagerDutyCustomFieldConfig(fieldName, "", "garbage"),
+				ExpectError: regexp.MustCompile("Unknown datatype garbage"),
+			},
+		},
+	})
+}
+
+func TestAccPagerDutyCustomFields_IllegalDataType(t *testing.T) {
+	fieldName := fmt.Sprintf("tf_%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckCustomFieldTests(t)
+		},
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckPagerDutyCustomFieldDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckPagerDutyCustomFieldConfig(fieldName, "", pagerduty.CustomFieldDataTypeFieldOption.String()),
+				ExpectError: regexp.MustCompile("Datatype field_option is not allowed on fields"),
+			},
+		},
+	})
+}
+
+func testAccCheckPagerDutyCustomFieldConfig(name, description, datatype string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_custom_field" "input" {
+  name = "%[1]s"
+  display_name = "%[1]s"
+  description = "%[2]s" 
+  datatype = "%[3]s"
+}
+`, name, description, datatype)
+}
+
+func testAccCheckPagerDutyCustomFieldConfigWithDescription(name, description, datatype string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_custom_field" "input" {
+  name = "%[1]s"
+  display_name = "%[1]s"
+  datatype = "%[2]s"
+  description = "%[3]s"
+}
+`, name, datatype, description)
+}
+
+func testAccCheckPagerDutyCustomFieldDestroy(s *terraform.State) error {
+	client, _ := testAccProvider.Meta().(*Config).Client()
+	for _, r := range s.RootModule().Resources {
+		if r.Type != "pagerduty_custom_field" {
+			continue
+		}
+
+		if _, _, err := client.CustomFields.Get(r.Primary.ID, nil); err == nil {
+			return fmt.Errorf("field still exists")
+		}
+
+	}
+	return nil
+}
+
+func testAccCheckPagerDutyCustomFieldExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no field ID is set")
+		}
+
+		client, _ := testAccProvider.Meta().(*Config).Client()
+
+		found, _, err := client.CustomFields.Get(rs.Primary.ID, nil)
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("field not found: %v - %v", rs.Primary.ID, found)
+		}
+
+		return nil
+	}
+}
+
+func testAccPreCheckCustomFieldTests(t *testing.T) {
+	if v := os.Getenv("PAGERDUTY_ACC_CUSTOM_FIELDS"); v == "" {
+		t.Skip("PAGERDUTY_ACC_CUSTOM_FIELDS not set. Skipping Custom Field-related test")
+	}
+}

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/custom_field.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/custom_field.go
@@ -1,0 +1,195 @@
+package pagerduty
+
+import (
+	"context"
+	"fmt"
+)
+
+// CustomFieldService handles the communication with field related methods of the PagerDuty API.
+type CustomFieldService service
+
+// CustomField represents a custom field.
+type CustomField struct {
+	ID           string               `json:"id,omitempty"`
+	Name         string               `json:"name,omitempty"`
+	DisplayName  string               `json:"display_name,omitempty"`
+	Type         string               `json:"type,omitempty"`
+	Summary      string               `json:"summary,omitempty"`
+	Self         string               `json:"self,omitempty"`
+	DataType     CustomFieldDataType  `json:"datatype,omitempty"`
+	Description  *string              `json:"description,omitempty"`
+	MultiValue   bool                 `json:"multi_value"`
+	FixedOptions bool                 `json:"fixed_options"`
+	FieldOptions []*CustomFieldOption `json:"field_options,omitempty"`
+}
+
+// ListCustomFieldResponse represents a list response of fields
+type ListCustomFieldResponse struct {
+	Total  int            `json:"total,omitempty"`
+	Fields []*CustomField `json:"fields,omitempty"`
+	Offset int            `json:"offset,omitempty"`
+	More   bool           `json:"more,omitempty"`
+	Limit  int            `json:"limit,omitempty"`
+}
+
+// CustomFieldPayload represents payload with a field object
+type CustomFieldPayload struct {
+	Field *CustomField `json:"field,omitempty"`
+}
+
+// ListCustomFieldOptions represents options when retrieving a list of fields.
+type ListCustomFieldOptions struct {
+	Offset   int      `url:"offset,omitempty"`
+	Limit    int      `url:"limit,omitempty"`
+	Total    bool     `url:"total,omitempty"`
+	Includes []string `url:"include,brackets,omitempty"`
+}
+
+type listCustomFieldOptionsGen struct {
+	options *ListCustomFieldOptions
+}
+
+func (o *listCustomFieldOptionsGen) currentOffset() int {
+	return o.options.Offset
+}
+
+func (o *listCustomFieldOptionsGen) changeOffset(i int) {
+	o.options.Offset = i
+}
+
+func (o *listCustomFieldOptionsGen) buildStruct() interface{} {
+	return o.options
+}
+
+// GetCustomFieldOptions represents options when retrieving a field.
+type GetCustomFieldOptions struct {
+	Includes []string `url:"include,brackets,omitempty"`
+}
+
+var customFieldsEarlyAccessHeader = RequestOptions{
+	Type:  "header",
+	Label: "X-EARLY-ACCESS",
+	Value: "flex-service-early-access",
+}
+
+// List lists existing custom fields. If a non-zero Limit is passed as an option, only a single page of results will be
+// returned. Otherwise, the entire list of fields will be returned.
+func (s *CustomFieldService) List(o *ListCustomFieldOptions) (*ListCustomFieldResponse, *Response, error) {
+	return s.ListContext(context.Background(), o)
+}
+
+// ListContext lists existing custom fields. If a non-zero Limit is passed as an option, only a single page of results will be
+// returned. Otherwise, the entire list of fields will be returned.
+func (s *CustomFieldService) ListContext(ctx context.Context, o *ListCustomFieldOptions) (*ListCustomFieldResponse, *Response, error) {
+	u := "/customfields/fields"
+	v := new(ListCustomFieldResponse)
+
+	if o == nil {
+		o = &ListCustomFieldOptions{}
+	}
+
+	if o.Limit != 0 {
+		resp, err := s.client.newRequestDoContext(ctx, "GET", u, o, nil, &v)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return v, resp, nil
+	} else {
+		fields := make([]*CustomField, 0)
+
+		// Create a handler closure capable of parsing data from the fields endpoint
+		// and appending resultant response plays to the return slice.
+		responseHandler := func(response *Response) (ListResp, *Response, error) {
+			var result ListCustomFieldResponse
+
+			if err := s.client.DecodeJSON(response, &result); err != nil {
+				return ListResp{}, response, err
+			}
+
+			fields = append(fields, result.Fields...)
+
+			// Return stats on the current page. Caller can use this information to
+			// adjust for requesting additional pages.
+			return ListResp{
+				More:   result.More,
+				Offset: result.Offset,
+				Limit:  result.Limit,
+			}, response, nil
+		}
+		err := s.client.newRequestPagedGetQueryDo(u, responseHandler, &listCustomFieldOptionsGen{
+			options: o,
+		}, customFieldsEarlyAccessHeader)
+		if err != nil {
+			return nil, nil, err
+		}
+		v.Fields = fields
+
+		return v, nil, nil
+	}
+}
+
+// Get gets a custom field.
+func (s *CustomFieldService) Get(id string, o *GetCustomFieldOptions) (*CustomField, *Response, error) {
+	return s.GetContext(context.Background(), id, o)
+}
+
+// GetContext gets a custom field.
+func (s *CustomFieldService) GetContext(ctx context.Context, id string, o *GetCustomFieldOptions) (*CustomField, *Response, error) {
+	u := fmt.Sprintf("/customfields/fields/%s", id)
+	v := new(CustomFieldPayload)
+
+	resp, err := s.client.newRequestDoOptionsContext(ctx, "GET", u, o, nil, v, customFieldsEarlyAccessHeader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.Field, resp, nil
+}
+
+// Create creates a new custom field.
+func (s *CustomFieldService) Create(field *CustomField) (*CustomField, *Response, error) {
+	return s.CreateContext(context.Background(), field)
+}
+
+// CreateContext creates a new custom field.
+func (s *CustomFieldService) CreateContext(ctx context.Context, field *CustomField) (*CustomField, *Response, error) {
+	u := "/customfields/fields"
+	v := new(CustomFieldPayload)
+
+	resp, err := s.client.newRequestDoOptionsContext(ctx, "POST", u, nil, &CustomFieldPayload{Field: field}, &v, customFieldsEarlyAccessHeader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.Field, resp, nil
+}
+
+// Delete removes an existing custom field.
+func (s *CustomFieldService) Delete(id string) (*Response, error) {
+	return s.DeleteContext(context.Background(), id)
+}
+
+// DeleteContext removes an existing custom field.
+func (s *CustomFieldService) DeleteContext(ctx context.Context, id string) (*Response, error) {
+	u := fmt.Sprintf("/customfields/fields/%s", id)
+	return s.client.newRequestDoOptionsContext(ctx, "DELETE", u, nil, nil, nil, customFieldsEarlyAccessHeader)
+}
+
+// Update updates an existing custom field.
+func (s *CustomFieldService) Update(id string, field *CustomField) (*CustomField, *Response, error) {
+	return s.UpdateContext(context.Background(), id, field)
+}
+
+// UpdateContext updates an existing custom field.
+func (s *CustomFieldService) UpdateContext(ctx context.Context, id string, field *CustomField) (*CustomField, *Response, error) {
+	u := fmt.Sprintf("/customfields/fields/%s", id)
+	v := new(CustomFieldPayload)
+
+	resp, err := s.client.newRequestDoOptionsContext(ctx, "PUT", u, nil, &CustomFieldPayload{Field: field}, &v, customFieldsEarlyAccessHeader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.Field, resp, nil
+}

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/custom_field_data_type.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/custom_field_data_type.go
@@ -1,0 +1,76 @@
+package pagerduty
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// CustomFieldDataType is an enumeration of available datatypes for fields.
+type CustomFieldDataType int64
+
+const (
+	CustomFieldDataTypeUnknown CustomFieldDataType = iota
+	CustomFieldDataTypeString
+	CustomFieldDataTypeInt
+	CustomFieldDataTypeFloat
+	CustomFieldDataTypeBool
+	CustomFieldDataTypeUrl
+	CustomFieldDataTypeDateTime
+	CustomFieldDataTypeFieldOption
+)
+
+func (d CustomFieldDataType) String() string {
+	return customFieldDataTypeToString[d]
+}
+
+func CustomFieldDataTypeFromString(s string) CustomFieldDataType {
+	return customFieldDataTypeFromString[s]
+}
+
+var customFieldDataTypeToString = map[CustomFieldDataType]string{
+	CustomFieldDataTypeUnknown:     "unknown",
+	CustomFieldDataTypeString:      "string",
+	CustomFieldDataTypeInt:         "integer",
+	CustomFieldDataTypeFloat:       "float",
+	CustomFieldDataTypeBool:        "boolean",
+	CustomFieldDataTypeUrl:         "url",
+	CustomFieldDataTypeDateTime:    "datetime",
+	CustomFieldDataTypeFieldOption: "field_option",
+}
+
+var customFieldDataTypeFromString = map[string]CustomFieldDataType{
+	"unknown":      CustomFieldDataTypeUnknown,
+	"string":       CustomFieldDataTypeString,
+	"integer":      CustomFieldDataTypeInt,
+	"float":        CustomFieldDataTypeFloat,
+	"boolean":      CustomFieldDataTypeBool,
+	"url":          CustomFieldDataTypeUrl,
+	"datetime":     CustomFieldDataTypeDateTime,
+	"field_option": CustomFieldDataTypeFieldOption,
+}
+
+func (d CustomFieldDataType) MarshalJSON() ([]byte, error) {
+	buffer := bytes.NewBufferString(fmt.Sprintf(`"%v"`, d.String()))
+	return buffer.Bytes(), nil
+}
+
+func (d *CustomFieldDataType) UnmarshalJSON(data []byte) error {
+	var str string
+	err := json.Unmarshal(data, &str)
+	if err != nil {
+		return err
+	}
+	*d = CustomFieldDataTypeFromString(str)
+	return nil
+}
+
+func (d *CustomFieldDataType) IsKnown() bool {
+	return *d != CustomFieldDataTypeUnknown
+}
+
+// IsAllowedOnField determines if the CustomFieldDataType is a legal value for fields. This enables field_option to be a defined datatype
+// (as is necessary for default values on field configurations) but not on fields.
+func (d *CustomFieldDataType) IsAllowedOnField() bool {
+	return d.IsKnown() && *d != CustomFieldDataTypeFieldOption
+}

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/custom_field_option.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/custom_field_option.go
@@ -1,0 +1,112 @@
+package pagerduty
+
+import (
+	"context"
+	"fmt"
+)
+
+// CustomFieldOption represents an option for a fixed-value field.
+type CustomFieldOption struct {
+	ID   string                 `json:"id,omitempty"`
+	Type string                 `json:"type,omitempty"`
+	Data *CustomFieldOptionData `json:"data,omitempty"`
+}
+
+// CustomFieldOptionData represents the value of a CustomFieldOption
+type CustomFieldOptionData struct {
+	DataType CustomFieldDataType `json:"datatype,omitempty"`
+	Value    interface{}         `json:"value,omitempty"`
+}
+
+// CustomFieldOptionPayload represents payload with a field option object
+type CustomFieldOptionPayload struct {
+	FieldOption *CustomFieldOption `json:"field_option,omitempty"`
+}
+
+// ListCustomFieldOptionsResponse represents a list response of field options
+type ListCustomFieldOptionsResponse struct {
+	FieldOptions []*CustomFieldOption `json:"field_options,omitempty"`
+}
+
+// CreateFieldOption creates a new field option.
+func (s *CustomFieldService) CreateFieldOption(fieldID string, fieldOption *CustomFieldOption) (*CustomFieldOption, *Response, error) {
+	return s.CreateFieldOptionContext(context.Background(), fieldID, fieldOption)
+}
+
+// CreateFieldOptionContext creates a new field option.
+func (s *CustomFieldService) CreateFieldOptionContext(ctx context.Context, fieldID string, fieldOption *CustomFieldOption) (*CustomFieldOption, *Response, error) {
+	u := fmt.Sprintf("/customfields/fields/%s/field_options", fieldID)
+	v := new(CustomFieldOptionPayload)
+
+	resp, err := s.client.newRequestDoOptionsContext(ctx, "POST", u, nil, &CustomFieldOptionPayload{FieldOption: fieldOption}, &v, customFieldsEarlyAccessHeader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.FieldOption, resp, nil
+}
+
+// UpdateFieldOption updates an existing field option.
+func (s *CustomFieldService) UpdateFieldOption(fieldID string, fieldOptionID string, fieldOption *CustomFieldOption) (*CustomFieldOption, *Response, error) {
+	return s.UpdateFieldOptionContext(context.Background(), fieldID, fieldOptionID, fieldOption)
+}
+
+// UpdateFieldOptionContext updates an existing field option.
+func (s *CustomFieldService) UpdateFieldOptionContext(ctx context.Context, fieldID string, fieldOptionID string, fieldOption *CustomFieldOption) (*CustomFieldOption, *Response, error) {
+	u := fmt.Sprintf("/customfields/fields/%s/field_options/%s", fieldID, fieldOptionID)
+	v := new(CustomFieldOptionPayload)
+
+	resp, err := s.client.newRequestDoOptionsContext(ctx, "PUT", u, nil, &CustomFieldOptionPayload{FieldOption: fieldOption}, &v, customFieldsEarlyAccessHeader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.FieldOption, resp, nil
+}
+
+// GetFieldOption gets a field option.
+func (s *CustomFieldService) GetFieldOption(fieldID string, fieldOptionID string) (*CustomFieldOption, *Response, error) {
+	return s.GetFieldOptionContext(context.Background(), fieldID, fieldOptionID)
+}
+
+// GetFieldOptionContext gets a field option.
+func (s *CustomFieldService) GetFieldOptionContext(ctx context.Context, fieldID string, fieldOptionID string) (*CustomFieldOption, *Response, error) {
+	u := fmt.Sprintf("/customfields/fields/%s/field_options/%s", fieldID, fieldOptionID)
+	v := new(CustomFieldOptionPayload)
+
+	resp, err := s.client.newRequestDoOptionsContext(ctx, "GET", u, nil, nil, &v, customFieldsEarlyAccessHeader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.FieldOption, resp, nil
+}
+
+// ListFieldOptions lists the field options for a field.
+func (s *CustomFieldService) ListFieldOptions(fieldID string) (*ListCustomFieldOptionsResponse, *Response, error) {
+	return s.ListFieldOptionsContext(context.Background(), fieldID)
+}
+
+// ListFieldOptionsContext lists the field options for a field.
+func (s *CustomFieldService) ListFieldOptionsContext(ctx context.Context, fieldID string) (*ListCustomFieldOptionsResponse, *Response, error) {
+	u := fmt.Sprintf("/customfields/fields/%s/field_options", fieldID)
+	v := new(ListCustomFieldOptionsResponse)
+
+	resp, err := s.client.newRequestDoOptionsContext(ctx, "GET", u, nil, nil, &v, customFieldsEarlyAccessHeader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v, resp, nil
+}
+
+// DeleteFieldOption deletes an existing field option.
+func (s *CustomFieldService) DeleteFieldOption(fieldID string, fieldOptionID string) (*Response, error) {
+	return s.DeleteFieldOptionContext(context.Background(), fieldID, fieldOptionID)
+}
+
+// DeleteFieldOptionContext disables an existing field option.
+func (s *CustomFieldService) DeleteFieldOptionContext(ctx context.Context, fieldID string, fieldOptionID string) (*Response, error) {
+	u := fmt.Sprintf("/customfields/fields/%s/field_options/%s", fieldID, fieldOptionID)
+	return s.client.newRequestDoOptionsContext(ctx, "DELETE", u, nil, nil, nil, customFieldsEarlyAccessHeader)
+}

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/custom_field_schema.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/custom_field_schema.go
@@ -1,0 +1,182 @@
+package pagerduty
+
+import (
+	"context"
+	"fmt"
+)
+
+// CustomFieldSchemaService handles the communication with field schema
+// related methods of the PagerDuty API.
+type CustomFieldSchemaService service
+
+// CustomFieldSchema represents a field schema.
+type CustomFieldSchema struct {
+	ID                  string                                 `json:"id,omitempty"`
+	Title               string                                 `json:"title,omitempty"`
+	Type                string                                 `json:"type,omitempty"`
+	Description         *string                                `json:"description,omitempty"`
+	FieldConfigurations []*CustomFieldSchemaFieldConfiguration `json:"field_configurations,omitempty"`
+}
+
+// ListCustomFieldSchemaOptions represents options when retrieving a list of field schemas.
+type ListCustomFieldSchemaOptions struct {
+	Offset int  `url:"offset,omitempty"`
+	Limit  int  `url:"limit,omitempty"`
+	Total  bool `url:"total,omitempty"`
+}
+
+// GetCustomFieldSchemaOptions represents options when retrieving a field schema
+type GetCustomFieldSchemaOptions struct {
+	Includes []string `url:"include,brackets,omitempty"`
+}
+
+type listCustomFieldSchemaOptionsGen struct {
+	options *ListCustomFieldSchemaOptions
+}
+
+func (o *listCustomFieldSchemaOptionsGen) currentOffset() int {
+	return o.options.Offset
+}
+
+func (o *listCustomFieldSchemaOptionsGen) changeOffset(i int) {
+	o.options.Offset = i
+}
+
+func (o *listCustomFieldSchemaOptionsGen) buildStruct() interface{} {
+	return o.options
+}
+
+// ListCustomFieldSchemaResponse represents a list response of field schemas
+type ListCustomFieldSchemaResponse struct {
+	Total   int                  `json:"total,omitempty"`
+	Schemas []*CustomFieldSchema `json:"schemas,omitempty"`
+	Offset  int                  `json:"offset,omitempty"`
+	More    bool                 `json:"more,omitempty"`
+	Limit   int                  `json:"limit,omitempty"`
+}
+
+type CustomFieldSchemaPayload struct {
+	Schema *CustomFieldSchema `json:"schema,omitempty"`
+}
+
+// List lists existing field schemas. If a non-zero Limit is passed as an option, only a single page of results will be
+// returned. Otherwise, the entire list of fields will be returned.
+func (s *CustomFieldSchemaService) List(o *ListCustomFieldSchemaOptions) (*ListCustomFieldSchemaResponse, *Response, error) {
+	return s.ListContext(context.Background(), o)
+}
+
+// ListContext lists existing field schemas. If a non-zero Limit is passed as an option, only a single page of results will be
+// returned. Otherwise, the entire list of fields will be returned.
+func (s *CustomFieldSchemaService) ListContext(ctx context.Context, o *ListCustomFieldSchemaOptions) (*ListCustomFieldSchemaResponse, *Response, error) {
+	u := "/customfields/schemas"
+	v := new(ListCustomFieldSchemaResponse)
+
+	if o == nil {
+		o = &ListCustomFieldSchemaOptions{}
+	}
+
+	if o.Limit != 0 {
+		resp, err := s.client.newRequestDoOptionsContext(ctx, "GET", u, o, nil, &v, customFieldsEarlyAccessHeader)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return v, resp, nil
+	} else {
+		schemas := make([]*CustomFieldSchema, 0)
+
+		// Create a handler closure capable of parsing data from the fields endpoint
+		// and appending resultant response plays to the return slice.
+		responseHandler := func(response *Response) (ListResp, *Response, error) {
+			var result ListCustomFieldSchemaResponse
+
+			if err := s.client.DecodeJSON(response, &result); err != nil {
+				return ListResp{}, response, err
+			}
+
+			schemas = append(schemas, result.Schemas...)
+
+			// Return stats on the current page. Caller can use this information to
+			// adjust for requesting additional pages.
+			return ListResp{
+				More:   result.More,
+				Offset: result.Offset,
+				Limit:  result.Limit,
+			}, response, nil
+		}
+		err := s.client.newRequestPagedGetQueryDoContext(ctx, u, responseHandler, &listCustomFieldSchemaOptionsGen{
+			options: o,
+		}, customFieldsEarlyAccessHeader)
+		if err != nil {
+			return nil, nil, err
+		}
+		v.Schemas = schemas
+
+		return v, nil, nil
+	}
+}
+
+// Get gets a field schema.
+func (s *CustomFieldSchemaService) Get(id string, o *GetCustomFieldSchemaOptions) (*CustomFieldSchema, *Response, error) {
+	return s.GetContext(context.Background(), id, o)
+}
+
+// GetContext gets a field schema.
+func (s *CustomFieldSchemaService) GetContext(ctx context.Context, id string, o *GetCustomFieldSchemaOptions) (*CustomFieldSchema, *Response, error) {
+	u := fmt.Sprintf("/customfields/schemas/%s", id)
+	v := new(CustomFieldSchemaPayload)
+
+	resp, err := s.client.newRequestDoOptionsContext(ctx, "GET", u, o, nil, v, customFieldsEarlyAccessHeader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.Schema, resp, nil
+}
+
+// Create creates a field schema.
+func (s *CustomFieldSchemaService) Create(schema *CustomFieldSchema) (*CustomFieldSchema, *Response, error) {
+	return s.CreateContext(context.Background(), schema)
+}
+
+// CreateContext creates a field schema.
+func (s *CustomFieldSchemaService) CreateContext(ctx context.Context, schema *CustomFieldSchema) (*CustomFieldSchema, *Response, error) {
+	u := "/customfields/schemas"
+	v := new(CustomFieldSchemaPayload)
+
+	resp, err := s.client.newRequestDoOptionsContext(ctx, "POST", u, nil, &CustomFieldSchemaPayload{Schema: schema}, &v, customFieldsEarlyAccessHeader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.Schema, resp, nil
+}
+
+// Update updates a field schema.
+func (s *CustomFieldSchemaService) Update(id string, schema *CustomFieldSchema) (*CustomFieldSchema, *Response, error) {
+	return s.UpdateContext(context.Background(), id, schema)
+}
+
+// UpdateContext updates a field schema.
+func (s *CustomFieldSchemaService) UpdateContext(ctx context.Context, id string, schema *CustomFieldSchema) (*CustomFieldSchema, *Response, error) {
+	u := fmt.Sprintf("/customfields/schemas/%s", id)
+	v := new(CustomFieldSchemaPayload)
+
+	resp, err := s.client.newRequestDoOptionsContext(ctx, "PUT", u, nil, &CustomFieldSchemaPayload{Schema: schema}, &v, customFieldsEarlyAccessHeader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.Schema, resp, nil
+}
+
+// Delete removes an existing field schema.
+func (s *CustomFieldSchemaService) Delete(id string) (*Response, error) {
+	return s.DeleteContext(context.Background(), id)
+}
+
+// DeleteContext removes an existing field schema.
+func (s *CustomFieldSchemaService) DeleteContext(ctx context.Context, id string) (*Response, error) {
+	u := fmt.Sprintf("/customfields/schemas/%s", id)
+	return s.client.newRequestDoOptionsContext(ctx, "DELETE", u, nil, nil, nil, customFieldsEarlyAccessHeader)
+}

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/custom_field_schema_assignment.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/custom_field_schema_assignment.go
@@ -1,0 +1,187 @@
+package pagerduty
+
+import (
+	"context"
+	"fmt"
+)
+
+// CustomFieldSchemaAssignmentService handles the communication with field schema assignment
+// related methods of the PagerDuty API.
+type CustomFieldSchemaAssignmentService service
+
+// CustomFieldSchemaAssignment represents a field schema assignment.
+type CustomFieldSchemaAssignment struct {
+	ID      string                      `json:"id,omitempty"`
+	Type    string                      `json:"type,omitempty"`
+	Service *ServiceReference           `json:"service,omitempty"`
+	Schema  *CustomFieldSchemaReference `json:"schema,omitempty"`
+}
+
+type CustomFieldSchemaAssignmentPayload struct {
+	SchemaAssignment *CustomFieldSchemaAssignment `json:"schema_assignment,omitempty"`
+}
+
+// ListCustomFieldSchemaAssignmentsResponse represents a list response of resources assigned to field schemas.
+type ListCustomFieldSchemaAssignmentsResponse struct {
+	Total             int                            `json:"total,omitempty"`
+	SchemaAssignments []*CustomFieldSchemaAssignment `json:"schema_assignments,omitempty"`
+	Offset            int                            `json:"offset,omitempty"`
+	More              bool                           `json:"more,omitempty"`
+	Limit             int                            `json:"limit,omitempty"`
+}
+
+// ListCustomFieldSchemaAssignmentsOptions represents options when retrieving a list of fields schema assignments.
+type ListCustomFieldSchemaAssignmentsOptions struct {
+	Offset int  `url:"offset,omitempty"`
+	Limit  int  `url:"limit,omitempty"`
+	Total  bool `url:"total,omitempty"`
+}
+
+// fullListCustomFieldSchemaAssignmentsOptions represents options when retrieving a list of schema assignments
+type fullListCustomFieldSchemaAssignmentsOptions struct {
+	SchemaID  string `url:"schema_id,omitempty"`
+	ServiceID string `url:"service_id,omitempty"`
+	Offset    int    `url:"offset,omitempty"`
+	Limit     int    `url:"limit,omitempty"`
+	Total     bool   `url:"total,omitempty"`
+}
+
+type fullListCustomFieldSchemaAssignmentsOptionsGen struct {
+	options *fullListCustomFieldSchemaAssignmentsOptions
+}
+
+func (o *fullListCustomFieldSchemaAssignmentsOptionsGen) currentOffset() int {
+	return o.options.Offset
+}
+
+func (o *fullListCustomFieldSchemaAssignmentsOptionsGen) changeOffset(i int) {
+	o.options.Offset = i
+}
+
+func (o *fullListCustomFieldSchemaAssignmentsOptionsGen) buildStruct() interface{} {
+	return o.options
+}
+
+// Create creates a custom field schema assignment.
+func (s *CustomFieldSchemaAssignmentService) Create(a *CustomFieldSchemaAssignment) (*CustomFieldSchemaAssignment, *Response, error) {
+	return s.CreateContext(context.Background(), a)
+}
+
+// CreateContext creates a custom field schema assignment.
+func (s *CustomFieldSchemaAssignmentService) CreateContext(ctx context.Context, a *CustomFieldSchemaAssignment) (*CustomFieldSchemaAssignment, *Response, error) {
+	u := "/customfields/schema_assignments"
+	v := new(CustomFieldSchemaAssignmentPayload)
+
+	resp, err := s.client.newRequestDoOptionsContext(ctx, "POST", u, nil, &CustomFieldSchemaAssignmentPayload{SchemaAssignment: a}, &v, customFieldsEarlyAccessHeader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.SchemaAssignment, resp, nil
+}
+
+// Delete removes a schema assignment
+func (s *CustomFieldSchemaAssignmentService) Delete(id string) (*Response, error) {
+	return s.DeleteContext(context.Background(), id)
+}
+
+// DeleteContext removes a schema assignment
+func (s *CustomFieldSchemaAssignmentService) DeleteContext(ctx context.Context, id string) (*Response, error) {
+	u := fmt.Sprintf("/customfields/schema_assignments/%s", id)
+
+	resp, err := s.client.newRequestDoOptionsContext(ctx, "DELETE", u, nil, nil, nil, customFieldsEarlyAccessHeader)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// ListForSchema returns a list of assignments or the passed schema id
+func (s *CustomFieldSchemaAssignmentService) ListForSchema(schemaID string, o *ListCustomFieldSchemaAssignmentsOptions) (*ListCustomFieldSchemaAssignmentsResponse, *Response, error) {
+	return s.ListForSchemaContext(context.Background(), schemaID, o)
+}
+
+// ListForSchemaContext returns a list of assignments for the passed schema id
+func (s *CustomFieldSchemaAssignmentService) ListForSchemaContext(ctx context.Context, schemaID string, o *ListCustomFieldSchemaAssignmentsOptions) (*ListCustomFieldSchemaAssignmentsResponse, *Response, error) {
+	fo := fullListCustomFieldSchemaAssignmentsOptions{
+		SchemaID: schemaID,
+	}
+	if o != nil {
+		fo.Limit = o.Limit
+		fo.Offset = o.Offset
+		fo.Total = o.Total
+	}
+
+	return s.listContext(ctx, &fo)
+}
+
+// ListForService returns a list of schema assignments for the passed service id.
+func (s *CustomFieldSchemaAssignmentService) ListForService(serviceID string, o *ListCustomFieldSchemaAssignmentsOptions) (*ListCustomFieldSchemaAssignmentsResponse, *Response, error) {
+	return s.ListForServiceContext(context.Background(), serviceID, o)
+}
+
+// ListForServiceContext returns a list of schema assignments for the passed service id.
+func (s *CustomFieldSchemaAssignmentService) ListForServiceContext(ctx context.Context, serviceID string, o *ListCustomFieldSchemaAssignmentsOptions) (*ListCustomFieldSchemaAssignmentsResponse, *Response, error) {
+	fo := fullListCustomFieldSchemaAssignmentsOptions{
+		ServiceID: serviceID,
+	}
+	if o != nil {
+		fo.Limit = o.Limit
+		fo.Offset = o.Offset
+		fo.Total = o.Total
+	}
+
+	return s.listContext(ctx, &fo)
+}
+
+// listContext lists existing custom fields. If a non-zero Limit is passed as an option, only a single page of results will be
+// returned. Otherwise, the entire list of fields will be returned.
+func (s *CustomFieldSchemaAssignmentService) listContext(ctx context.Context, o *fullListCustomFieldSchemaAssignmentsOptions) (*ListCustomFieldSchemaAssignmentsResponse, *Response, error) {
+	u := "/customfields/schema_assignments"
+	v := new(ListCustomFieldSchemaAssignmentsResponse)
+
+	if o == nil {
+		o = &fullListCustomFieldSchemaAssignmentsOptions{}
+	}
+
+	if o.Limit != 0 {
+		resp, err := s.client.newRequestDoContext(ctx, "GET", u, o, nil, &v)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return v, resp, nil
+	} else {
+		assignments := make([]*CustomFieldSchemaAssignment, 0)
+
+		// Create a handler closure capable of parsing data from the fields endpoint
+		// and appending resultant response plays to the return slice.
+		responseHandler := func(response *Response) (ListResp, *Response, error) {
+			var result ListCustomFieldSchemaAssignmentsResponse
+
+			if err := s.client.DecodeJSON(response, &result); err != nil {
+				return ListResp{}, response, err
+			}
+
+			assignments = append(assignments, result.SchemaAssignments...)
+
+			// Return stats on the current page. Caller can use this information to
+			// adjust for requesting additional pages.
+			return ListResp{
+				More:   result.More,
+				Offset: result.Offset,
+				Limit:  result.Limit,
+			}, response, nil
+		}
+		err := s.client.newRequestPagedGetQueryDo(u, responseHandler, &fullListCustomFieldSchemaAssignmentsOptionsGen{
+			options: o,
+		}, customFieldsEarlyAccessHeader)
+		if err != nil {
+			return nil, nil, err
+		}
+		v.SchemaAssignments = assignments
+
+		return v, nil, nil
+	}
+}

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/custom_field_schema_field_configuration.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/custom_field_schema_field_configuration.go
@@ -1,0 +1,208 @@
+package pagerduty
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+)
+
+type CustomFieldSchemaFieldConfiguration struct {
+	ID           string                   `json:"id,omitempty"`
+	Type         string                   `json:"type,omitempty"`
+	Required     bool                     `json:"required"`
+	Field        *CustomField             `json:"field,omitempty"`
+	DefaultValue *CustomFieldDefaultValue `json:"default_value,omitempty"`
+}
+
+type CustomFieldDefaultValue struct {
+	DataType   CustomFieldDataType `json:"datatype,omitempty"`
+	MultiValue bool                `json:"multi_value"`
+	Value      interface{}         `json:"value,omitempty"`
+}
+
+type rawCustomFieldDefaultValue struct {
+	DataType   CustomFieldDataType `json:"datatype,omitempty"`
+	MultiValue bool                `json:"multi_value"`
+	Value      interface{}         `json:"value,omitempty"`
+}
+
+func (d *CustomFieldDefaultValue) UnmarshalJSON(data []byte) error {
+	var p rawCustomFieldDefaultValue
+	err := json.Unmarshal(data, &p)
+	if err != nil {
+		return err
+	}
+	*d = CustomFieldDefaultValue{
+		DataType:   p.DataType,
+		MultiValue: p.MultiValue,
+	}
+	if p.Value != nil {
+		switch p.DataType {
+		case CustomFieldDataTypeInt:
+			err := d.convertForInt(p.Value)
+			if err != nil {
+				return err
+			}
+		case CustomFieldDataTypeFieldOption:
+			m := p.Value.(map[string]interface{})
+			d.Value = m["id"]
+		default:
+			d.Value = p.Value
+		}
+	}
+	return nil
+}
+
+func (d *CustomFieldDefaultValue) MarshalJSON() ([]byte, error) {
+	var nd rawCustomFieldDefaultValue
+	switch d.DataType {
+	case CustomFieldDataTypeFieldOption:
+		nd = rawCustomFieldDefaultValue{
+			DataType:   d.DataType,
+			MultiValue: d.MultiValue,
+			Value:      map[string]string{"type": "field_option_reference", "id": d.Value.(string)},
+		}
+	default:
+		nd = rawCustomFieldDefaultValue{
+			DataType:   d.DataType,
+			MultiValue: d.MultiValue,
+			Value:      d.Value,
+		}
+	}
+	return json.Marshal(nd)
+
+}
+
+func (d *CustomFieldDefaultValue) convertForInt(value interface{}) error {
+	switch v := value.(type) {
+	case []interface{}:
+		if d.MultiValue {
+			var s []interface{}
+			for _, f := range v {
+				switch ev := f.(type) {
+				case float64:
+					s = append(s, int64(math.Round(ev)))
+				default:
+					return fmt.Errorf("received unexpected %T as an element in a multi-value int", ev)
+				}
+			}
+			d.Value = s
+			return nil
+		} else {
+			return fmt.Errorf("Received unexpected %T for non-multi-value int", v)
+		}
+	case float64:
+		if d.MultiValue {
+			return fmt.Errorf("Received unexpected %T for multi-value int", v)
+		} else {
+			d.Value = int64(math.Round(v))
+			return nil
+		}
+	default:
+		return fmt.Errorf("received unexpected %T as for an integer default value", v)
+	}
+}
+
+// ListCustomFieldSchemaConfigurationsOptions represents options when retrieving a list of field schemas.
+type ListCustomFieldSchemaConfigurationsOptions struct {
+	Includes []string `url:"include,brackets,omitempty"`
+}
+
+// GetCustomFieldSchemaConfigurationsOptions represents options when retrieving a field configuration for a schema
+type GetCustomFieldSchemaConfigurationsOptions struct {
+	Includes []string `url:"include,brackets,omitempty"`
+}
+
+type CustomFieldSchemaFieldConfigurationPayload struct {
+	FieldConfiguration *CustomFieldSchemaFieldConfiguration `json:"field_configuration,omitempty"`
+}
+
+// ListCustomFieldSchemaFieldConfigurationsResponse represents a list response of field configurations for a schema
+type ListCustomFieldSchemaFieldConfigurationsResponse struct {
+	FieldConfigurations []*CustomFieldSchemaFieldConfiguration `json:"field_configurations,omitempty"`
+}
+
+// ListFieldConfigurations lists field configurations for a schema.
+func (s *CustomFieldSchemaService) ListFieldConfigurations(schemaID string, o *ListCustomFieldSchemaConfigurationsOptions) (*ListCustomFieldSchemaFieldConfigurationsResponse, *Response, error) {
+	return s.ListFieldConfigurationsContext(context.Background(), schemaID, o)
+}
+
+// ListFieldConfigurationsContext lists field configurations for a schema.
+func (s *CustomFieldSchemaService) ListFieldConfigurationsContext(ctx context.Context, schemaID string, o *ListCustomFieldSchemaConfigurationsOptions) (*ListCustomFieldSchemaFieldConfigurationsResponse, *Response, error) {
+	u := fmt.Sprintf("/customfields/schemas/%s/field_configurations", schemaID)
+	v := new(ListCustomFieldSchemaFieldConfigurationsResponse)
+
+	resp, err := s.client.newRequestDoOptionsContext(ctx, "GET", u, o, nil, &v, customFieldsEarlyAccessHeader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v, resp, nil
+}
+
+// GetFieldConfiguration gets a field configuration in a schema.
+func (s *CustomFieldSchemaService) GetFieldConfiguration(schemaID string, configurationID string, o *GetCustomFieldSchemaConfigurationsOptions) (*CustomFieldSchemaFieldConfiguration, *Response, error) {
+	return s.GetFieldConfigurationContext(context.Background(), schemaID, configurationID, o)
+}
+
+// GetFieldConfigurationContext gets a field configuration in a schema.
+func (s *CustomFieldSchemaService) GetFieldConfigurationContext(ctx context.Context, schemaID string, configurationID string, o *GetCustomFieldSchemaConfigurationsOptions) (*CustomFieldSchemaFieldConfiguration, *Response, error) {
+	u := fmt.Sprintf("/customfields/schemas/%s/field_configurations/%s", schemaID, configurationID)
+	v := new(CustomFieldSchemaFieldConfigurationPayload)
+	p := &CustomFieldSchemaFieldConfigurationPayload{}
+
+	resp, err := s.client.newRequestDoOptionsContext(ctx, "GET", u, o, p, v, customFieldsEarlyAccessHeader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.FieldConfiguration, resp, nil
+}
+
+// DeleteFieldConfiguration deletes a field configuration for a schema.
+func (s *CustomFieldSchemaService) DeleteFieldConfiguration(schemaID string, configurationID string) (*Response, error) {
+	return s.DeleteFieldConfigurationContext(context.Background(), schemaID, configurationID)
+}
+
+// DeleteFieldConfigurationContext deletes a field configuration for a schema.
+func (s *CustomFieldSchemaService) DeleteFieldConfigurationContext(ctx context.Context, schemaID string, configurationID string) (*Response, error) {
+	u := fmt.Sprintf("/customfields/schemas/%s/field_configurations/%s", schemaID, configurationID)
+	return s.client.newRequestDoOptionsContext(ctx, "DELETE", u, nil, nil, nil, customFieldsEarlyAccessHeader)
+}
+
+// CreateFieldConfiguration creates a field configuration in a schema.
+func (s *CustomFieldSchemaService) CreateFieldConfiguration(schemaID string, configuration *CustomFieldSchemaFieldConfiguration) (*CustomFieldSchemaFieldConfiguration, *Response, error) {
+	return s.CreateFieldConfigurationContext(context.Background(), schemaID, configuration)
+}
+
+// CreateFieldConfigurationContext creates a field configuration in a schema.
+func (s *CustomFieldSchemaService) CreateFieldConfigurationContext(ctx context.Context, schemaID string, configuration *CustomFieldSchemaFieldConfiguration) (*CustomFieldSchemaFieldConfiguration, *Response, error) {
+	u := fmt.Sprintf("/customfields/schemas/%s/field_configurations", schemaID)
+	v := new(CustomFieldSchemaFieldConfigurationPayload)
+
+	resp, err := s.client.newRequestDoOptionsContext(ctx, "POST", u, nil, &CustomFieldSchemaFieldConfigurationPayload{FieldConfiguration: configuration}, &v, customFieldsEarlyAccessHeader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.FieldConfiguration, resp, nil
+}
+
+// UpdateFieldConfiguration updates a field configuration in a schema.
+func (s *CustomFieldSchemaService) UpdateFieldConfiguration(schemaID string, configurationID string, configuration *CustomFieldSchemaFieldConfiguration) (*CustomFieldSchemaFieldConfiguration, *Response, error) {
+	return s.UpdateFieldConfigurationContext(context.Background(), schemaID, configurationID, configuration)
+}
+
+// UpdateFieldConfigurationContext updates a field configuration in a schema.
+func (s *CustomFieldSchemaService) UpdateFieldConfigurationContext(ctx context.Context, schemaID string, configurationID string, configuration *CustomFieldSchemaFieldConfiguration) (*CustomFieldSchemaFieldConfiguration, *Response, error) {
+	u := fmt.Sprintf("/customfields/schemas/%s/field_configurations/%s", schemaID, configurationID)
+	v := new(CustomFieldSchemaFieldConfigurationPayload)
+
+	resp, err := s.client.newRequestDoOptionsContext(ctx, "PUT", u, nil, CustomFieldSchemaFieldConfigurationPayload{FieldConfiguration: configuration}, &v, customFieldsEarlyAccessHeader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v.FieldConfiguration, resp, nil
+}

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/pagerduty.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/pagerduty.go
@@ -33,38 +33,41 @@ type Config struct {
 
 // Client manages the communication with the PagerDuty API
 type Client struct {
-	baseURL                    *url.URL
-	client                     *http.Client
-	Config                     *Config
-	Abilities                  *AbilityService
-	Addons                     *AddonService
-	EscalationPolicies         *EscalationPolicyService
-	Extensions                 *ExtensionService
-	MaintenanceWindows         *MaintenanceWindowService
-	Rulesets                   *RulesetService
-	EventOrchestrations        *EventOrchestrationService
-	EventOrchestrationPaths    *EventOrchestrationPathService
-	Schedules                  *ScheduleService
-	Services                   *ServicesService
-	Teams                      *TeamService
-	ExtensionSchemas           *ExtensionSchemaService
-	Users                      *UserService
-	Vendors                    *VendorService
-	EventRules                 *EventRuleService
-	BusinessServices           *BusinessServiceService
-	ServiceDependencies        *ServiceDependencyService
-	Priorities                 *PriorityService
-	ResponsePlays              *ResponsePlayService
-	SlackConnections           *SlackConnectionService
-	Tags                       *TagService
-	WebhookSubscriptions       *WebhookSubscriptionService
-	BusinessServiceSubscribers *BusinessServiceSubscriberService
-	OnCall                     *OnCallService
-	AutomationActionsRunner    *AutomationActionsRunnerService
-	AutomationActionsAction    *AutomationActionsActionService
-	Incidents                  *IncidentService
-	IncidentWorkflows          *IncidentWorkflowService
-	IncidentWorkflowTriggers   *IncidentWorkflowTriggerService
+	baseURL                      *url.URL
+	client                       *http.Client
+	Config                       *Config
+	Abilities                    *AbilityService
+	Addons                       *AddonService
+	EscalationPolicies           *EscalationPolicyService
+	Extensions                   *ExtensionService
+	MaintenanceWindows           *MaintenanceWindowService
+	Rulesets                     *RulesetService
+	EventOrchestrations          *EventOrchestrationService
+	EventOrchestrationPaths      *EventOrchestrationPathService
+	Schedules                    *ScheduleService
+	Services                     *ServicesService
+	Teams                        *TeamService
+	ExtensionSchemas             *ExtensionSchemaService
+	Users                        *UserService
+	Vendors                      *VendorService
+	EventRules                   *EventRuleService
+	BusinessServices             *BusinessServiceService
+	ServiceDependencies          *ServiceDependencyService
+	Priorities                   *PriorityService
+	ResponsePlays                *ResponsePlayService
+	SlackConnections             *SlackConnectionService
+	Tags                         *TagService
+	WebhookSubscriptions         *WebhookSubscriptionService
+	BusinessServiceSubscribers   *BusinessServiceSubscriberService
+	OnCall                       *OnCallService
+	AutomationActionsRunner      *AutomationActionsRunnerService
+	AutomationActionsAction      *AutomationActionsActionService
+	Incidents                    *IncidentService
+	IncidentWorkflows            *IncidentWorkflowService
+	IncidentWorkflowTriggers     *IncidentWorkflowTriggerService
+	CustomFields                 *CustomFieldService
+	CustomFieldSchemas           *CustomFieldSchemaService
+	CustomFieldSchemaAssignments *CustomFieldSchemaAssignmentService
 }
 
 // Response is a wrapper around http.Response
@@ -132,6 +135,9 @@ func NewClient(config *Config) (*Client, error) {
 	c.Incidents = &IncidentService{c}
 	c.IncidentWorkflows = &IncidentWorkflowService{c}
 	c.IncidentWorkflowTriggers = &IncidentWorkflowTriggerService{c}
+	c.CustomFields = &CustomFieldService{c}
+	c.CustomFieldSchemas = &CustomFieldSchemaService{c}
+	c.CustomFieldSchemaAssignments = &CustomFieldSchemaAssignmentService{c}
 
 	InitCache(c)
 	PopulateCache()

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/references.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/references.go
@@ -58,3 +58,7 @@ type SubscriberReference resourceReference
 // IncidentAttributeReference represents a reference to a Incident
 // Attribute schema
 type IncidentAttributeReference resourceReference
+
+// CustomFieldSchemaReference represents a reference to a Custom
+// Field schema
+type CustomFieldSchemaReference resourceReference

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -123,7 +123,7 @@ github.com/hashicorp/terraform-registry-address
 github.com/hashicorp/terraform-svchost
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20230117201746-310c225f8600
+# github.com/heimweh/go-pagerduty v0.0.0-20230213205146-a7761402c92d
 ## explicit
 github.com/heimweh/go-pagerduty/pagerduty
 # github.com/klauspost/compress v1.15.9

--- a/website/docs/d/custom_field.html.markdown
+++ b/website/docs/d/custom_field.html.markdown
@@ -1,0 +1,39 @@
+---
+layout: "pagerduty"
+page_title: "PagerDuty: pagerduty_custom_field"
+sidebar_current: "docs-pagerduty-datasource-custom-field"
+description: |-
+  Get information about a custom field that you can add to a custom field schema.
+---
+
+# pagerduty\_custom\_field
+
+Use this data source to get information about a specific [Custom Field](https://support.pagerduty.com/docs/custom-fields) that you can add to a custom field schema.
+
+-> The Custom Fields feature is currently available in Early Access.
+
+## Example Usage
+
+```hcl
+data "pagerduty_custom_field" "sre_environment" {
+  name      = "environment"
+}
+
+resource "pagerduty_custom_field_schema" "foo" {
+  title       = "myschema"
+  description = "some description"
+  field {
+    field = data.pagerduty_custom_field.sre_environment.id
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the field.
+
+## Attributes Reference
+
+* `id` - The ID of the found field.

--- a/website/docs/d/custom_field_schema.html.markdown
+++ b/website/docs/d/custom_field_schema.html.markdown
@@ -1,0 +1,40 @@
+---
+layout: "pagerduty"
+page_title: "PagerDuty: pagerduty_custom_field_schema"
+sidebar_current: "docs-pagerduty-datasource-custom-field_schema"
+description: |-
+  Get information about a custom field schema that you can assign to services.
+---
+
+# pagerduty\_custom\_field\_schema
+
+Use this data source to get information about a specific [Custom Field Schema](https://support.pagerduty.com/docs/custom-fields#schemas) that you can assign to a service.
+
+-> The Custom Fields feature is currently available in Early Access.
+
+## Example Usage
+
+```hcl
+data "pagerduty_custom_field_schema" "myschema" {
+  title = "myschema title"
+}
+
+data "pagerduty_service" "first_service" {
+  name = "My Service"
+}
+
+resource "pagerduty_custom_field_schema_assignment" "foo" {
+  schema  = data.pagerduty_custom_field_schema.myschema.id
+  service = data.pagerduty_service.first_service.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `title` - (Required) The title of the field schema.
+
+## Attributes Reference
+
+* `id` - The ID of the found field schema.

--- a/website/docs/r/custom_field.html.markdown
+++ b/website/docs/r/custom_field.html.markdown
@@ -1,0 +1,51 @@
+---
+layout: "pagerduty"
+page_title: "PagerDuty: pagerduty_custom_field"
+sidebar_current: "docs-pagerduty-resource-custom-field"
+description: |-
+  Creates and manages a custom field in PagerDuty.
+---
+
+# pagerduty\_custom\_field
+
+A [Custom Field](https://support.pagerduty.com/docs/custom-fields) is a resuable element which can be added to Custom Field Schemas.
+
+-> The Custom Fields feature is currently available in Early Access.
+
+## Example Usage
+
+```hcl
+resource "pagerduty_custom_field" "cs_impact" {
+  name      = "impact"
+  datatype  = "string"
+}
+
+resource "pagerduty_custom_field" "sre_environment" {
+  name          = "environment"
+  datatype      = "string"
+  fixed_options = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+  * `name` - (Required) The name of the field.
+  * `datatype` - (Required) The datatype of the field. Must be one of `string`, `integer`, `float`, `boolean`, `datetime`, or `url`.
+  * `multi_value` - (Optional) True if the field can accept multiple values.
+  * `fixed_options` - (Optional) True if the field can only accept values from a set of options.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+  * `id` - The ID of the field.
+
+## Import
+
+Fields can be imported using the `id`, e.g.
+
+```
+$ terraform import pagerduty_custom_field.sre_environment PLBP09X
+```

--- a/website/docs/r/custom_field_option.html.markdown
+++ b/website/docs/r/custom_field_option.html.markdown
@@ -1,0 +1,55 @@
+---
+layout: "pagerduty"
+page_title: "PagerDuty: pagerduty_custom_field_option"
+sidebar_current: "docs-pagerduty-resource-custom-field-option"
+description: |-
+  Creates and manages a custom field option in PagerDuty.
+---
+
+# pagerduty\_custom\_field\_option
+
+A Custom Field Option is a specific value that can be used for [Custom Fields](https://support.pagerduty.com/docs/custom-fields) that only allow values from a set of fixed option. 
+
+-> The Custom Fields feature is currently available in Early Access.
+
+## Example Usage
+
+```hcl
+resource "pagerduty_custom_field" "sre_environment" {
+  name          = "environment"
+  datatype      = "string"
+  fixed_options = true
+}
+
+resource "pagerduty_custom_field_option" "dev_environment" {
+  field    = pagerduty_custom_field.sre_environment.id
+  datatype = "string"
+  value    = "dev"
+}
+
+resource "pagerduty_custom_field_option" "stage_environment" {
+  field    = pagerduty_custom_field.sre_environment.id
+  datatype = "string"
+  value    = "stage"
+}
+
+resource "pagerduty_custom_field_option" "prod_environment" {
+  field    = pagerduty_custom_field.sre_environment.id
+  datatype = "string"
+  value    = "prod"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `field` - (Required) The ID of the field.
+* `datatype` - (Required) The datatype of the field option. Must be one of `string`, `integer`, `float`, `boolean`, `datetime`, or `url`.
+* `value` - (Required) The allowed value.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+  * `id` - The ID of the field option.

--- a/website/docs/r/custom_field_schema.html.markdown
+++ b/website/docs/r/custom_field_schema.html.markdown
@@ -1,0 +1,49 @@
+---
+layout: "pagerduty"
+page_title: "PagerDuty: pagerduty_custom_field_schema"
+sidebar_current: "docs-pagerduty-resource-custom-field-schema"
+description: |-
+  Creates and manages a custom field schema in PagerDuty.
+---
+
+# pagerduty\_custom\_field\_schema
+
+A [Custom Field Schema](https://support.pagerduty.com/docs/custom-fields#schemas) is a set of Custom Fields which can be set on an incident.
+
+-> The Custom Fields feature is currently available in Early Access.
+
+
+## Example Usage
+
+```hcl
+resource "pagerduty_custom_field" "cs_impact" {
+  name      = "impact"
+  datatype  = "string"
+}
+
+resource "pagerduty_custom_field_schema" "my_schema" {
+  title       = "My Schema"
+  description = "Fields used on incidents"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+  * `title` - (Required) The title of the field schema.
+  * `description` - (Optional) The description of the field schema.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+  * `id` - The ID of the field schema.
+
+## Import
+
+Fields schemas can be imported using the `id`, e.g.
+
+```
+$ terraform import pagerduty_custom_field_schema.my_schema PLBP09X
+```

--- a/website/docs/r/custom_field_schema_assignment.html.markdown
+++ b/website/docs/r/custom_field_schema_assignment.html.markdown
@@ -1,0 +1,49 @@
+---
+layout: "pagerduty"
+page_title: "PagerDuty: pagerduty_custom_field_schema_assignment"
+sidebar_current: "docs-pagerduty-resource-custom-field-schema-assignment"
+description: |-
+  Creates and manages a custom field schema assignment in PagerDuty.
+---
+
+# pagerduty\_custom\_field\_schema\_assignment
+
+A [Custom Field Schema Assignment](https://support.pagerduty.com/docs/custom-fields#associate-schemas-with-services) is a relationship between a Custom Field Schema and a Service.
+
+-> The Custom Fields feature is currently available in Early Access.
+
+## Example Usage
+
+```hcl
+resource "pagerduty_custom_field" "cs_impact" {
+  name      = "impact"
+  datatype  = "string"
+}
+
+resource "pagerduty_custom_field_schema" "my_schema" {
+  title       = "My Schema"
+  description = "Fields used on incidents"
+}
+
+data "pagerduty_service" "first_service" {
+  name = "My First Service"
+}
+
+resource "pagerduty_custom_field_schema_assignment" "assignment" {
+  schema  = pagerduty_custom_field_schema.my_schema.id
+  service = data.pagerduty_service.first_service.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+  * `schema` - (Required) The id of the field schema.
+  * `service` - (Required) The id of the service.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+  * `id` - The ID of the field schema assignment.

--- a/website/docs/r/custom_field_schema_field_configuration.html.markdown
+++ b/website/docs/r/custom_field_schema_field_configuration.html.markdown
@@ -1,0 +1,99 @@
+---
+layout: "pagerduty"
+page_title: "PagerDuty: pagerduty_custom_field_schema_field_configuration"
+sidebar_current: "docs-pagerduty-resource-custom-field-schema-field-configuration"
+description: |-
+  Creates and manages a custom field configuration in PagerDuty.
+---
+
+# pagerduty\_custom\_field\_schema\_field\_configuration
+
+A [Custom Field Configuration](https://support.pagerduty.com/docs/custom-fields#associate-schemas-with-services) is a declaration of a specific Custom Field in a specific Custom Field Schema.
+
+-> The Custom Fields feature is currently available in Early Access.
+
+## Example Usage
+
+```hcl
+resource "pagerduty_custom_field" "cs_impact" {
+  name      = "impact"
+  datatype  = "string"
+}
+
+resource "pagerduty_custom_field_schema" "my_schema" {
+  title       = "My Schema"
+  description = "Fields used on incidents"
+}
+
+resource "pagerduty_custom_field_configuration" "first_field_configuration" {
+  schema                 = pagerduty_custom_field_schema.my_schema.id
+  field                  = pagerduty_custom_field.cs_impact.id
+  required               = true
+  default_value          = "none"
+  default_value_datatype = "string"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `field` - (Required) The ID of the field.
+* `schema` - (Required) The ID of the schema.
+* `required` - (Optional) True if the field is required
+* `default_value` - (Optional) The default value for the field.
+* `default_value_datatype` - (Optional) The datatype of the default value.
+* `default_value_multi_value` - (Optional) Whether or not the default value is multi-valued.
+
+#### Required and Default Value
+
+Although `required`, `default_value`, and `default_value_datatype` are all
+technically optional, they must be provided together, i.e. if `required` is `true`,
+there **must** be a `default_value` and a `default_value_datatype`.
+
+The `default_value_multi_value` attribute is only required if it is `true`, i.e. these two fragments
+are semantically identical:
+
+```hcl
+    field                     = "ID1"
+    schema                    = "ID2"
+    required                  = true
+    default_value             = "foo"
+    default_value_datatype    = "string"
+```
+
+```hcl
+    field                     = "ID1"
+    schema                    = "ID2"
+    required                  = true
+    default_value             = "foo"
+    default_value_datatype    = "string"
+    default_value_multi_value = false
+```
+
+Default values are always strings. When providing a default value for a multi-valued field, the default value
+needs to be a JSON-encoded array, e.g.
+
+```hcl
+    field                     = "ID1"
+    required                  = true
+    default_value             = jsonencode(["foo", "bar"])
+    default_value_datatype    = "string"
+    default_value_multi_value = true
+```
+
+
+```hcl
+    field                     = "ID1"
+    required                  = true
+    default_value             = jsonencode([50, 60])
+    default_value_datatype    = "string"
+    default_value_multi_value = true
+```
+
+## Attributes Reference
+
+The following attributes are exported:
+
+  * `id` - The ID of the field configuration.
+


### PR DESCRIPTION
This adds support for the new PagerDuty Custom Fields on Incidents features. These are currently in Early Access and not available to all accounts.

API Documentation for this feature are visible on https://developer.pagerduty.com/api-reference/f1a95bb9397ba-changelog

Dependent upon https://github.com/heimweh/go-pagerduty/pull/120

Testing is done similarly to incident workflows where there is an environment variable (`PAGERDUTY_ACC_CUSTOM_FIELDS`) that must be set. As with workflows, any value will do, but `1` is recommended:

```
PAGERDUTY_ACC_CUSTOM_FIELDS=1 make testacc TESTARGS="-run PagerDutyCustomField"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run PagerDutyCustomField -timeout 120m
?       github.com/terraform-providers/terraform-provider-pagerduty     [no test files]
=== RUN   TestAccDataSourcePagerDutyCustomField
--- PASS: TestAccDataSourcePagerDutyCustomField (6.24s)
=== RUN   TestAccDataSourcePagerDutyCustomFieldSchema
--- PASS: TestAccDataSourcePagerDutyCustomFieldSchema (5.20s)
=== RUN   TestAccPagerDutyCustomFieldOptions_Basic
--- PASS: TestAccPagerDutyCustomFieldOptions_Basic (11.44s)
=== RUN   TestAccPagerDutyCustomFieldOptions_Integer
--- PASS: TestAccPagerDutyCustomFieldOptions_Integer (11.48s)
=== RUN   TestAccPagerDutyCustomFieldOptions_Integer_Bad
--- PASS: TestAccPagerDutyCustomFieldOptions_Integer_Bad (1.60s)
=== RUN   TestAccPagerDutyCustomFieldOptions_Integer_Bad_Float
--- PASS: TestAccPagerDutyCustomFieldOptions_Integer_Bad_Float (1.22s)
=== RUN   TestAccPagerDutyCustomFieldOptions_Float
--- PASS: TestAccPagerDutyCustomFieldOptions_Float (11.48s)
=== RUN   TestAccPagerDutyCustomFieldOptions_Float_Bad
--- PASS: TestAccPagerDutyCustomFieldOptions_Float_Bad (1.10s)
=== RUN   TestAccPagerDutyCustomFieldSchemaAssignment
--- PASS: TestAccPagerDutyCustomFieldSchemaAssignment (12.06s)
=== RUN   TestPagerDutyCustomField_ValidateDefaultFieldValue
=== RUN   TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_default!!!_for_type_integer,_multi-value:_false
=== RUN   TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_42_for_type_integer,_multi-value:_false
=== RUN   TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_42_for_type_integer,_multi-value:_true
=== RUN   TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_[42,"foo"]_for_type_integer,_multi-value:_true
=== RUN   TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_[50.5,"foo"]_for_type_float,_multi-value:_true
=== RUN   TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_[50.5,42.3]_for_type_float,_multi-value:_true
=== RUN   TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_default!!!_for_type_float,_multi-value:_false
=== RUN   TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_50.5_for_type_float,_multi-value:_false
=== RUN   TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_50.5_for_type_float,_multi-value:_true
=== RUN   TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_[50.5,"foo"]_for_type_float,_multi-value:_true#01
=== RUN   TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_[50.5,42.3]_for_type_float,_multi-value:_true#01
=== RUN   TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_default!!!_for_type_boolean,_multi-value:_false
=== RUN   TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_True_for_type_boolean,_multi-value:_false
=== RUN   TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_true_for_type_boolean,_multi-value:_false
=== RUN   TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_false_for_type_boolean,_multi-value:_false
=== RUN   TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_default!!!_for_type_url,_multi-value:_false
=== RUN   TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_\x01_for_type_url,_multi-value:_false
=== RUN   TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_https://www.pagerduty.com/_for_type_url,_multi-value:_false
=== RUN   TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_default!!!_for_type_datetime,_multi-value:_false
=== RUN   TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_2022-01-03T15:04:05Z_for_type_datetime,_multi-value:_false
=== RUN   TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_anything_goes_--_validated_server-side_for_type_field_option,_multi-value:_false
=== RUN   TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_something_for_type_field_option,_multi-value:_true
--- PASS: TestPagerDutyCustomField_ValidateDefaultFieldValue (0.00s)
    --- PASS: TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_default!!!_for_type_integer,_multi-value:_false (0.00s)
    --- PASS: TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_42_for_type_integer,_multi-value:_false (0.00s)
    --- PASS: TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_42_for_type_integer,_multi-value:_true (0.00s)
    --- PASS: TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_[42,"foo"]_for_type_integer,_multi-value:_true (0.00s)
    --- PASS: TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_[50.5,"foo"]_for_type_float,_multi-value:_true (0.00s)
    --- PASS: TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_[50.5,42.3]_for_type_float,_multi-value:_true (0.00s)
    --- PASS: TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_default!!!_for_type_float,_multi-value:_false (0.00s)
    --- PASS: TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_50.5_for_type_float,_multi-value:_false (0.00s)
    --- PASS: TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_50.5_for_type_float,_multi-value:_true (0.00s)
    --- PASS: TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_[50.5,"foo"]_for_type_float,_multi-value:_true#01 (0.00s)
    --- PASS: TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_[50.5,42.3]_for_type_float,_multi-value:_true#01 (0.00s)
    --- PASS: TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_default!!!_for_type_boolean,_multi-value:_false (0.00s)
    --- PASS: TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_True_for_type_boolean,_multi-value:_false (0.00s)
    --- PASS: TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_true_for_type_boolean,_multi-value:_false (0.00s)
    --- PASS: TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_false_for_type_boolean,_multi-value:_false (0.00s)
    --- PASS: TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_default!!!_for_type_url,_multi-value:_false (0.00s)
    --- PASS: TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_\x01_for_type_url,_multi-value:_false (0.00s)
    --- PASS: TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_https://www.pagerduty.com/_for_type_url,_multi-value:_false (0.00s)
    --- PASS: TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_default!!!_for_type_datetime,_multi-value:_false (0.00s)
    --- PASS: TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_2022-01-03T15:04:05Z_for_type_datetime,_multi-value:_false (0.00s)
    --- PASS: TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_anything_goes_--_validated_server-side_for_type_field_option,_multi-value:_false (0.00s)
    --- PASS: TestPagerDutyCustomField_ValidateDefaultFieldValue/Test_value:_something_for_type_field_option,_multi-value:_true (0.00s)
=== RUN   TestAccPagerDutyCustomFieldConfiguration_Basic
--- PASS: TestAccPagerDutyCustomFieldConfiguration_Basic (7.31s)
=== RUN   TestAccPagerDutyCustomFieldConfiguration_Required
--- PASS: TestAccPagerDutyCustomFieldConfiguration_Required (12.79s)
=== RUN   TestAccPagerDutyCustomFieldConfiguration_Required_BadDataType
--- PASS: TestAccPagerDutyCustomFieldConfiguration_Required_BadDataType (1.04s)
=== RUN   TestAccPagerDutyCustomFieldConfiguration_Required_Without_Default
--- PASS: TestAccPagerDutyCustomFieldConfiguration_Required_Without_Default (1.02s)
=== RUN   TestAccPagerDutyCustomFieldConfiguration_Required_Without_DefaultDataType
--- PASS: TestAccPagerDutyCustomFieldConfiguration_Required_Without_DefaultDataType (1.00s)
=== RUN   TestAccPagerDutyCustomFieldConfiguration_Default_Without_Required
--- PASS: TestAccPagerDutyCustomFieldConfiguration_Default_Without_Required (1.03s)
=== RUN   TestAccPagerDutyCustomFieldConfiguration_Required_InvalidValue_MultiValue
--- PASS: TestAccPagerDutyCustomFieldConfiguration_Required_InvalidValue_MultiValue (1.08s)
=== RUN   TestAccPagerDutyCustomFieldSchemas_Basic
--- PASS: TestAccPagerDutyCustomFieldSchemas_Basic (8.16s)
=== RUN   TestAccPagerDutyCustomFields_Basic
--- PASS: TestAccPagerDutyCustomFields_Basic (8.09s)
=== RUN   TestAccPagerDutyCustomField_BasicWithDescription
--- PASS: TestAccPagerDutyCustomField_BasicWithDescription (4.42s)
=== RUN   TestAccPagerDutyCustomFields_UnknownDataType
--- PASS: TestAccPagerDutyCustomFields_UnknownDataType (1.03s)
=== RUN   TestAccPagerDutyCustomFields_IllegalDataType
--- PASS: TestAccPagerDutyCustomFields_IllegalDataType (0.97s)
=== RUN   TestPagerDutyCustomField_ConvertValueForBuild
--- PASS: TestPagerDutyCustomField_ConvertValueForBuild (0.00s)
=== RUN   TestPagerDutyCustomField_ConvertDefaultValueForFlatten
--- PASS: TestPagerDutyCustomField_ConvertDefaultValueForFlatten (0.00s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   110.134s
```