### PR TITLE
service: Compute additional fields already included in API response

### DIFF
--- a/pagerduty/data_source_pagerduty_service.go
+++ b/pagerduty/data_source_pagerduty_service.go
@@ -19,6 +19,43 @@ func dataSourcePagerDutyService() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"auto_resolve_timeout": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"acknowledgement_timeout": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"alert_creation": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"escalation_policy": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"teams": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The set of teams associated with the service",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 			"type": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -65,9 +102,23 @@ func dataSourcePagerDutyServiceRead(d *schema.ResourceData, meta interface{}) er
 			)
 		}
 
+		var teams []map[string]interface{}
+		for _, team := range found.Teams {
+			teams = append(teams, map[string]interface{}{
+				"id":   team.ID,
+				"name": team.Summary,
+			})
+		}
+
 		d.SetId(found.ID)
 		d.Set("name", found.Name)
 		d.Set("type", found.Type)
+		d.Set("auto_resolve_timeout", found.AutoResolveTimeout)
+		d.Set("acknowledgement_timeout", found.AcknowledgementTimeout)
+		d.Set("alert_creation", found.AlertCreation)
+		d.Set("description", found.Description)
+		d.Set("teams", teams)
+		d.Set("escalation_policy", found.EscalationPolicy.ID)
 
 		return nil
 	})

