### PR TITLE
Addressing name typo on custom fields schema field config docs and test

### DIFF
--- a/pagerduty/resource_pagerduty_custom_field_schema_field_configuration_test.go
+++ b/pagerduty/resource_pagerduty_custom_field_schema_field_configuration_test.go
@@ -599,7 +599,7 @@ func testAccDeleteTestPagerDutyCustomFieldSchemaForFieldConfiguration(schemaID s
 func testAccCheckPagerDutyCustomFieldConfigurationDestroy(s *terraform.State) error {
 	client, _ := testAccProvider.Meta().(*Config).Client()
 	for _, r := range s.RootModule().Resources {
-		if r.Type != "pagerduty_custom_field_configuration" {
+		if r.Type != "pagerduty_custom_field_schema_field_configuration" {
 			continue
 		}
 

--- a/website/docs/r/custom_field_schema_field_configuration.html.markdown
+++ b/website/docs/r/custom_field_schema_field_configuration.html.markdown
@@ -25,7 +25,7 @@ resource "pagerduty_custom_field_schema" "my_schema" {
   description = "Fields used on incidents"
 }
 
-resource "pagerduty_custom_field_configuration" "first_field_configuration" {
+resource "pagerduty_custom_field_schema_field_configuration" "first_field_configuration" {
   schema                 = pagerduty_custom_field_schema.my_schema.id
   field                  = pagerduty_custom_field.cs_impact.id
   required               = true


### PR DESCRIPTION
## Test results...

```sh
PAGERDUTY_ACC_CUSTOM_FIELDS=1 make testacc TESTARGS="-run TestAccPagerDutyCustomFieldConfiguration"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccPagerDutyCustomFieldConfiguration -timeout 120m
?       github.com/terraform-providers/terraform-provider-pagerduty     [no test files]
=== RUN   TestAccPagerDutyCustomFieldConfiguration_Basic
--- PASS: TestAccPagerDutyCustomFieldConfiguration_Basic (9.78s)
=== RUN   TestAccPagerDutyCustomFieldConfiguration_Required
--- PASS: TestAccPagerDutyCustomFieldConfiguration_Required (14.02s)
=== RUN   TestAccPagerDutyCustomFieldConfiguration_Required_BadDataType
--- PASS: TestAccPagerDutyCustomFieldConfiguration_Required_BadDataType (0.20s)
=== RUN   TestAccPagerDutyCustomFieldConfiguration_Required_Without_Default
--- PASS: TestAccPagerDutyCustomFieldConfiguration_Required_Without_Default (0.17s)
=== RUN   TestAccPagerDutyCustomFieldConfiguration_Required_Without_DefaultDataType
--- PASS: TestAccPagerDutyCustomFieldConfiguration_Required_Without_DefaultDataType (0.16s)
=== RUN   TestAccPagerDutyCustomFieldConfiguration_Required_InvalidValue_MultiValue
--- PASS: TestAccPagerDutyCustomFieldConfiguration_Required_InvalidValue_MultiValue (0.17s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   25.070s
```