### PR TITLE
Enable event orchestration active status for service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go v0.71.0 // indirect
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.1
-	github.com/heimweh/go-pagerduty v0.0.0-20230228152537-1474894a62f8
+	github.com/heimweh/go-pagerduty v0.0.0-20230309154026-a9e5d087e1e3
 	github.com/klauspost/compress v1.15.9 // indirect
 	github.com/montanaflynn/stats v0.6.6 // indirect
 	go.mongodb.org/mongo-driver v1.10.2 // indirect
@@ -17,5 +17,3 @@ require (
 	google.golang.org/genproto v0.0.0-20201109203340-2640f1f9cdfb // indirect
 	google.golang.org/grpc v1.33.2 // indirect
 )
-
-replace github.com/heimweh/go-pagerduty => github.com/imjaroiswebdev/go-pagerduty v0.0.0-20230308230704-601256a7e95c

--- a/go.mod
+++ b/go.mod
@@ -18,4 +18,4 @@ require (
 	google.golang.org/grpc v1.33.2 // indirect
 )
 
-replace github.com/heimweh/go-pagerduty => github.com/imjaroiswebdev/go-pagerduty v0.0.0-20230118135544-45c70992821b
+replace github.com/heimweh/go-pagerduty => github.com/imjaroiswebdev/go-pagerduty v0.0.0-20230308230704-601256a7e95c

--- a/go.mod
+++ b/go.mod
@@ -17,3 +17,5 @@ require (
 	google.golang.org/genproto v0.0.0-20201109203340-2640f1f9cdfb // indirect
 	google.golang.org/grpc v1.33.2 // indirect
 )
+
+replace github.com/heimweh/go-pagerduty => github.com/imjaroiswebdev/go-pagerduty v0.0.0-20230118135544-45c70992821b

--- a/go.sum
+++ b/go.sum
@@ -224,14 +224,14 @@ github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
+github.com/heimweh/go-pagerduty v0.0.0-20230309154026-a9e5d087e1e3 h1:4p1DAww7nTqTfvxk1ucaUCh2p49/CxubKh+JwqzSRo8=
+github.com/heimweh/go-pagerduty v0.0.0-20230309154026-a9e5d087e1e3/go.mod h1:t9vftsO1IjYHGdgJXeemZtomCWnxi2SRgu0PRcRb2oY=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
-github.com/imjaroiswebdev/go-pagerduty v0.0.0-20230308230704-601256a7e95c h1:WCfZjYf59e8w32AOK/QV89zKqq2dalWashTAyjBLwjU=
-github.com/imjaroiswebdev/go-pagerduty v0.0.0-20230308230704-601256a7e95c/go.mod h1:t9vftsO1IjYHGdgJXeemZtomCWnxi2SRgu0PRcRb2oY=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=

--- a/go.sum
+++ b/go.sum
@@ -224,14 +224,14 @@ github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/heimweh/go-pagerduty v0.0.0-20230228152537-1474894a62f8 h1:dyKF2FYeCgn4JjIFu30wO6cl/OzlQsFhuPwh1GnYJFU=
-github.com/heimweh/go-pagerduty v0.0.0-20230228152537-1474894a62f8/go.mod h1:t9vftsO1IjYHGdgJXeemZtomCWnxi2SRgu0PRcRb2oY=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
+github.com/imjaroiswebdev/go-pagerduty v0.0.0-20230118135544-45c70992821b h1:OA7xTHsjeP0H1xZm3vcMKvuXWVuW5U+OD4yYhe9JX34=
+github.com/imjaroiswebdev/go-pagerduty v0.0.0-20230118135544-45c70992821b/go.mod h1:t9vftsO1IjYHGdgJXeemZtomCWnxi2SRgu0PRcRb2oY=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=

--- a/go.sum
+++ b/go.sum
@@ -230,8 +230,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
-github.com/imjaroiswebdev/go-pagerduty v0.0.0-20230118135544-45c70992821b h1:OA7xTHsjeP0H1xZm3vcMKvuXWVuW5U+OD4yYhe9JX34=
-github.com/imjaroiswebdev/go-pagerduty v0.0.0-20230118135544-45c70992821b/go.mod h1:t9vftsO1IjYHGdgJXeemZtomCWnxi2SRgu0PRcRb2oY=
+github.com/imjaroiswebdev/go-pagerduty v0.0.0-20230308230704-601256a7e95c h1:WCfZjYf59e8w32AOK/QV89zKqq2dalWashTAyjBLwjU=
+github.com/imjaroiswebdev/go-pagerduty v0.0.0-20230308230704-601256a7e95c/go.mod h1:t9vftsO1IjYHGdgJXeemZtomCWnxi2SRgu0PRcRb2oY=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=