--- a/pagerduty/data_source_pagerduty_service_test.go
+++ b/pagerduty/data_source_pagerduty_service_test.go
@@ -23,9 +23,50 @@ func TestAccDataSourcePagerDutyService_Basic(t *testing.T) {
 			{
 				Config: testAccDataSourcePagerDutyServiceConfig(username, email, service, escalationPolicy, teamname),
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourcePagerDutyService("pagerduty_service.test", "data.pagerduty_service.by_name"),
-					resource.TestCheckResourceAttr("data.pagerduty_service.by_name", "teams.#", "1"),
-					resource.TestCheckResourceAttr("data.pagerduty_service.by_name", "teams.0.name", teamname),
+					testAccDataSourcePagerDutyService("pagerduty_service.no_team_service", "data.pagerduty_service.no_team_service"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourcePagerDutyService_HasNoTeam(t *testing.T) {
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.test", username)
+	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	teamname := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourcePagerDutyServiceConfig(username, email, service, escalationPolicy, teamname),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.pagerduty_service.no_team_service", "teams.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourcePagerDutyService_HasOneTeam(t *testing.T) {
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.test", username)
+	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	teamname := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourcePagerDutyServiceConfig(username, email, service, escalationPolicy, teamname),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.pagerduty_service.one_team_service", "teams.#", "1"),
+					resource.TestCheckResourceAttr("data.pagerduty_service.one_team_service", "teams.0.name", teamname),
 				),
 			},
 		},
@@ -45,7 +86,7 @@ func testAccDataSourcePagerDutyService(src, n string) resource.TestCheckFunc {
 			return fmt.Errorf("Expected to get a service ID from PagerDuty")
 		}
 
-		testAtts := []string{"teams", "id", "name", "type", "auto_resolve_timeout", "acknowledgement_timeout", "alert_creation", "description", "escalation_policy"}
+		testAtts := []string{"id", "name", "type", "auto_resolve_timeout", "acknowledgement_timeout", "alert_creation", "description", "escalation_policy"}
 
 		for _, att := range testAtts {
 			if a[att] != srcA[att] {
@@ -59,9 +100,9 @@ func testAccDataSourcePagerDutyService(src, n string) resource.TestCheckFunc {
 
 func testAccDataSourcePagerDutyServiceConfig(username, email, service, escalationPolicy, teamname string) string {
 	return fmt.Sprintf(`
-resource "pagerduty_team" "test" {
+resource "pagerduty_team" "team_one" {
 	name        = "%s"
-	description = "test"
+	description = "team_one"
 }
 
 resource "pagerduty_user" "test" {
@@ -69,15 +110,30 @@ resource "pagerduty_user" "test" {
   email = "%s"
 }
 
-resource "pagerduty_team_membership" "test" {
-	team_id = pagerduty_team.test.id
+resource "pagerduty_team_membership" "team_membership_one" {
+	depends_on = [pagerduty_team.team_one, pagerduty_user.test]
+	team_id = pagerduty_team.team_one.id
 	user_id = pagerduty_user.test.id
 }
 
-resource "pagerduty_escalation_policy" "test" {
+resource "pagerduty_escalation_policy" "no_team_ep" {
+	name        = "no_team_ep"
+	num_loops   = 2
+	rule {
+	  escalation_delay_in_minutes = 10
+	  target {
+		type = "user_reference"
+		id   = pagerduty_user.test.id
+	  }
+	}
+  }
+
+resource "pagerduty_escalation_policy" "one_team_ep" {
+
+  depends_on = [pagerduty_team_membership.team_membership_one, pagerduty_user.test]
   name        = "%s"
   num_loops   = 2
-  teams       = [pagerduty_team.test.id]
+  teams       = [pagerduty_team.team_one.id]
   rule {
     escalation_delay_in_minutes = 10
     target {
@@ -87,17 +143,34 @@ resource "pagerduty_escalation_policy" "test" {
   }
 }
 
-resource "pagerduty_service" "test" {
+resource "pagerduty_service" "no_team_service" {
+	depends_on = [pagerduty_escalation_policy.no_team_ep]
+	name                    = "no_team_service"
+	auto_resolve_timeout    = 14400
+	acknowledgement_timeout = 600
+	escalation_policy       = pagerduty_escalation_policy.no_team_ep.id
+	alert_creation          = "create_incidents"
+}
+
+
+resource "pagerduty_service" "one_team_service" {
+  depends_on = [pagerduty_escalation_policy.one_team_ep]
   name                    = "%s"
   auto_resolve_timeout    = 14400
   acknowledgement_timeout = 600
-  escalation_policy       = pagerduty_escalation_policy.test.id
+  escalation_policy       = pagerduty_escalation_policy.one_team_ep.id
   alert_creation          = "create_incidents"
 }
 
-data "pagerduty_service" "by_name" {
-  depends_on = [pagerduty_team_membership.test, pagerduty_service.test]
-  name = pagerduty_service.test.name
+data "pagerduty_service" "no_team_service" {
+	depends_on = [pagerduty_service.no_team_service]
+	name = pagerduty_service.no_team_service.name
 }
+
+data "pagerduty_service" "one_team_service" {
+  depends_on = [pagerduty_service.one_team_service]
+  name = pagerduty_service.one_team_service.name
+}
+
 `, teamname, username, email, service, escalationPolicy)
 }

--- a/pagerduty/data_source_pagerduty_service_test.go
+++ b/pagerduty/data_source_pagerduty_service_test.go
@@ -111,7 +111,6 @@ resource "pagerduty_user" "test" {
 }
 
 resource "pagerduty_team_membership" "team_membership_one" {
-	depends_on = [pagerduty_team.team_one, pagerduty_user.test]
 	team_id = pagerduty_team.team_one.id
 	user_id = pagerduty_user.test.id
 }
@@ -130,7 +129,7 @@ resource "pagerduty_escalation_policy" "no_team_ep" {
 
 resource "pagerduty_escalation_policy" "one_team_ep" {
 
-  depends_on = [pagerduty_team_membership.team_membership_one, pagerduty_user.test]
+  depends_on = [pagerduty_team_membership.team_membership_one]
   name        = "%s"
   num_loops   = 2
   teams       = [pagerduty_team.team_one.id]
@@ -144,7 +143,6 @@ resource "pagerduty_escalation_policy" "one_team_ep" {
 }
 
 resource "pagerduty_service" "no_team_service" {
-	depends_on = [pagerduty_escalation_policy.no_team_ep]
 	name                    = "no_team_service"
 	auto_resolve_timeout    = 14400
 	acknowledgement_timeout = 600
@@ -154,7 +152,6 @@ resource "pagerduty_service" "no_team_service" {
 
 
 resource "pagerduty_service" "one_team_service" {
-  depends_on = [pagerduty_escalation_policy.one_team_ep]
   name                    = "%s"
   auto_resolve_timeout    = 14400
   acknowledgement_timeout = 600
@@ -163,12 +160,10 @@ resource "pagerduty_service" "one_team_service" {
 }
 
 data "pagerduty_service" "no_team_service" {
-	depends_on = [pagerduty_service.no_team_service]
 	name = pagerduty_service.no_team_service.name
 }
 
 data "pagerduty_service" "one_team_service" {
-  depends_on = [pagerduty_service.one_team_service]
   name = pagerduty_service.one_team_service.name
 }
 

--- a/website/docs/d/service.html.markdown
+++ b/website/docs/d/service.html.markdown
@@ -45,6 +45,6 @@ The following arguments are supported:
 * `alert_creation` - Whether a service creates only incidents, or both alerts and incidents. A service must create alerts in order to enable incident merging.
 * `description` - The user-provided description of the service.
 * `escalation_policy` - The escalation policy associated with this service.
-* `teams` - The set of teams associated with this service.
+* `teams` - The set of teams associated with the service.
 
 [1]: https://api-reference.pagerduty.com/#!/Services/get_services

--- a/website/docs/d/service.html.markdown
+++ b/website/docs/d/service.html.markdown
@@ -40,5 +40,11 @@ The following arguments are supported:
 * `id` - The ID of the found service.
 * `name` - The short name of the found service.
 * `type` - The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
+* `auto_resolve_timeout` - Time in seconds that an incident is automatically resolved if left open for that long. Value is null if the feature is disabled. Value must not be negative. Setting this field to 0, null (or unset in POST request) will disable the feature.
+* `acknowledgement_timeout` - Time in seconds that an incident changes to the Triggered State after being Acknowledged. Value is null if the feature is disabled. Value must not be negative. Setting this field to 0, null (or unset in POST request) will disable the feature.
+* `alert_creation` - Whether a service creates only incidents, or both alerts and incidents. A service must create alerts in order to enable incident merging.
+* `description` - The user-provided description of the service.
+* `escalation_policy` - The escalation policy associated with this service.
+* `teams` - The set of teams associated with this service.
 
 [1]: https://api-reference.pagerduty.com/#!/Services/get_services

--- a/website/docs/d/service.html.markdown
+++ b/website/docs/d/service.html.markdown
@@ -40,8 +40,8 @@ The following arguments are supported:
 * `id` - The ID of the found service.
 * `name` - The short name of the found service.
 * `type` - The type of object. The value returned will be `service`. Can be used for passing to a service dependency.
-* `auto_resolve_timeout` - Time in seconds that an incident is automatically resolved if left open for that long. Value is null if the feature is disabled. Value must not be negative. Setting this field to 0, null (or unset in POST request) will disable the feature.
-* `acknowledgement_timeout` - Time in seconds that an incident changes to the Triggered State after being Acknowledged. Value is null if the feature is disabled. Value must not be negative. Setting this field to 0, null (or unset in POST request) will disable the feature.
+* `auto_resolve_timeout` - Time in seconds that an incident is automatically resolved if left open for that long. Value is null if the feature is disabled. Value must not be negative. Setting this field to 0, null (or unset) will disable the feature.
+* `acknowledgement_timeout` - Time in seconds that an incident changes to the Triggered State after being Acknowledged. Value is null if the feature is disabled. Value must not be negative. Setting this field to 0, null (or unset) will disable the feature.
 * `alert_creation` - Whether a service creates only incidents, or both alerts and incidents. A service must create alerts in order to enable incident merging.
 * `description` - The user-provided description of the service.
 * `escalation_policy` - The escalation policy associated with this service.


### PR DESCRIPTION
Extends: #624 

WHAT
Adds additional fields already present in the data model

WHY
We are trying to generate terraform + matching state import scripts for existing resources, this will allow us to model all the required input fields for the pagerduty_service resource to allow us to import existing into state successfully

## Tests extended and introduced

```sh
make testacc TESTARGS="-count=1 -run TestAccDataSourcePagerDutyService"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -count=1 -run TestAccDataSourcePagerDutyService -timeout 120m
?       github.com/terraform-providers/terraform-provider-pagerduty     [no test files]
=== RUN   TestAccDataSourcePagerDutyService_Basic
--- PASS: TestAccDataSourcePagerDutyService_Basic (16.35s)
=== RUN   TestAccDataSourcePagerDutyService_HasNoTeam
--- PASS: TestAccDataSourcePagerDutyService_HasNoTeam (14.92s)
=== RUN   TestAccDataSourcePagerDutyService_HasOneTeam
--- PASS: TestAccDataSourcePagerDutyService_HasOneTeam (16.10s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   47.837s
```
