### PR TITLE
Addressing GOAWAY error on `pagerduty_service_dependency`

### DIFF
--- a/pagerduty/resource_pagerduty_service_dependency.go
+++ b/pagerduty/resource_pagerduty_service_dependency.go
@@ -181,10 +181,11 @@ func resourcePagerDutyServiceDependencyDisassociate(d *schema.ResourceData, meta
 	// listServiceRelationships by calling get dependencies using the serviceDependency.DependentService.ID
 	retryErr := resource.Retry(5*time.Minute, func() *resource.RetryError {
 		if dependencies, _, err := client.ServiceDependencies.GetServiceDependenciesForType(dependency.DependentService.ID, dependency.DependentService.Type); err != nil {
-			if isErrCode(err, 404) || isErrCode(err, 500) || isErrCode(err, 429) {
-				return resource.RetryableError(err)
-			}
-			return resource.NonRetryableError(err)
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
+
+			return resource.RetryableError(err)
 		} else if dependencies != nil {
 			for _, rel := range dependencies.Relationships {
 				if rel.ID == d.Id() {
@@ -221,10 +222,11 @@ func resourcePagerDutyServiceDependencyDisassociate(d *schema.ResourceData, meta
 	}
 	retryErr = resource.Retry(5*time.Minute, func() *resource.RetryError {
 		if _, _, err = client.ServiceDependencies.DisassociateServiceDependencies(&input); err != nil {
-			if isErrCode(err, 404) || isErrCode(err, 429) {
-				return resource.RetryableError(err)
-			}
-			return resource.NonRetryableError(err)
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
+
+			return resource.RetryableError(err)
 		}
 		return nil
 	})
@@ -295,10 +297,11 @@ func findDependencySetState(depID, serviceID, serviceType string, d *schema.Reso
 	time.Sleep(1 * time.Second)
 	retryErr := resource.Retry(5*time.Minute, func() *resource.RetryError {
 		if dependencies, _, err := client.ServiceDependencies.GetServiceDependenciesForType(serviceID, serviceType); err != nil {
-			if isErrCode(err, 404) || isErrCode(err, 500) || isErrCode(err, 429) {
-				return resource.RetryableError(err)
-			}
-			return resource.NonRetryableError(err)
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
+
+			return resource.RetryableError(err)
 		} else if dependencies != nil {
 			for _, rel := range dependencies.Relationships {
 				if rel.ID == depID {


### PR DESCRIPTION
Closes #620 

Following with the adoption of #507 workaround, I'm proceeding to remove the check for http error for retries, because it has been showing to be successful to mitigate the **GOAWAY** issues with the API.

## Test results...
```sh
make testacc TESTARGS="-run TestAccPagerDutyBusinessServiceDependency"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccPagerDutyBusinessServiceDependency -timeout 120m
?       github.com/terraform-providers/terraform-provider-pagerduty     [no test files]
=== RUN   TestAccPagerDutyBusinessServiceDependency_Basic
--- PASS: TestAccPagerDutyBusinessServiceDependency_Basic (15.56s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   16.177s
```