### PR TITLE
Address: Cannot destroy schedule because of open incidents

### DIFF
--- a/pagerduty/resource_pagerduty_schedule.go
+++ b/pagerduty/resource_pagerduty_schedule.go
@@ -368,17 +368,30 @@ func resourcePagerDutyScheduleDelete(d *schema.ResourceData, meta interface{}) e
 	scheduleId := d.Id()
 
 	log.Printf("[INFO] Starting deletion process of Schedule %s", scheduleId)
+	var scheduleData *pagerduty.Schedule
+	retryErr := resource.Retry(10*time.Second, func() *resource.RetryError {
+		resp, _, err := client.Schedules.Get(scheduleId, &pagerduty.GetScheduleOptions{})
+		if err != nil {
+			time.Sleep(2 * time.Second)
+			return resource.RetryableError(err)
+		}
+		scheduleData = resp
+		return nil
+	})
+	if retryErr != nil {
+		return retryErr
+	}
 
 	log.Printf("[INFO] Listing Escalation Policies that use schedule : %s", scheduleId)
 	// Extracting Escalation Policies that use this Schedule
-	epsAssociatedToSchedule, err := extractEPsAssociatedToSchedule(client, scheduleId)
+	epsAssociatedToSchedule, err := extractEPsAssociatedToSchedule(client, scheduleData)
 	if err != nil {
 		return err
 	}
 
 	// An Schedule with open incidents related can't be remove till those
 	// incidents have been resolved.
-	linksToIncidentsOpen, err := listIncidentsOpenedRelatedToSchedule(client, scheduleId, epsAssociatedToSchedule)
+	linksToIncidentsOpen, err := listIncidentsOpenedRelatedToSchedule(client, scheduleData, epsAssociatedToSchedule)
 	if err != nil {
 		return err
 	}
@@ -393,7 +406,7 @@ func resourcePagerDutyScheduleDelete(d *schema.ResourceData, meta interface{}) e
 
 	log.Printf("[INFO] Deleting PagerDuty schedule: %s", scheduleId)
 	// Retrying to give other resources (such as escalation policies) to delete