--- a/pagerduty/resource_pagerduty_event_orchestration_path_service_test.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_service_test.go
@@ -167,6 +167,52 @@ func TestAccPagerDutyEventOrchestrationPathService_Basic(t *testing.T) {
 					testAccCheckPagerDutyEventOrchestrationServicePathNotExists(resourceName),
 				),
 			},
+			// Adding/Updating/Removing `enable_event_orchestration_for_service` attribute
+			{
+				Config: testAccCheckPagerDutyEventOrchestrationPathServiceDefaultConfig(escalationPolicy, service),
+				Check: resource.ComposeTestCheckFunc(
+					append(
+						baseChecks,
+						resource.TestCheckNoResourceAttr(resourceName, "enable_event_orchestration_for_service"),
+					)...,
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyEventOrchestrationPathServiceEnableEOForServiceEnableUpdateConfig(escalationPolicy, service),
+				Check: resource.ComposeTestCheckFunc(
+					append(
+						baseChecks,
+						resource.TestCheckResourceAttr(resourceName, "enable_event_orchestration_for_service", "true"),
+					)...,
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyEventOrchestrationPathServiceEnableEOForServiceDisableUpdateConfig(escalationPolicy, service),
+				Check: resource.ComposeTestCheckFunc(
+					append(
+						baseChecks,
+						resource.TestCheckResourceAttr(resourceName, "enable_event_orchestration_for_service", "false"),
+					)...,
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyEventOrchestrationPathServiceEnableEOForServiceEnableUpdateConfig(escalationPolicy, service),
+				Check: resource.ComposeTestCheckFunc(
+					append(
+						baseChecks,
+						resource.TestCheckResourceAttr(resourceName, "enable_event_orchestration_for_service", "true"),
+					)...,
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyEventOrchestrationPathServiceDefaultConfig(escalationPolicy, service),
+				Check: resource.ComposeTestCheckFunc(
+					append(
+						baseChecks,
+						resource.TestCheckResourceAttr(resourceName, "enable_event_orchestration_for_service", "false"),
+					)...,
+				),
+			},
 		},
 	})
 }
