### PR TITLE
Address: Service integration perm diff with Generic email and empty/omitted `email_filter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,10 @@ the value of the environment variable is not relevant.
 For example:
 ```sh
 PAGERDUTY_ACC_INCIDENT_WORKFLOWS=1 make testacc TESTARGS="-run PagerDutyIncidentWorkflow"
+PAGERDUTY_ACC_SERVICE_INTEGRATION_GENERIC_EMAIL_NO_FILTERS="user@<your_domain>.pagerduty.com" make testacc TESTARGS="-run TestAccPagerDutyServiceIntegration_GenericEmailNoFilters"
 ```
 
-| Variable Name                      | Feature Set        |
-|------------------------------------|--------------------|
-| `PAGERDUTY_ACC_INCIDENT_WORKFLOWS` | Incident Workflows |
+| Variable Name                                               | Feature Set         |
+| ----------------------------------------------------------- | ------------------- |
+| `PAGERDUTY_ACC_INCIDENT_WORKFLOWS`                          | Incident Workflows  |
+| `PAGERDUTY_ACC_SERVICE_INTEGRATION_GENERIC_EMAIL_NO_FILTERS` | Service Integration |

--- a/pagerduty/resource_pagerduty_service_integration.go
+++ b/pagerduty/resource_pagerduty_service_integration.go
@@ -355,11 +355,11 @@ func customizeServiceIntegrationDiff() schema.CustomizeDiffFunc {
 				old := oldEF[idx]
 				isSameEFConfig := old["id"] == new["id"]
 
+				efConfig := new
 				if isSameEFConfig && isEFDefaultConfigBlock(old) && isEFEmptyConfigBlock(new) {
-					updatedEF = append(updatedEF, old)
-				} else {
-					updatedEF = append(updatedEF, new)
+					efConfig = old
 				}
+				updatedEF = append(updatedEF, efConfig)
 			}
 
 			diff.SetNew("email_filter", updatedEF)

--- a/pagerduty/resource_pagerduty_service_integration_test.go
+++ b/pagerduty/resource_pagerduty_service_integration_test.go
@@ -395,6 +395,13 @@ func TestAccPagerDutyServiceIntegration_GenericEmailNoFilters(t *testing.T) {
 						"pagerduty_service_integration.bar", "type", "generic_email_inbound_integration"),
 				),
 			},
+			{
+				Config: testAccCheckPagerDutyServiceIntegrationMultipleGenericEmailNoFilters(username, email, escalationPolicy, service, serviceIntegration),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"pagerduty_service_integration.foo", "type", "generic_email_inbound_integration"),
+				),
+			},
 		},
 	})
 }
@@ -1042,6 +1049,73 @@ resource "pagerduty_service_integration" "bar" {
   type              = "generic_email_inbound_integration"
   integration_email = "%[6]s"
   email_filter {}
+}
+`, username, email, escalationPolicy, service, serviceIntegration, integrationEmail)
+}
+
+func testAccCheckPagerDutyServiceIntegrationMultipleGenericEmailNoFilters(username, email, escalationPolicy, service, serviceIntegration string) string {
+	integrationEmail := os.Getenv("PAGERDUTY_ACC_SERVICE_INTEGRATION_GENERIC_EMAIL_NO_FILTERS")
+
+	return fmt.Sprintf(`
+resource "pagerduty_user" "foo" {
+  name        = "%s"
+  email       = "%s"
+  color       = "green"
+  role        = "user"
+  job_title   = "foo"
+  description = "foo"
+}
+
+resource "pagerduty_escalation_policy" "foo" {
+  name        = "%s"
+  description = "bar"
+  num_loops   = 2
+
+  rule {
+    escalation_delay_in_minutes = 10
+
+    target {
+      type = "user_reference"
+      id   = pagerduty_user.foo.id
+    }
+  }
+}
+
+resource "pagerduty_service" "foo" {
+  name                    = "%s"
+  description             = "bar"
+  auto_resolve_timeout    = 3600
+  acknowledgement_timeout = 3600
+  escalation_policy       = pagerduty_escalation_policy.foo.id
+
+  incident_urgency_rule {
+    type    = "constant"
+    urgency = "high"
+  }
+}
+
+resource "pagerduty_service_integration" "foo" {
+  name              = "%[5]s"
+  service           = pagerduty_service.foo.id
+  type              = "generic_email_inbound_integration"
+  integration_email = "%[6]s"
+  email_filter {
+    body_mode        = "always"
+    body_regex       = null
+    from_email_mode  = "match"
+    from_email_regex = "(@bar.com*)"
+    subject_mode     = "match"
+    subject_regex    = "(CRITICAL*)"
+  }
+  email_filter {}
+  email_filter {
+    body_mode        = "always"
+    body_regex       = null
+    from_email_mode  = "match"
+    from_email_regex = "(@bar.com*)"
+    subject_mode     = "match"
+    subject_regex    = "(CRITICAL*)"
+  }
 }
 `, username, email, escalationPolicy, service, serviceIntegration, integrationEmail)
 }

