### PR TITLE
service: Compute additional fields already included in API response

### DIFF
--- a/pagerduty/data_source_pagerduty_service.go
+++ b/pagerduty/data_source_pagerduty_service.go
@@ -19,6 +19,43 @@ func dataSourcePagerDutyService() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"auto_resolve_timeout": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"acknowledgement_timeout": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"alert_creation": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"escalation_policy": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"teams": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The set of teams associated with the service",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 			"type": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -65,9 +102,23 @@ func dataSourcePagerDutyServiceRead(d *schema.ResourceData, meta interface{}) er
 			)
 		}
 
+		var teams []map[string]interface{}
+		for _, team := range found.Teams {
+			teams = append(teams, map[string]interface{}{
+				"id":   team.ID,
+				"name": team.Summary,
+			})
+		}
+
 		d.SetId(found.ID)
 		d.Set("name", found.Name)
 		d.Set("type", found.Type)
+		d.Set("auto_resolve_timeout", found.AutoResolveTimeout)
+		d.Set("acknowledgement_timeout", found.AcknowledgementTimeout)
+		d.Set("alert_creation", found.AlertCreation)
+		d.Set("description", found.Description)
+		d.Set("teams", teams)
+		d.Set("escalation_policy", found.EscalationPolicy.ID)
 
 		return nil
 	})


### PR DESCRIPTION
## WHAT

* Adds additional fields already present in the data model

## WHY

* We are trying to generate terraform + matching state import scripts for existing resources, this will allow us to model all the required input fields for the `pagerduty_service` resource to allow us to import existing into state successfully

## Tests

* All existing unit tests pass, and it is purely additive, if you want extra tests for each field - just let me know.
* I didn't run the acceptance tests locally as I don't have an environment setup to run them in - LMK if this is required.