### PR TITLE
RDC-1062 add node filter to process automation job

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go v0.71.0 // indirect
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.1
-	github.com/heimweh/go-pagerduty v0.0.0-20230309154026-a9e5d087e1e3
+	github.com/heimweh/go-pagerduty v0.0.0-20230309222029-be9daaa91ad3
 	github.com/klauspost/compress v1.15.9 // indirect
 	github.com/montanaflynn/stats v0.6.6 // indirect
 	go.mongodb.org/mongo-driver v1.10.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -226,6 +226,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/heimweh/go-pagerduty v0.0.0-20230309154026-a9e5d087e1e3 h1:4p1DAww7nTqTfvxk1ucaUCh2p49/CxubKh+JwqzSRo8=
 github.com/heimweh/go-pagerduty v0.0.0-20230309154026-a9e5d087e1e3/go.mod h1:t9vftsO1IjYHGdgJXeemZtomCWnxi2SRgu0PRcRb2oY=
+github.com/heimweh/go-pagerduty v0.0.0-20230309222029-be9daaa91ad3 h1:Hq/xOdD0O1qo4c4Sihv208dB1R/i50IMAwOkgUy1b58=
+github.com/heimweh/go-pagerduty v0.0.0-20230309222029-be9daaa91ad3/go.mod h1:t9vftsO1IjYHGdgJXeemZtomCWnxi2SRgu0PRcRb2oY=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/pagerduty/data_source_pagerduty_automation_actions_action.go
+++ b/pagerduty/data_source_pagerduty_automation_actions_action.go
@@ -50,6 +50,11 @@ func dataSourcePagerDutyAutomationActionsAction() *schema.Resource {
 							Optional: true,
 							Computed: true,
 						},
+						"process_automation_node_filter": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
 						"script": {
 							Type:     schema.TypeString,
 							Optional: true,

--- a/pagerduty/data_source_pagerduty_automation_actions_action_test.go
+++ b/pagerduty/data_source_pagerduty_automation_actions_action_test.go
@@ -73,6 +73,7 @@ resource "pagerduty_automation_actions_action" "test" {
 	action_data_reference {
 		process_automation_job_id = "pa_job_id_123"
 		process_automation_job_arguments = "-arg 1"
+		process_automation_node_filter = "tags: production"
 	  }
 }
 

--- a/pagerduty/resource_pagerduty_automation_actions_action.go
+++ b/pagerduty/resource_pagerduty_automation_actions_action.go
@@ -55,6 +55,10 @@ func resourcePagerDutyAutomationActionsAction() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+						"process_automation_node_filter": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 						"script": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -167,6 +171,13 @@ func expandActionDataReference(v interface{}) pagerduty.AutomationActionsActionD
 		v_str := v.(string)
 		if v_str != "" {
 			adr.ProcessAutomationJobArguments = &v_str
+		}
+	}
+
+	if v, ok := attr_map["process_automation_node_filter"]; ok {
+		v_str := v.(string)
+		if v_str != "" {
+			adr.ProcessAutomationNodeFilter = &v_str
 		}
 	}
 