--- a/pagerduty/resource_pagerduty_service_integration_test.go
+++ b/pagerduty/resource_pagerduty_service_integration_test.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"testing"
 
@@ -364,6 +365,34 @@ func TestAccPagerDutyServiceIntegrationEmail_Filters(t *testing.T) {
 						"pagerduty_service_integration.foo", "email_parser.1.value_extractor.2.type", "regex"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service_integration.foo", "email_parser.1.value_extractor.2.value_name", "FieldName2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPagerDutyServiceIntegration_GenericEmailNoFilters(t *testing.T) {
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.test", username)
+	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	serviceIntegration := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckServiceIntegrationGenericEmailNoFilters(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyServiceIntegrationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyServiceIntegrationGenericEmailNoFilters(username, email, escalationPolicy, service, serviceIntegration),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"pagerduty_service_integration.foo", "type", "generic_email_inbound_integration"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service_integration.bar", "type", "generic_email_inbound_integration"),
 				),
 			},
 		},
@@ -957,4 +986,68 @@ resource "pagerduty_service_integration" "foo" {
   email_parsing_fallback = "open_new_incident"
 }
 `, username, email, escalationPolicy, service, serviceIntegration, accountDomain)
+}
+
+func testAccCheckPagerDutyServiceIntegrationGenericEmailNoFilters(username, email, escalationPolicy, service, serviceIntegration string) string {
+	integrationEmail := os.Getenv("PAGERDUTY_ACC_SERVICE_INTEGRATION_GENERIC_EMAIL_NO_FILTERS")
+
+	return fmt.Sprintf(`
+resource "pagerduty_user" "foo" {
+  name        = "%s"
+  email       = "%s"
+  color       = "green"
+  role        = "user"
+  job_title   = "foo"
+  description = "foo"
+}
+
+resource "pagerduty_escalation_policy" "foo" {
+  name        = "%s"
+  description = "bar"
+  num_loops   = 2
+
+  rule {
+    escalation_delay_in_minutes = 10
+
+    target {
+      type = "user_reference"
+      id   = pagerduty_user.foo.id
+    }
+  }
+}
+
+resource "pagerduty_service" "foo" {
+  name                    = "%s"
+  description             = "bar"
+  auto_resolve_timeout    = 3600
+  acknowledgement_timeout = 3600
+  escalation_policy       = pagerduty_escalation_policy.foo.id
+
+  incident_urgency_rule {
+    type    = "constant"
+    urgency = "high"
+  }
+}
+
+resource "pagerduty_service_integration" "foo" {
+  name              = "%[5]s"
+  service           = pagerduty_service.foo.id
+  type              = "generic_email_inbound_integration"
+  integration_email = "%[6]s"
+}
+
+resource "pagerduty_service_integration" "bar" {
+  name              = "%[5]s"
+  service           = pagerduty_service.foo.id
+  type              = "generic_email_inbound_integration"
+  integration_email = "%[6]s"
+  email_filter {}
+}
+`, username, email, escalationPolicy, service, serviceIntegration, integrationEmail)
+}
+
+func testAccPreCheckServiceIntegrationGenericEmailNoFilters(t *testing.T) {
+	if v := os.Getenv("PAGERDUTY_ACC_SERVICE_INTEGRATION_GENERIC_EMAIL_NO_FILTERS"); v == "" {
+		t.Skip("PAGERDUTY_ACC_SERVICE_INTEGRATION_GENERIC_EMAIL_NO_FILTERS not set. Skipping Service Integration related test")
+	}
 }


### PR DESCRIPTION
On Provider version [v2.4.0](https://github.com/PagerDuty/terraform-provider-pagerduty/releases/tag/v2.4.0) the attribute `email_filter` was introduced to `pagerduty_service_integration` to enhance the configuration capabilities for `generic_email_inbound_integration` type, however the `email_filter` response from PD API always returns the default values for each field of that make part of the `email_filter` itself, even when this value is configured as empty or omitted from Terraform config. That said, this causes a permanent diff on the state, because the values for the empty/omitted `email_filter` aren't written on the TF code.

Additionally users coming from version **v2.3.0** will find this diff after the update to newer versions of the Provider.

So, this update is meant to solve this permanent diff issue with `pagerduty_service_integration.email_filter` attribute.

## New test cases introduced...
![Screenshot 2023-01-30 at 21 56 26](https://user-images.githubusercontent.com/24704624/215857267-66c4fc2f-9270-410b-a429-dc477a399bc4.png)
