### PR TITLE
Fix/slack url eu

### DIFF
--- a/pagerduty/config.go
+++ b/pagerduty/config.go
@@ -29,6 +29,9 @@ type Config struct {
 	// The PagerDuty User level token for Slack
 	UserToken string
 
+	// The URL to send requests to Slack
+	SlackUrlOverride string
+
 	// Skip validation of the token against the PagerDuty API
 	SkipCredsValidation bool
 
@@ -117,7 +120,7 @@ func (c *Config) SlackClient() (*pagerduty.Client, error) {
 	httpClient.Transport = logging.NewTransport("PagerDuty", http.DefaultTransport)
 
 	config := &pagerduty.Config{
-		BaseURL:    c.AppUrl,
+		BaseURL:    c.SlackUrlOverride,
 		Debug:      logging.IsDebugOrHigher(),
 		HTTPClient: httpClient,
 		Token:      c.UserToken,

--- a/pagerduty/provider.go
+++ b/pagerduty/provider.go
@@ -43,6 +43,12 @@ func Provider() *schema.Provider {
 				Optional: true,
 				Default:  "",
 			},
+
+			"slack_url": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
@@ -157,6 +163,12 @@ func providerConfigure(data *schema.ResourceData, terraformVersion string) (inte
 		ServiceRegion = ServiceRegion + "."
 	}
 
+	var SlackUrl = data.Get("slack_url").(string)
+
+	if SlackUrl == "" {
+		SlackUrl = "https://api." + ServiceRegion + "pagerduty.com"
+	}
+
 	config := Config{
 		ApiUrl:              "https://api." + ServiceRegion + "pagerduty.com",
 		AppUrl:              "https://app." + ServiceRegion + "pagerduty.com",
@@ -165,6 +177,7 @@ func providerConfigure(data *schema.ResourceData, terraformVersion string) (inte
 		UserToken:           data.Get("user_token").(string),
 		UserAgent:           fmt.Sprintf("(%s %s) Terraform/%s", runtime.GOOS, runtime.GOARCH, terraformVersion),
 		ApiUrlOverride:      data.Get("api_url_override").(string),
+		SlackUrlOverride:    SlackUrl,
 	}
 
 	log.Println("[INFO] Initializing PagerDuty client")

--- a/pagerduty/provider.go
+++ b/pagerduty/provider.go
@@ -166,7 +166,7 @@ func providerConfigure(data *schema.ResourceData, terraformVersion string) (inte
 	var SlackUrl = data.Get("slack_url").(string)
 
 	if SlackUrl == "" {
-		SlackUrl = "https://api." + ServiceRegion + "pagerduty.com"
+		SlackUrl = "https://app." + ServiceRegion + "pagerduty.com"
 	}
 
 	config := Config{


### PR DESCRIPTION
**What:**
Method to override Slack URL for EU users of pagerduty. If left empty same URL for Slack requests is used as before. This is therefore purely a way for users to override it and shouldnt impact others. 
**Why:**
Noticed that for our EU PagerDuty instance the slack_connection failed. This is because the URL to send requests to is not [app.pagerduty](https://app.pagerduty.com/) but should be `https://(pagerduty_instance).eu.pagerduty.com` as you can see that requests are made to this address when creating Slack connections in the PagerDuty UI.
**Tests:**
Tests are passing