@@ -650,7 +696,6 @@ func testAccCheckPagerDutyEventOrchestrationPathServiceAllActionsUpdateConfig(ep
 			catch_all {
 				actions {
 					suspend = 360
-					suppress = true
 					priority = "P0IN2KX"
 					annotate = "[UPD] Routed through an event orchestration - catch-all rule"
 					pagerduty_automation_action {
@@ -730,4 +775,38 @@ func testAccCheckPagerDutyEventOrchestrationPathServiceOneSetNoActionsConfig(ep,
 
 func testAccCheckPagerDutyEventOrchestrationPathServiceResourceDeleteConfig(ep, s string) string {
 	return createBaseServicePathConfig(ep, s)
+}
+
+func testAccCheckPagerDutyEventOrchestrationPathServiceEnableEOForServiceEnableUpdateConfig(ep, s string) string {
+	return fmt.Sprintf("%s%s", createBaseServicePathConfig(ep, s),
+		`resource "pagerduty_event_orchestration_service" "serviceA" {
+			service = pagerduty_service.bar.id
+      enable_event_orchestration_for_service = true
+		
+			set {
+				id = "start"
+			}
+
+			catch_all {
+				actions { }
+			}
+		}
+	`)
+}
+
+func testAccCheckPagerDutyEventOrchestrationPathServiceEnableEOForServiceDisableUpdateConfig(ep, s string) string {
+	return fmt.Sprintf("%s%s", createBaseServicePathConfig(ep, s),
+		`resource "pagerduty_event_orchestration_service" "serviceA" {
+			service = pagerduty_service.bar.id
+      enable_event_orchestration_for_service = false
+		
+			set {
+				id = "start"
+			}
+
+			catch_all {
+				actions { }
+			}
+		}
+	`)
 }

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/event_orchestration_path.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/event_orchestration_path.go
@@ -94,7 +94,7 @@ type EventOrchestrationPathActionExtractions struct {
 }
 
 type EventOrchestrationPathServiceActiveStatus struct {
-	Active bool `json:"active,omitempty"`
+	Active bool `json:"active"`
 }
 
 type EventOrchestrationPathCatchAll struct {

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/event_orchestration_path.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/event_orchestration_path.go
@@ -93,6 +93,10 @@ type EventOrchestrationPathActionExtractions struct {
 	Source   string `json:"source,omitempty"`
 }
 
+type EventOrchestrationPathServiceActiveStatus struct {
+	Active bool `json:"active,omitempty"`
+}
+
 type EventOrchestrationPathCatchAll struct {
 	Actions *EventOrchestrationPathRuleActions `json:"actions,omitempty"`
 }
@@ -132,6 +136,20 @@ func (s *EventOrchestrationPathService) Get(id string, pathType string) (*EventO
 	return v.OrchestrationPath, resp, nil
 }
 
+// GetServiceActiveStatus for EventOrchestrationPath
+func (s *EventOrchestrationPathService) GetServiceActiveStatus(id string) (*EventOrchestrationPathServiceActiveStatus, *Response, error) {
+	u := fmt.Sprintf("%s/services/%s/active", eventOrchestrationBaseUrl, id)
+	v := new(EventOrchestrationPathServiceActiveStatus)
+
+	resp, err := s.client.newRequestDo("GET", u, nil, nil, &v)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v, resp, nil
+}
+
 // Update for EventOrchestrationPath
 func (s *EventOrchestrationPathService) Update(id string, pathType string, orchestration_path *EventOrchestrationPath) (*EventOrchestrationPath, *Response, error) {
 	u := orchestrationPathUrlBuilder(id, pathType)
@@ -144,4 +162,18 @@ func (s *EventOrchestrationPathService) Update(id string, pathType string, orche
 	}
 
 	return v.OrchestrationPath, resp, nil
+}
+
+// UpdateServiceActiveStatus for EventOrchestrationPath
+func (s *EventOrchestrationPathService) UpdateServiceActiveStatus(id string, isActive bool) (*EventOrchestrationPathServiceActiveStatus, *Response, error) {
+	u := fmt.Sprintf("%s/services/%s/active", eventOrchestrationBaseUrl, id)
+	v := new(EventOrchestrationPathServiceActiveStatus)
+	p := EventOrchestrationPathServiceActiveStatus{Active: isActive}
+
+	resp, err := s.client.newRequestDo("PUT", u, nil, p, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v, resp, err
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -123,7 +123,7 @@ github.com/hashicorp/terraform-registry-address
 github.com/hashicorp/terraform-svchost
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20230117201746-310c225f8600 => github.com/imjaroiswebdev/go-pagerduty v0.0.0-20230118135544-45c70992821b
+# github.com/heimweh/go-pagerduty v0.0.0-20230213205146-a7761402c92d => github.com/imjaroiswebdev/go-pagerduty v0.0.0-20230308230704-601256a7e95c
 ## explicit
 github.com/heimweh/go-pagerduty/pagerduty
 # github.com/klauspost/compress v1.15.9
@@ -350,4 +350,4 @@ google.golang.org/protobuf/types/known/anypb
 google.golang.org/protobuf/types/known/durationpb
 google.golang.org/protobuf/types/known/emptypb
 google.golang.org/protobuf/types/known/timestamppb
-# github.com/heimweh/go-pagerduty => github.com/imjaroiswebdev/go-pagerduty v0.0.0-20230118135544-45c70992821b
+# github.com/heimweh/go-pagerduty => github.com/imjaroiswebdev/go-pagerduty v0.0.0-20230308230704-601256a7e95c

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -123,7 +123,7 @@ github.com/hashicorp/terraform-registry-address
 github.com/hashicorp/terraform-svchost
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20230213205146-a7761402c92d => github.com/imjaroiswebdev/go-pagerduty v0.0.0-20230308230704-601256a7e95c
+# github.com/heimweh/go-pagerduty v0.0.0-20230309154026-a9e5d087e1e3
 ## explicit
 github.com/heimweh/go-pagerduty/pagerduty
 # github.com/klauspost/compress v1.15.9
@@ -350,4 +350,3 @@ google.golang.org/protobuf/types/known/anypb
 google.golang.org/protobuf/types/known/durationpb
 google.golang.org/protobuf/types/known/emptypb
 google.golang.org/protobuf/types/known/timestamppb
-# github.com/heimweh/go-pagerduty => github.com/imjaroiswebdev/go-pagerduty v0.0.0-20230308230704-601256a7e95c

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -123,7 +123,7 @@ github.com/hashicorp/terraform-registry-address
 github.com/hashicorp/terraform-svchost
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20230228152537-1474894a62f8
+# github.com/heimweh/go-pagerduty v0.0.0-20230117201746-310c225f8600 => github.com/imjaroiswebdev/go-pagerduty v0.0.0-20230118135544-45c70992821b
 ## explicit
 github.com/heimweh/go-pagerduty/pagerduty
 # github.com/klauspost/compress v1.15.9
@@ -350,3 +350,4 @@ google.golang.org/protobuf/types/known/anypb
 google.golang.org/protobuf/types/known/durationpb
 google.golang.org/protobuf/types/known/emptypb
 google.golang.org/protobuf/types/known/timestamppb
+# github.com/heimweh/go-pagerduty => github.com/imjaroiswebdev/go-pagerduty v0.0.0-20230118135544-45c70992821b

--- a/website/docs/r/event_orchestration_service.html.markdown
+++ b/website/docs/r/event_orchestration_service.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 A [Service Orchestration](https://support.pagerduty.com/docs/event-orchestration#service-orchestrations) allows you to create a set of Event Rules. The Service Orchestration evaluates Events sent to this Service against each of its rules, beginning with the rules in the "start" set. When a matching rule is found, it can modify and enhance the event and can route the event to another set of rules within this Service Orchestration for further processing.
 
-**Note:** If you have a Service that uses [Service Event Rules](https://support.pagerduty.com/docs/rulesets#service-event-rules), you can switch to [Service Orchestrations](https://support.pagerduty.com/docs/event-orchestration#service-orchestrations) at any time. Please read the [Switch to Service Orchestrations](https://support.pagerduty.com/docs/event-orchestration#switch-to-service-orchestrations) instructions for more information.
+-> If you have a Service that uses [Service Event Rules](https://support.pagerduty.com/docs/rulesets#service-event-rules), you can switch to [Service Orchestrations](https://support.pagerduty.com/docs/event-orchestration#service-orchestrations) at any time setting the attribute `enable_event_orchestration_for_service` to `true`. Please read the [Switch to Service Orchestrations](https://support.pagerduty.com/docs/event-orchestration#switch-to-service-orchestrations) instructions for more information.
 
 ## Example of configuring a Service Orchestration
 
@@ -146,6 +146,7 @@ resource "pagerduty_event_orchestration_service" "www" {
 The following arguments are supported:
 
 * `service` - (Required) ID of the Service to which this Service Orchestration belongs to.
+* `enable_event_orchestration_for_service` - (Optional) Opt-in/out for switching the Service to [Service Orchestrations](https://support.pagerduty.com/docs/event-orchestration#service-orchestrations).
 * `set` - (Required) A Service Orchestration must contain at least a "start" set, but can contain any number of additional sets that are routed to by other rules to form a directional graph.
 * `catch_all` - (Required) the `catch_all` actions will be applied if an Event reaches the end of any set without matching any rules in that set.
 


### PR DESCRIPTION
Closes: #565 #589 #643 

This update will bring support for the new attribute `enable_event_orchestration_for_service` to the resource `pagerduty_event_orchestration_service` with the direct effect of allowing to switch to Service Orchestration using this new attribute from the EO Service Terraform configuration instead of having to make it through the PagerDuty's UI.

## Acceptance Criteria

- [x] `enable_event_orchestration_for_service` is a property of the pagerduty_event_orchestration_service resource.
- [x] The property is boolean, optional, no default value.
- [x] We will need to always call this endpoint in the provider’s Read handler function to set the property.
- [x] If the user doesn’t specify the property on the resource we do not need to call this endpoint in the Update handler function.
- [x] Handle **410 (Gone)** response from EO Service Active status endpoint.

## Example of use...

```hcl
resource "pagerduty_event_orchestration_service" "serviceA" {
  service                                = pagerduty_service.example.id
  enable_event_orchestration_for_service = true

  set {
    id = "start"
  }

  catch_all {
    actions {}
  }
}
```

Depends on: https://github.com/heimweh/go-pagerduty/pull/127