-	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
+	retryErr = resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if _, err := client.Schedules.Delete(scheduleId); err != nil {
 			if !isErrCode(err, 400) {
 				return resource.RetryableError(err)
@@ -582,33 +595,13 @@ func flattenScheFinalSchedule(finalSche *pagerduty.SubSchedule) []map[string]int
 	return res
 }
 
-func listIncidentsOpenedRelatedToSchedule(c *pagerduty.Client, scheduleID string, epIDs []string) ([]string, error) {
-	var s *pagerduty.Schedule
-	retryErr := resource.Retry(10*time.Second, func() *resource.RetryError {
-		resp, _, err := c.Schedules.Get(scheduleID, &pagerduty.GetScheduleOptions{})
-		if err != nil {
-			time.Sleep(2 * time.Second)
-			return resource.RetryableError(err)
-		}
-		s = resp
-		return nil
-	})
-	if retryErr != nil {
-		return nil, retryErr
-	}
-
-	teams := []string{}
-	for _, t := range s.Teams {
-		teams = append(teams, t.ID)
-	}
-
+func listIncidentsOpenedRelatedToSchedule(c *pagerduty.Client, schedule *pagerduty.Schedule, epIDs []string) ([]string, error) {
 	var incidents []*pagerduty.Incident
-	retryErr = resource.Retry(10*time.Second, func() *resource.RetryError {
+	retryErr := resource.Retry(10*time.Second, func() *resource.RetryError {
 		var err error
 		incidents, err = c.Incidents.ListAll(&pagerduty.ListIncidentsOptions{
 			DateRange: "all",
 			Statuses:  []string{"triggered", "acknowledged"},
-			TeamIDs:   teams,
 			Limit:     100,
 		})
 		if err != nil {
@@ -617,6 +610,9 @@ func listIncidentsOpenedRelatedToSchedule(c *pagerduty.Client, scheduleID string
 		}
 		return nil
 	})
+	if retryErr != nil {
+		return nil, retryErr
+	}
 
 	filterIncidentsByEPs := func(incidents []*pagerduty.Incident, eps []string) []*pagerduty.Incident {
 		var r []*pagerduty.Incident
@@ -641,23 +637,9 @@ func listIncidentsOpenedRelatedToSchedule(c *pagerduty.Client, scheduleID string
 	return linksToIncidents, nil
 }
 
-func extractEPsAssociatedToSchedule(c *pagerduty.Client, id string) ([]string, error) {
-	var s *pagerduty.Schedule
-	retryErr := resource.Retry(10*time.Second, func() *resource.RetryError {
-		resp, _, err := c.Schedules.Get(id, &pagerduty.GetScheduleOptions{})
-		if err != nil {
-			time.Sleep(2 * time.Second)
-			return resource.RetryableError(err)
-		}
-		s = resp
-		return nil
-	})
-	if retryErr != nil {
-		return nil, retryErr
-	}
-
+func extractEPsAssociatedToSchedule(c *pagerduty.Client, schedule *pagerduty.Schedule) ([]string, error) {
 	eps := []string{}
-	for _, ep := range s.EscalationPolicies {
+	for _, ep := range schedule.EscalationPolicies {
 		eps = append(eps, ep.ID)
 	}
 	return eps, nil

--- a/pagerduty/resource_pagerduty_schedule_test.go
+++ b/pagerduty/resource_pagerduty_schedule_test.go
@@ -305,6 +305,92 @@ func TestAccPagerDutyScheduleWithTeams_EscalationPolicyDependantWithOpenIncident
 	})
 }
 
+func TestAccPagerDutySchedule_EscalationPolicyDependantWithOpenIncidents(t *testing.T) {
+	service1 := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	service2 := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.test", username)
+	schedule := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	location := "America/New_York"
+	start := timeNowInLoc(location).Add(24 * time.Hour).Round(1 * time.Hour).Format(time.RFC3339)
+	rotationVirtualStart := timeNowInLoc(location).Add(24 * time.Hour).Round(1 * time.Hour).Format(time.RFC3339)
+	escalationPolicy1 := fmt.Sprintf("ts-%s", acctest.RandString(5))
+	escalationPolicy2 := fmt.Sprintf("ts-%s", acctest.RandString(5))
+	incident_id := ""
+	p_incident_id := &incident_id
+	unrelated_incident_id := ""
+	p_unrelated_incident_id := &unrelated_incident_id
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyScheduleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyScheduleEscalationPolicyDependantWithOpenIncidentConfig(username, email, schedule, location, start, rotationVirtualStart, escalationPolicy1, service1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyScheduleExists("pagerduty_schedule.foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "name", schedule),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "description", "foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_escalation_policy.foo", "name", escalationPolicy1),
+					testAccCheckPagerDutyScheduleOpenIncidentOnService(p_incident_id, "pagerduty_service.foo", "pagerduty_escalation_policy.foo"),
+				),
+			},
+			{
+				Config:      testAccCheckPagerDutyScheduleEscalationPolicyDependantWithOpenIncidentConfigUpdated(username, email, escalationPolicy1, service1),
+				ExpectError: regexp.MustCompile("Before Removing Schedule \".*\" You must first resolve the following incidents related with Escalation Policies using this Schedule"),
+			},
+			{
+				// Extra intermediate step with the original plan for resolving the
+				// outstanding incident and retrying the schedule destroy after that.
+				Config: testAccCheckPagerDutyScheduleEscalationPolicyDependantWithOpenIncidentConfig(username, email, schedule, location, start, rotationVirtualStart, escalationPolicy1, service1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccPagerDutyScheduleResolveIncident(p_incident_id, "pagerduty_escalation_policy.foo"),
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyScheduleEscalationPolicyDependantWithOpenIncidentConfigUpdated(username, email, escalationPolicy1, service1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"pagerduty_escalation_policy.foo", "name", escalationPolicy1),
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyScheduleEscalationPolicyDependantWithUnrelatedOpenIncidentConfig(username, email, schedule, location, start, rotationVirtualStart, escalationPolicy1, escalationPolicy2, service1, service2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyScheduleExists("pagerduty_schedule.foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "name", schedule),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "description", "foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_escalation_policy.foo", "name", escalationPolicy1),
+					resource.TestCheckResourceAttr(
+						"pagerduty_escalation_policy.bar", "name", escalationPolicy2),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "name", service1),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.bar", "name", service2),
+					testAccCheckPagerDutyScheduleOpenIncidentOnService(p_unrelated_incident_id, "pagerduty_service.bar", "pagerduty_escalation_policy.bar"),
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyScheduleEscalationPolicyDependantWithUnrelatedOpenIncidentConfigUpdated(username, email, schedule, location, start, rotationVirtualStart, escalationPolicy1, escalationPolicy2, service1, service2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"pagerduty_escalation_policy.foo", "name", escalationPolicy1),
+					resource.TestCheckResourceAttr(
+						"pagerduty_escalation_policy.bar", "name", escalationPolicy2),
+					testAccPagerDutyScheduleResolveIncident(p_unrelated_incident_id, "pagerduty_escalation_policy.bar"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccPagerDutyScheduleOverflow_Basic(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	email := fmt.Sprintf("%s@foo.test", username)
@@ -1186,6 +1272,69 @@ resource "pagerduty_service" "foo" {
 `, username, email, team, schedule, location, start, rotationVirtualStart, escalationPolicy, service)
 }
 
+func testAccCheckPagerDutyScheduleEscalationPolicyDependantWithOpenIncidentConfig(username, email, schedule, location, start, rotationVirtualStart, escalationPolicy, service string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "foo" {
+  name  = "%s"
+  email = "%s"
+}
+
+resource "pagerduty_schedule" "foo" {
+  name = "%s"
+
+  time_zone   = "%s"
+  description = "foo"
+
+  layer {
+    name                         = "foo"
+    start                        = "%s"
+    rotation_virtual_start       = "%s"
+    rotation_turn_length_seconds = 86400
+    users                        = [pagerduty_user.foo.id]
+
+    restriction {
+      type              = "daily_restriction"
+      start_time_of_day = "08:00:00"
+      duration_seconds  = 32101
+    }
+  }
+}
+
+resource "pagerduty_escalation_policy" "foo" {
+  name      = "%s"
+  num_loops = 2
+
+  rule {
+    escalation_delay_in_minutes = 10
+    target {
+      type = "user_reference"
+      id   = pagerduty_user.foo.id
+    }
+    target {
+      type = "schedule_reference"
+      id   = pagerduty_schedule.foo.id
+    }
+  }
+  
+  rule {
+    escalation_delay_in_minutes = 10
+    target {
+      type = "schedule_reference"
+      id   = pagerduty_schedule.foo.id
+    }
+  }
+}
+resource "pagerduty_service" "foo" {
+	name                    = "%s"
+	description             = "foo"
+	auto_resolve_timeout    = 1800
+	acknowledgement_timeout = 1800
+	escalation_policy       = pagerduty_escalation_policy.foo.id
+	alert_creation          = "create_incidents"
+}
+`, username, email, schedule, location, start, rotationVirtualStart, escalationPolicy, service)
+}
+
 func testAccCheckPagerDutyScheduleWithTeamsEscalationPolicyDependantWithUnrelatedOpenIncidentConfig(username, email, schedule, location, start, rotationVirtualStart, team, escalationPolicy1, escalationPolicy2, service1, service2 string) string {
 	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
@@ -1280,6 +1429,91 @@ resource "pagerduty_service" "bar" {
 `, username, email, team, schedule, location, start, rotationVirtualStart, escalationPolicy1, escalationPolicy2, service1, service2)
 }
 
+func testAccCheckPagerDutyScheduleEscalationPolicyDependantWithUnrelatedOpenIncidentConfig(username, email, schedule, location, start, rotationVirtualStart, escalationPolicy1, escalationPolicy2, service1, service2 string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "foo" {
+  name  = "%[1]s"
+  email = "%[2]s"
+}
+
+resource "pagerduty_schedule" "foo" {
+  name = "%[3]s"
+
+  time_zone   = "%[4]s"
+  description = "foo"
+
+  layer {
+    name                         = "foo"
+    start                        = "%[5]s"
+    rotation_virtual_start       = "%[6]s"
+    rotation_turn_length_seconds = 86400
+    users                        = [pagerduty_user.foo.id]
+
+    restriction {
+      type              = "daily_restriction"
+      start_time_of_day = "08:00:00"
+      duration_seconds  = 32101
+    }
+  }
+}
+
+resource "pagerduty_escalation_policy" "foo" {
+  name      = "%[7]s"
+  num_loops = 2
+
+  rule {
+    escalation_delay_in_minutes = 10
+    target {
+      type = "user_reference"
+      id   = pagerduty_user.foo.id
+    }
+    target {
+      type = "schedule_reference"
+      id   = pagerduty_schedule.foo.id
+    }
+  }
+  
+  rule {
+    escalation_delay_in_minutes = 10
+    target {
+      type = "schedule_reference"
+      id   = pagerduty_schedule.foo.id
+    }
+  }
+}
+
+resource "pagerduty_escalation_policy" "bar" {
+  name      = "%[8]s"
+  num_loops = 2
+
+  rule {
+    escalation_delay_in_minutes = 10
+    target {
+      type = "user_reference"
+      id   = pagerduty_user.foo.id
+    }
+  }
+}
+
+resource "pagerduty_service" "foo" {
+	name                    = "%[9]s"
+	description             = "foo"
+	auto_resolve_timeout    = 1800
+	acknowledgement_timeout = 1800
+	escalation_policy       = pagerduty_escalation_policy.foo.id
+	alert_creation          = "create_incidents"
+}
+resource "pagerduty_service" "bar" {
+	name                    = "%[10]s"
+	description             = "bar"
+	auto_resolve_timeout    = 1800
+	acknowledgement_timeout = 1800
+	escalation_policy       = pagerduty_escalation_policy.bar.id
+	alert_creation          = "create_incidents"
+}
+`, username, email, schedule, location, start, rotationVirtualStart, escalationPolicy1, escalationPolicy2, service1, service2)
+}
+
 func testAccCheckPagerDutyScheduleWithTeamsEscalationPolicyDependantWithUnrelatedOpenIncidentConfigUpdated(username, email, schedule, location, start, rotationVirtualStart, team, escalationPolicy1, escalationPolicy2, service1, service2 string) string {
 	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
@@ -1339,6 +1573,58 @@ resource "pagerduty_service" "bar" {
 `, username, email, team, schedule, location, start, rotationVirtualStart, escalationPolicy1, escalationPolicy2, service1, service2)
 }
 
+func testAccCheckPagerDutyScheduleEscalationPolicyDependantWithUnrelatedOpenIncidentConfigUpdated(username, email, schedule, location, start, rotationVirtualStart, escalationPolicy1, escalationPolicy2, service1, service2 string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "foo" {
+  name  = "%[1]s"
+  email = "%[2]s"
+}
+
+resource "pagerduty_escalation_policy" "foo" {
+  name      = "%[7]s"
+  num_loops = 2
+
+  rule {
+    escalation_delay_in_minutes = 10
+    target {
+      type = "user_reference"
+      id   = pagerduty_user.foo.id
+    }
+  }
+}
+
+resource "pagerduty_escalation_policy" "bar" {
+  name      = "%[8]s"
+  num_loops = 2
+
+  rule {
+    escalation_delay_in_minutes = 10
+    target {
+      type = "user_reference"
+      id   = pagerduty_user.foo.id
+    }
+  }
+}
+
+resource "pagerduty_service" "foo" {
+	name                    = "%[9]s"
+	description             = "foo"
+	auto_resolve_timeout    = 1800
+	acknowledgement_timeout = 1800
+	escalation_policy       = pagerduty_escalation_policy.foo.id
+	alert_creation          = "create_incidents"
+}
+resource "pagerduty_service" "bar" {
+	name                    = "%[10]s"
+	description             = "bar"
+	auto_resolve_timeout    = 1800
+	acknowledgement_timeout = 1800
+	escalation_policy       = pagerduty_escalation_policy.bar.id
+	alert_creation          = "create_incidents"
+}
+`, username, email, schedule, location, start, rotationVirtualStart, escalationPolicy1, escalationPolicy2, service1, service2)
+}
+
 func testAccCheckPagerDutyScheduleWithTeamsEscalationPolicyDependantWithOpenIncidentConfigUpdated(username, email, team, escalationPolicy, service string) string {
 	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
@@ -1373,4 +1659,34 @@ resource "pagerduty_service" "foo" {
 	alert_creation          = "create_incidents"
 }
 `, username, email, team, escalationPolicy, service)
+}
+
+func testAccCheckPagerDutyScheduleEscalationPolicyDependantWithOpenIncidentConfigUpdated(username, email, escalationPolicy, service string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "foo" {
+  name  = "%s"
+  email = "%s"
+}
+
+resource "pagerduty_escalation_policy" "foo" {
+  name      = "%s"
+  num_loops = 2
+
+  rule {
+    escalation_delay_in_minutes = 10
+    target {
+      type = "user_reference"
+      id   = pagerduty_user.foo.id
+    }
+  }
+}
+resource "pagerduty_service" "foo" {
+	name                    = "%s"
+	description             = "foo"
+	auto_resolve_timeout    = 1800
+	acknowledgement_timeout = 1800
+	escalation_policy       = pagerduty_escalation_policy.foo.id
+	alert_creation          = "create_incidents"
+}
+`, username, email, escalationPolicy, service)
 }

--- a/pagerduty/resource_pagerduty_schedule_test.go
+++ b/pagerduty/resource_pagerduty_schedule_test.go
@@ -219,7 +219,8 @@ func TestAccPagerDutyScheduleWithTeams_EscalationPolicyDependant(t *testing.T) {
 }
 
 func TestAccPagerDutyScheduleWithTeams_EscalationPolicyDependantWithOpenIncidents(t *testing.T) {
-	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	service1 := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	service2 := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	email := fmt.Sprintf("%s@foo.test", username)
 	schedule := fmt.Sprintf("tf-%s", acctest.RandString(5))
@@ -227,9 +228,12 @@ func TestAccPagerDutyScheduleWithTeams_EscalationPolicyDependantWithOpenIncident
 	start := timeNowInLoc(location).Add(24 * time.Hour).Round(1 * time.Hour).Format(time.RFC3339)
 	rotationVirtualStart := timeNowInLoc(location).Add(24 * time.Hour).Round(1 * time.Hour).Format(time.RFC3339)
 	team := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	escalationPolicy := fmt.Sprintf("ts-%s", acctest.RandString(5))
+	escalationPolicy1 := fmt.Sprintf("ts-%s", acctest.RandString(5))
+	escalationPolicy2 := fmt.Sprintf("ts-%s", acctest.RandString(5))
 	incident_id := ""
 	p_incident_id := &incident_id
+	unrelated_incident_id := ""
+	p_unrelated_incident_id := &unrelated_incident_id
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -237,7 +241,7 @@ func TestAccPagerDutyScheduleWithTeams_EscalationPolicyDependantWithOpenIncident
 		CheckDestroy: testAccCheckPagerDutyScheduleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckPagerDutyScheduleWithTeamsEscalationPolicyDependantWithOpenIncidentConfig(username, email, schedule, location, start, rotationVirtualStart, team, escalationPolicy, service),
+				Config: testAccCheckPagerDutyScheduleWithTeamsEscalationPolicyDependantWithOpenIncidentConfig(username, email, schedule, location, start, rotationVirtualStart, team, escalationPolicy1, service1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyScheduleExists("pagerduty_schedule.foo"),
 					resource.TestCheckResourceAttr(
@@ -245,27 +249,56 @@ func TestAccPagerDutyScheduleWithTeams_EscalationPolicyDependantWithOpenIncident
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "description", "foo"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_escalation_policy.foo", "name", escalationPolicy),
+						"pagerduty_escalation_policy.foo", "name", escalationPolicy1),
 					testAccCheckPagerDutyScheduleOpenIncidentOnService(p_incident_id, "pagerduty_service.foo", "pagerduty_escalation_policy.foo"),
 				),
 			},
 			{
-				Config:      testAccCheckPagerDutyScheduleWithTeamsEscalationPolicyDependantWithOpenIncidentConfigUpdated(username, email, team, escalationPolicy, service),
+				Config:      testAccCheckPagerDutyScheduleWithTeamsEscalationPolicyDependantWithOpenIncidentConfigUpdated(username, email, team, escalationPolicy1, service1),
 				ExpectError: regexp.MustCompile("Before Removing Schedule \".*\" You must first resolve the following incidents related with Escalation Policies using this Schedule"),
 			},
 			{
 				// Extra intermediate step with the original plan for resolving the
 				// outstanding incident and retrying the schedule destroy after that.
-				Config: testAccCheckPagerDutyScheduleWithTeamsEscalationPolicyDependantWithOpenIncidentConfig(username, email, schedule, location, start, rotationVirtualStart, team, escalationPolicy, service),
+				Config: testAccCheckPagerDutyScheduleWithTeamsEscalationPolicyDependantWithOpenIncidentConfig(username, email, schedule, location, start, rotationVirtualStart, team, escalationPolicy1, service1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccPagerDutyScheduleResolveIncident(p_incident_id, "pagerduty_escalation_policy.foo"),
 				),
 			},
 			{
-				Config: testAccCheckPagerDutyScheduleWithTeamsEscalationPolicyDependantWithOpenIncidentConfigUpdated(username, email, team, escalationPolicy, service),
+				Config: testAccCheckPagerDutyScheduleWithTeamsEscalationPolicyDependantWithOpenIncidentConfigUpdated(username, email, team, escalationPolicy1, service1),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"pagerduty_escalation_policy.foo", "name", escalationPolicy),
+						"pagerduty_escalation_policy.foo", "name", escalationPolicy1),
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyScheduleWithTeamsEscalationPolicyDependantWithUnrelatedOpenIncidentConfig(username, email, schedule, location, start, rotationVirtualStart, team, escalationPolicy1, escalationPolicy2, service1, service2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyScheduleExists("pagerduty_schedule.foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "name", schedule),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "description", "foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_escalation_policy.foo", "name", escalationPolicy1),
+					resource.TestCheckResourceAttr(
+						"pagerduty_escalation_policy.bar", "name", escalationPolicy2),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "name", service1),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.bar", "name", service2),
+					testAccCheckPagerDutyScheduleOpenIncidentOnService(p_unrelated_incident_id, "pagerduty_service.bar", "pagerduty_escalation_policy.bar"),
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyScheduleWithTeamsEscalationPolicyDependantWithUnrelatedOpenIncidentConfigUpdated(username, email, schedule, location, start, rotationVirtualStart, team, escalationPolicy1, escalationPolicy2, service1, service2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"pagerduty_escalation_policy.foo", "name", escalationPolicy1),
+					resource.TestCheckResourceAttr(
+						"pagerduty_escalation_policy.bar", "name", escalationPolicy2),
+					testAccPagerDutyScheduleResolveIncident(p_unrelated_incident_id, "pagerduty_escalation_policy.bar"),
 				),
 			},
 		},
@@ -1151,6 +1184,159 @@ resource "pagerduty_service" "foo" {
 	alert_creation          = "create_incidents"
 }
 `, username, email, team, schedule, location, start, rotationVirtualStart, escalationPolicy, service)
+}
+
+func testAccCheckPagerDutyScheduleWithTeamsEscalationPolicyDependantWithUnrelatedOpenIncidentConfig(username, email, schedule, location, start, rotationVirtualStart, team, escalationPolicy1, escalationPolicy2, service1, service2 string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "foo" {
+  name  = "%[1]s"
+  email = "%[2]s"
+}
+
+resource "pagerduty_team" "foo" {
+	name = "%[3]s"
+	description = "fighters"
+}
+
+resource "pagerduty_schedule" "foo" {
+  name = "%[4]s"
+
+  time_zone   = "%[5]s"
+  description = "foo"
+
+  teams = [pagerduty_team.foo.id]
+
+  layer {
+    name                         = "foo"
+    start                        = "%[6]s"
+    rotation_virtual_start       = "%[7]s"
+    rotation_turn_length_seconds = 86400
+    users                        = [pagerduty_user.foo.id]
+
+    restriction {
+      type              = "daily_restriction"
+      start_time_of_day = "08:00:00"
+      duration_seconds  = 32101
+    }
+  }
+}
+
+resource "pagerduty_escalation_policy" "foo" {
+  name      = "%[8]s"
+  num_loops = 2
+  teams     = [pagerduty_team.foo.id]
+
+  rule {
+    escalation_delay_in_minutes = 10
+    target {
+      type = "user_reference"
+      id   = pagerduty_user.foo.id
+    }
+    target {
+      type = "schedule_reference"
+      id   = pagerduty_schedule.foo.id
+    }
+  }
+  
+  rule {
+    escalation_delay_in_minutes = 10
+    target {
+      type = "schedule_reference"
+      id   = pagerduty_schedule.foo.id
+    }
+  }
+}
+
+resource "pagerduty_escalation_policy" "bar" {
+  name      = "%[9]s"
+  num_loops = 2
+  teams     = [pagerduty_team.foo.id]
+
+  rule {
+    escalation_delay_in_minutes = 10
+    target {
+      type = "user_reference"
+      id   = pagerduty_user.foo.id
+    }
+  }
+}
+
+resource "pagerduty_service" "foo" {
+	name                    = "%[10]s"
+	description             = "foo"
+	auto_resolve_timeout    = 1800
+	acknowledgement_timeout = 1800
+	escalation_policy       = pagerduty_escalation_policy.foo.id
+	alert_creation          = "create_incidents"
+}
+resource "pagerduty_service" "bar" {
+	name                    = "%[11]s"
+	description             = "bar"
+	auto_resolve_timeout    = 1800
+	acknowledgement_timeout = 1800
+	escalation_policy       = pagerduty_escalation_policy.bar.id
+	alert_creation          = "create_incidents"
+}
+`, username, email, team, schedule, location, start, rotationVirtualStart, escalationPolicy1, escalationPolicy2, service1, service2)
+}
+
+func testAccCheckPagerDutyScheduleWithTeamsEscalationPolicyDependantWithUnrelatedOpenIncidentConfigUpdated(username, email, schedule, location, start, rotationVirtualStart, team, escalationPolicy1, escalationPolicy2, service1, service2 string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "foo" {
+  name  = "%[1]s"
+  email = "%[2]s"
+}
+
+resource "pagerduty_team" "foo" {
+	name = "%[3]s"
+	description = "fighters"
+}
+
+resource "pagerduty_escalation_policy" "foo" {
+  name      = "%[8]s"
+  num_loops = 2
+  teams     = [pagerduty_team.foo.id]
+
+  rule {
+    escalation_delay_in_minutes = 10
+    target {
+      type = "user_reference"
+      id   = pagerduty_user.foo.id
+    }
+  }
+}
+
+resource "pagerduty_escalation_policy" "bar" {
+  name      = "%[9]s"
+  num_loops = 2
+  teams     = [pagerduty_team.foo.id]
+
+  rule {
+    escalation_delay_in_minutes = 10
+    target {
+      type = "user_reference"
+      id   = pagerduty_user.foo.id
+    }
+  }
+}
+
+resource "pagerduty_service" "foo" {
+	name                    = "%[10]s"
+	description             = "foo"
+	auto_resolve_timeout    = 1800
+	acknowledgement_timeout = 1800
+	escalation_policy       = pagerduty_escalation_policy.foo.id
+	alert_creation          = "create_incidents"
+}
+resource "pagerduty_service" "bar" {
+	name                    = "%[11]s"
+	description             = "bar"
+	auto_resolve_timeout    = 1800
+	acknowledgement_timeout = 1800
+	escalation_policy       = pagerduty_escalation_policy.bar.id
+	alert_creation          = "create_incidents"
+}
+`, username, email, team, schedule, location, start, rotationVirtualStart, escalationPolicy1, escalationPolicy2, service1, service2)
 }
 
 func testAccCheckPagerDutyScheduleWithTeamsEscalationPolicyDependantWithOpenIncidentConfigUpdated(username, email, team, escalationPolicy, service string) string {


### PR DESCRIPTION
Address: #619 

Additionally addresses the case when Escalation Policy using the Schedule trying be deleted doesn't belong to the same Team as the Schedule, which led to face the API error Bad Request `[Schedule can't be deleted if it's being used by an escalation policy snapshot with open incidents]`.

## Test cases extended and introduced

```sh
TF_LOG=debug make testacc TESTARGS="-run TestAccPagerDutySchedule -count=1"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccPagerDutySchedule -count=1 -timeout 120m
?       github.com/terraform-providers/terraform-provider-pagerduty     [no test files]
=== RUN   TestAccPagerDutySchedule_import
--- PASS: TestAccPagerDutySchedule_import (11.03s)
=== RUN   TestAccPagerDutySchedule_Basic
--- PASS: TestAccPagerDutySchedule_Basic (14.62s)
=== RUN   TestAccPagerDutyScheduleWithTeams_Basic
--- PASS: TestAccPagerDutyScheduleWithTeams_Basic (16.00s)
=== RUN   TestAccPagerDutyScheduleWithTeams_EscalationPolicyDependant
--- PASS: TestAccPagerDutyScheduleWithTeams_EscalationPolicyDependant (19.58s)
=== RUN   TestAccPagerDutyScheduleWithTeams_EscalationPolicyDependantWithOpenIncidents (👈Extended)
--- PASS: TestAccPagerDutyScheduleWithTeams_EscalationPolicyDependantWithOpenIncidents (52.30s)
=== RUN   TestAccPagerDutySchedule_EscalationPolicyDependantWithOpenIncidents (👈Introduced)
--- PASS: TestAccPagerDutySchedule_EscalationPolicyDependantWithOpenIncidents (48.67s)
=== RUN   TestAccPagerDutyScheduleOverflow_Basic
--- PASS: TestAccPagerDutyScheduleOverflow_Basic (15.39s)
=== RUN   TestAccPagerDutySchedule_BasicWeek
--- PASS: TestAccPagerDutySchedule_BasicWeek (14.41s)
=== RUN   TestAccPagerDutySchedule_Multi
--- PASS: TestAccPagerDutySchedule_Multi (15.40s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   207.942s
```

 