@@ -297,6 +308,10 @@ func flattenActionDataReference(adr pagerduty.AutomationActionsActionDataReferen
 
 	if adr.ProcessAutomationJobArguments != nil {
 		adr_map["process_automation_job_arguments"] = *adr.ProcessAutomationJobArguments
+	}
+
+	if adr.ProcessAutomationNodeFilter != nil {
+		adr_map["process_automation_node_filter"] = *adr.ProcessAutomationNodeFilter
 	}
 
 	if adr.Script != nil {

--- a/pagerduty/resource_pagerduty_automation_actions_action_test.go
+++ b/pagerduty/resource_pagerduty_automation_actions_action_test.go
@@ -47,6 +47,8 @@ func TestAccPagerDutyAutomationActionsActionTypeProcessAutomation_Basic(t *testi
 						"pagerduty_automation_actions_action.foo", "action_data_reference.0.process_automation_job_arguments", "-arg 1"),
 					// Known defect with inconsistent handling of nested aggregates: https://github.com/hashicorp/terraform-plugin-sdk/issues/413
 					resource.TestCheckResourceAttr(
+						"pagerduty_automation_actions_action.foo", "action_data_reference.0.process_automation_node_filter", "tags: production"),
+					resource.TestCheckResourceAttr(
 						"pagerduty_automation_actions_action.foo", "action_data_reference.0.script", ""),
 					resource.TestCheckResourceAttr(
 						"pagerduty_automation_actions_action.foo", "action_data_reference.0.invocation_command", ""),
@@ -71,6 +73,8 @@ func TestAccPagerDutyAutomationActionsActionTypeProcessAutomation_Basic(t *testi
 					resource.TestCheckResourceAttr(
 						"pagerduty_automation_actions_action.foo", "action_data_reference.0.process_automation_job_arguments", ""),
 					// Known defect with inconsistent handling of nested aggregates: https://github.com/hashicorp/terraform-plugin-sdk/issues/413
+					resource.TestCheckResourceAttr(
+						"pagerduty_automation_actions_action.foo", "action_data_reference.0.process_automation_node_filter", ""),
 					resource.TestCheckResourceAttr(
 						"pagerduty_automation_actions_action.foo", "action_data_reference.0.script", ""),
 					resource.TestCheckResourceAttr(
@@ -113,6 +117,8 @@ func TestAccPagerDutyAutomationActionsActionTypeScript_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"pagerduty_automation_actions_action.foo", "action_data_reference.0.process_automation_job_arguments", ""),
 					resource.TestCheckResourceAttr(
+						"pagerduty_automation_actions_action.foo", "action_data_reference.0.process_automation_node_filter", ""),
+					resource.TestCheckResourceAttr(
 						"pagerduty_automation_actions_action.foo", "action_data_reference.0.script", "java --version"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_automation_actions_action.foo", "action_data_reference.0.invocation_command", "/bin/bash"),
@@ -137,6 +143,8 @@ func TestAccPagerDutyAutomationActionsActionTypeScript_Basic(t *testing.T) {
 						"pagerduty_automation_actions_action.foo", "action_data_reference.0.process_automation_job_id", ""),
 					resource.TestCheckResourceAttr(
 						"pagerduty_automation_actions_action.foo", "action_data_reference.0.process_automation_job_arguments", ""),
+					resource.TestCheckResourceAttr(
+						"pagerduty_automation_actions_action.foo", "action_data_reference.0.process_automation_node_filter", ""),
 					resource.TestCheckResourceAttr(
 						"pagerduty_automation_actions_action.foo", "action_data_reference.0.script", "echo 777"),
 					resource.TestCheckResourceAttr(
@@ -205,6 +213,7 @@ resource "pagerduty_automation_actions_action" "foo" {
 	action_data_reference {
 		process_automation_job_id = "pa_job_id_123"
 		process_automation_job_arguments = "-arg 1"
+		process_automation_node_filter = "tags: production"
 	  }
 }
 `, actionName, actionName)

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/automation_actions_action.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/automation_actions_action.go
@@ -26,6 +26,7 @@ type AutomationActionsAction struct {
 type AutomationActionsActionDataReference struct {
 	ProcessAutomationJobId        *string `json:"process_automation_job_id,omitempty"`
 	ProcessAutomationJobArguments *string `json:"process_automation_job_arguments,omitempty"`
+	ProcessAutomationNodeFilter *string `json:"process_automation_node_filter,omitempty"`
 	Script                        *string `json:"script,omitempty"`
 	InvocationCommand             *string `json:"invocation_command,omitempty"`
 }

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/automation_actions_action.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/automation_actions_action.go
@@ -26,7 +26,7 @@ type AutomationActionsAction struct {
 type AutomationActionsActionDataReference struct {
 	ProcessAutomationJobId        *string `json:"process_automation_job_id,omitempty"`
 	ProcessAutomationJobArguments *string `json:"process_automation_job_arguments,omitempty"`
-	ProcessAutomationNodeFilter *string `json:"process_automation_node_filter,omitempty"`
+	ProcessAutomationNodeFilter   *string `json:"process_automation_node_filter,omitempty"`
 	Script                        *string `json:"script,omitempty"`
 	InvocationCommand             *string `json:"invocation_command,omitempty"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -123,7 +123,7 @@ github.com/hashicorp/terraform-registry-address
 github.com/hashicorp/terraform-svchost
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20230309154026-a9e5d087e1e3
+# github.com/heimweh/go-pagerduty v0.0.0-20230309222029-be9daaa91ad3
 ## explicit
 github.com/heimweh/go-pagerduty/pagerduty
 # github.com/klauspost/compress v1.15.9

--- a/website/docs/d/automation_actions_action.html.markdown
+++ b/website/docs/d/automation_actions_action.html.markdown
@@ -44,6 +44,7 @@ Action Data (`action_data_reference`) supports the following:
 
   * `process_automation_job_id` - (Required for `process_automation` action_type) The ID of the Process Automation job to execute.
   * `process_automation_job_arguments` - (Optional) The arguments to pass to the Process Automation job execution.
+  * `process_automation_node_filter` - (Optional) The expression that filters on which nodes a Process Automation Job executess [Learn more](https://docs.rundeck.com/docs/manual/05-nodes.html#node-filtering).
   * `script` - (Required for `script` action_type) Body of the script to be executed on the Runner. Max length is 16777215 characters.
   * `invocation_command` - (Optional) The command to execute the script with.
 

--- a/website/docs/d/automation_actions_action.html.markdown
+++ b/website/docs/d/automation_actions_action.html.markdown
@@ -44,7 +44,7 @@ Action Data (`action_data_reference`) supports the following:
 
   * `process_automation_job_id` - (Required for `process_automation` action_type) The ID of the Process Automation job to execute.
   * `process_automation_job_arguments` - (Optional) The arguments to pass to the Process Automation job execution.
-  * `process_automation_node_filter` - (Optional) The expression that filters on which nodes a Process Automation Job executess [Learn more](https://docs.rundeck.com/docs/manual/05-nodes.html#node-filtering).
+  * `process_automation_node_filter` - (Optional) The expression that filters on which nodes a Process Automation Job executes [Learn more](https://docs.rundeck.com/docs/manual/05-nodes.html#node-filtering).
   * `script` - (Required for `script` action_type) Body of the script to be executed on the Runner. Max length is 16777215 characters.
   * `invocation_command` - (Optional) The command to execute the script with.
 

--- a/website/docs/r/automation_actions_action.html.markdown
+++ b/website/docs/r/automation_actions_action.html.markdown
@@ -49,10 +49,10 @@ Action Data (`action_data_reference`) supports the following:
 
   * `process_automation_job_id` - (Required for `process_automation` action_type) The ID of the Process Automation job to execute.
   * `process_automation_job_arguments` - (Optional) The arguments to pass to the Process Automation job execution.
+  * `process_automation_node_filter` - (Optional) The expression that filters on which nodes a Process Automation Job executess [Learn more](https://docs.rundeck.com/docs/manual/05-nodes.html#node-filtering).
   * `script` - (Required for `script` action_type) Body of the script to be executed on the Runner. Max length is 16777215 characters.
   * `invocation_command` - (Optional) The command to execute the script with.
 
-  
 ## Attributes Reference
 
 The following attributes are exported:

--- a/website/docs/r/automation_actions_action.html.markdown
+++ b/website/docs/r/automation_actions_action.html.markdown
@@ -49,7 +49,7 @@ Action Data (`action_data_reference`) supports the following:
 
   * `process_automation_job_id` - (Required for `process_automation` action_type) The ID of the Process Automation job to execute.
   * `process_automation_job_arguments` - (Optional) The arguments to pass to the Process Automation job execution.
-  * `process_automation_node_filter` - (Optional) The expression that filters on which nodes a Process Automation Job executess [Learn more](https://docs.rundeck.com/docs/manual/05-nodes.html#node-filtering).
+  * `process_automation_node_filter` - (Optional) The expression that filters on which nodes a Process Automation Job executes [Learn more](https://docs.rundeck.com/docs/manual/05-nodes.html#node-filtering).
   * `script` - (Required for `script` action_type) Body of the script to be executed on the Runner. Max length is 16777215 characters.
   * `invocation_command` - (Optional) The command to execute the script with.
 


### PR DESCRIPTION
Adds node filtering for automation_action resources. 

Ex.
```terraform
resource "pagerduty_automation_actions_action" "pa_action_example" {
  name = "PA Action created/updated via TF"
  description = "Description of the PA Action created via TF"
  action_type = "process_automation"
  action_data_reference {
    process_automation_job_id = "12345"
    process_automation_node_filter = "tags: production"
  }
}
```

Depends on https://github.com/heimweh/go-pagerduty/pull/126