### PR TITLE
Remove early access header for incident workflows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go v0.71.0 // indirect
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.1
-	github.com/heimweh/go-pagerduty v0.0.0-20230213205146-a7761402c92d
+	github.com/heimweh/go-pagerduty v0.0.0-20230228152537-1474894a62f8
 	github.com/klauspost/compress v1.15.9 // indirect
 	github.com/montanaflynn/stats v0.6.6 // indirect
 	go.mongodb.org/mongo-driver v1.10.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -224,10 +224,8 @@ github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/heimweh/go-pagerduty v0.0.0-20230117201746-310c225f8600 h1:mf9awB4qvSXN6fIo94bd/MnG2n3ts+i2KA+mZ3N92z4=
-github.com/heimweh/go-pagerduty v0.0.0-20230117201746-310c225f8600/go.mod h1:t9vftsO1IjYHGdgJXeemZtomCWnxi2SRgu0PRcRb2oY=
-github.com/heimweh/go-pagerduty v0.0.0-20230213205146-a7761402c92d h1:9OZp5Bgl1WDswugwBKLiTcxeCT/t0c293zUtXLL6OUc=
-github.com/heimweh/go-pagerduty v0.0.0-20230213205146-a7761402c92d/go.mod h1:t9vftsO1IjYHGdgJXeemZtomCWnxi2SRgu0PRcRb2oY=
+github.com/heimweh/go-pagerduty v0.0.0-20230228152537-1474894a62f8 h1:dyKF2FYeCgn4JjIFu30wO6cl/OzlQsFhuPwh1GnYJFU=
+github.com/heimweh/go-pagerduty v0.0.0-20230228152537-1474894a62f8/go.mod h1:t9vftsO1IjYHGdgJXeemZtomCWnxi2SRgu0PRcRb2oY=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/incident_workflow.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/incident_workflow.go
@@ -55,12 +55,6 @@ type IncidentWorkflowPayload struct {
 	IncidentWorkflow *IncidentWorkflow `json:"incident_workflow,omitempty"`
 }
 
-var incidentWorkflowsEarlyAccessHeader = RequestOptions{
-	Type:  "header",
-	Label: "X-EARLY-ACCESS",
-	Value: "incident-workflows-early-access",
-}
-
 // ListIncidentWorkflowOptions represents options when retrieving a list of incident workflows.
 type ListIncidentWorkflowOptions struct {
 	Offset   int      `url:"offset,omitempty"`
@@ -102,7 +96,7 @@ func (s *IncidentWorkflowService) ListContext(ctx context.Context, o *ListIncide
 	}
 
 	if o.Limit != 0 {
-		resp, err := s.client.newRequestDoOptionsContext(ctx, "GET", u, o, nil, &v, incidentWorkflowsEarlyAccessHeader)
+		resp, err := s.client.newRequestDoContext(ctx, "GET", u, o, nil, &v)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -132,7 +126,7 @@ func (s *IncidentWorkflowService) ListContext(ctx context.Context, o *ListIncide
 		}
 		err := s.client.newRequestPagedGetQueryDoContext(ctx, u, responseHandler, &listIncidentWorkflowOptionsGen{
 			options: o,
-		}, incidentWorkflowsEarlyAccessHeader)
+		})
 		if err != nil {
 			return nil, nil, err
 		}
