### PR TITLE
Address #655 Tags are not cleaned up from State after removed externally

### DIFF
--- a/pagerduty/resource_pagerduty_tag.go
+++ b/pagerduty/resource_pagerduty_tag.go
@@ -88,10 +88,17 @@ func resourcePagerDutyTagRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Reading PagerDuty tag %s", d.Id())
 
 	return resource.Retry(30*time.Second, func() *resource.RetryError {
-		if tag, _, err := client.Tags.Get(d.Id()); err != nil {
-			time.Sleep(2 * time.Second)
-			return resource.RetryableError(err)
-		} else if tag != nil {
+		tag, _, err := client.Tags.Get(d.Id())
+		if err != nil {
+			errResp := handleNotFoundError(err, d)
+			if errResp != nil {
+				time.Sleep(2 * time.Second)
+				return resource.RetryableError(errResp)
+			}
+
+			return nil
+		}
+		if tag != nil {
 			log.Printf("Tag Type: %v", tag.Type)
 			d.Set("label", tag.Label)
 			d.Set("summary", tag.Summary)


### PR DESCRIPTION
Closes #655 

## Test cases extended...

```sh
$ make testacc TESTARGS="-run TestAccPagerDutyTag_Basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccPagerDutyTag_Basic -timeout 120m
?       github.com/terraform-providers/terraform-provider-pagerduty     [no test files]
=== RUN   TestAccPagerDutyTag_Basic
--- PASS: TestAccPagerDutyTag_Basic (5.39s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   5.864s

```