@@ -152,7 +146,7 @@ func (s *IncidentWorkflowService) GetContext(ctx context.Context, id string) (*I
 	u := fmt.Sprintf("/incident_workflows/%s", id)
 	v := new(IncidentWorkflowPayload)
 
-	resp, err := s.client.newRequestDoOptionsContext(ctx, "GET", u, nil, nil, v, incidentWorkflowsEarlyAccessHeader)
+	resp, err := s.client.newRequestDoContext(ctx, "GET", u, nil, nil, v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -170,7 +164,7 @@ func (s *IncidentWorkflowService) CreateContext(ctx context.Context, iw *Inciden
 	u := "/incident_workflows"
 	v := new(IncidentWorkflowPayload)
 
-	resp, err := s.client.newRequestDoOptionsContext(ctx, "POST", u, nil, &IncidentWorkflowPayload{IncidentWorkflow: iw}, &v, incidentWorkflowsEarlyAccessHeader)
+	resp, err := s.client.newRequestDoContext(ctx, "POST", u, nil, &IncidentWorkflowPayload{IncidentWorkflow: iw}, &v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -186,7 +180,7 @@ func (s *IncidentWorkflowService) Delete(id string) (*Response, error) {
 // DeleteContext removes an existing incident workflow.
 func (s *IncidentWorkflowService) DeleteContext(ctx context.Context, id string) (*Response, error) {
 	u := fmt.Sprintf("/incident_workflows/%s", id)
-	return s.client.newRequestDoOptionsContext(ctx, "DELETE", u, nil, nil, nil, incidentWorkflowsEarlyAccessHeader)
+	return s.client.newRequestDoContext(ctx, "DELETE", u, nil, nil, nil)
 }
 
 // Update updates an existing incident workflow.
@@ -199,7 +193,7 @@ func (s *IncidentWorkflowService) UpdateContext(ctx context.Context, id string, 
 	u := fmt.Sprintf("/incident_workflows/%s", id)
 	v := new(IncidentWorkflowPayload)
 
-	resp, err := s.client.newRequestDoOptionsContext(ctx, "PUT", u, nil, &IncidentWorkflowPayload{IncidentWorkflow: iw}, &v, incidentWorkflowsEarlyAccessHeader)
+	resp, err := s.client.newRequestDoContext(ctx, "PUT", u, nil, &IncidentWorkflowPayload{IncidentWorkflow: iw}, &v)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/incident_workflow_trigger.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/incident_workflow_trigger.go
@@ -75,7 +75,7 @@ func (s *IncidentWorkflowTriggerService) ListContext(ctx context.Context, o *Lis
 	}
 
 	if o.Limit != 0 {
-		resp, err := s.client.newRequestDoOptionsContext(ctx, "GET", u, o, nil, &v, incidentWorkflowsEarlyAccessHeader)
+		resp, err := s.client.newRequestDoContext(ctx, "GET", u, o, nil, &v)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -104,7 +104,7 @@ func (s *IncidentWorkflowTriggerService) ListContext(ctx context.Context, o *Lis
 		}
 		err := s.client.newRequestCursorPagedGetQueryDoContext(ctx, u, responseHandler, &listIncidentWorkflowTriggerOptionsGen{
 			options: o,
-		}, incidentWorkflowsEarlyAccessHeader)
+		})
 		if err != nil {
 			return nil, nil, err
 		}
@@ -124,7 +124,7 @@ func (s *IncidentWorkflowTriggerService) GetContext(ctx context.Context, id stri
 	u := fmt.Sprintf("/incident_workflows/triggers/%s", id)
 	v := new(IncidentWorkflowTriggerPayload)
 
-	resp, err := s.client.newRequestDoOptionsContext(ctx, "GET", u, nil, nil, v, incidentWorkflowsEarlyAccessHeader)
+	resp, err := s.client.newRequestDoContext(ctx, "GET", u, nil, nil, v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -142,7 +142,7 @@ func (s *IncidentWorkflowTriggerService) CreateContext(ctx context.Context, t *I
 	u := "/incident_workflows/triggers"
 	v := new(IncidentWorkflowTriggerPayload)
 
-	resp, err := s.client.newRequestDoOptionsContext(ctx, "POST", u, nil, &t, &v, incidentWorkflowsEarlyAccessHeader)
+	resp, err := s.client.newRequestDoContext(ctx, "POST", u, nil, &t, &v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -158,7 +158,7 @@ func (s *IncidentWorkflowTriggerService) Delete(id string) (*Response, error) {
 // DeleteContext removes an existing incident workflow trigger.
 func (s *IncidentWorkflowTriggerService) DeleteContext(ctx context.Context, id string) (*Response, error) {
 	u := fmt.Sprintf("/incident_workflows/triggers/%s", id)
-	return s.client.newRequestDoOptionsContext(ctx, "DELETE", u, nil, nil, nil, incidentWorkflowsEarlyAccessHeader)
+	return s.client.newRequestDoContext(ctx, "DELETE", u, nil, nil, nil)
 }
 
 // Update updates an existing incident workflow trigger.
@@ -171,7 +171,7 @@ func (s *IncidentWorkflowTriggerService) UpdateContext(ctx context.Context, id s
 	u := fmt.Sprintf("/incident_workflows/triggers/%s", id)
 	v := new(IncidentWorkflowTriggerPayload)
 
-	resp, err := s.client.newRequestDoOptionsContext(ctx, "PUT", u, nil, &t, &v, incidentWorkflowsEarlyAccessHeader)
+	resp, err := s.client.newRequestDoContext(ctx, "PUT", u, nil, &t, &v)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -123,7 +123,7 @@ github.com/hashicorp/terraform-registry-address
 github.com/hashicorp/terraform-svchost
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20230213205146-a7761402c92d
+# github.com/heimweh/go-pagerduty v0.0.0-20230228152537-1474894a62f8
 ## explicit
 github.com/heimweh/go-pagerduty/pagerduty
 # github.com/klauspost/compress v1.15.9

--- a/website/docs/d/incident_workflow.html.markdown
+++ b/website/docs/d/incident_workflow.html.markdown
@@ -10,8 +10,6 @@ description: |-
 
 Use this data source to get information about a specific [Incident Workflow](https://support.pagerduty.com/docs/incident-workflows) so that you can create a trigger for it.
 
--> The Incident Workflows feature is currently available in Early Access.
-
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/incident_workflow.html.markdown
+++ b/website/docs/r/incident_workflow.html.markdown
@@ -10,8 +10,6 @@ description: |-
 
 An [Incident Workflow](https://support.pagerduty.com/docs/incident-workflows) is a series of steps which can be executed on an incident.
 
--> The Incident Workflows feature is currently available in Early Access.
-
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/incident_workflow_trigger.html.markdown
+++ b/website/docs/r/incident_workflow_trigger.html.markdown
@@ -10,8 +10,6 @@ description: |-
 
 An [Incident Workflow Trigger](https://support.pagerduty.com/docs/incident-workflows#triggers) defines when and if an [Incident Workflow](https://support.pagerduty.com/docs/incident-workflows) will be triggered.
 
--> The Incident Workflows feature is currently available in Early Access.
-
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
Since **Incident Workflows** have become Globally Available neither the heads-up for *Early Access* on related documentation, nor the `X-EARLY-ACCESS` are longer needed on API calls, We are proceeding to remove them with this update.

## Acceptance tests execution result for Incident Workflows...

```sh
PAGERDUTY_ACC_INCIDENT_WORKFLOWS=1 make testacc TESTARGS="-run TestAccPagerDutyIncidentWorkflow -count=1"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccPagerDutyIncidentWorkflow -count=1 -timeout 120m
?       github.com/terraform-providers/terraform-provider-pagerduty     [no test files]
=== RUN   TestAccPagerDutyIncidentWorkflow_import
--- PASS: TestAccPagerDutyIncidentWorkflow_import (6.22s)
=== RUN   TestAccPagerDutyIncidentWorkflowTrigger_import
--- PASS: TestAccPagerDutyIncidentWorkflowTrigger_import (14.21s)
=== RUN   TestAccPagerDutyIncidentWorkflow_Basic
--- PASS: TestAccPagerDutyIncidentWorkflow_Basic (7.62s)
=== RUN   TestAccPagerDutyIncidentWorkflow_Team
--- PASS: TestAccPagerDutyIncidentWorkflow_Team (7.43s)
=== RUN   TestAccPagerDutyIncidentWorkflowTrigger_BadType
--- PASS: TestAccPagerDutyIncidentWorkflowTrigger_BadType (0.20s)
=== RUN   TestAccPagerDutyIncidentWorkflowTrigger_ConditionWithManualType
--- PASS: TestAccPagerDutyIncidentWorkflowTrigger_ConditionWithManualType (0.16s)
=== RUN   TestAccPagerDutyIncidentWorkflowTrigger_ConditionalTypeWithoutCondition
--- PASS: TestAccPagerDutyIncidentWorkflowTrigger_ConditionalTypeWithoutCondition (0.16s)
=== RUN   TestAccPagerDutyIncidentWorkflowTrigger_SubscribedToAllWithInvalidServices
--- PASS: TestAccPagerDutyIncidentWorkflowTrigger_SubscribedToAllWithInvalidServices (0.16s)
=== RUN   TestAccPagerDutyIncidentWorkflowTrigger_BasicManual
--- PASS: TestAccPagerDutyIncidentWorkflowTrigger_BasicManual (14.03s)
=== RUN   TestAccPagerDutyIncidentWorkflowTrigger_BasicConditionalAllServices
--- PASS: TestAccPagerDutyIncidentWorkflowTrigger_BasicConditionalAllServices (10.34s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   60.781s
```

This PR depends on https://github.com/heimweh/go-pagerduty/pull/124