### PR TITLE
Address: Service Read lifecycle wasn't detecting drift for auto pause notif and alert grouping params

### DIFF
--- a/pagerduty/import_pagerduty_service_test.go
+++ b/pagerduty/import_pagerduty_service_test.go
@@ -55,3 +55,67 @@ func TestAccPagerDutyServiceWithIncidentUrgency_import(t *testing.T) {
 		},
 	})
 }
+
+func TestAccPagerDutyServiceWithAlertGroupingParameters_import(t *testing.T) {
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.test", username)
+	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyServiceConfigWithAlertContentGrouping(username, email, escalationPolicy, service),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "alert_grouping_parameters.0.config.0.aggregate", "all"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "alert_grouping_parameters.0.type", "content_based"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "alert_grouping_parameters.0.config.0.fields.0", "custom_details.field1"),
+				),
+			},
+
+			{
+				ResourceName:      "pagerduty_service.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccPagerDutyServiceWithAutoPauseNotifications_import(t *testing.T) {
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.test", username)
+	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyServiceConfigWithAutoPauseNotificationsParameters(username, email, escalationPolicy, service),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "auto_pause_notifications_parameters.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "auto_pause_notifications_parameters.0.enabled", "true"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "auto_pause_notifications_parameters.0.timeout", "300"),
+				),
+			},
+
+			{
+				ResourceName:      "pagerduty_service.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}


### PR DESCRIPTION
Closes #626 and #574

## Test cases introduced...

```sh
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccPagerDutyServiceWithAlertGroupingParameters_import -timeout 120m
?       github.com/terraform-providers/terraform-provider-pagerduty     [no test files]
=== RUN   TestAccPagerDutyServiceWithAlertGroupingParameters_import
--- PASS: TestAccPagerDutyServiceWithAlertGroupingParameters_import (15.43s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   15.710s
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccPagerDutyServiceWithAutoPauseNotifications_import -timeout 120m
?       github.com/terraform-providers/terraform-provider-pagerduty     [no test files]
=== RUN   TestAccPagerDutyServiceWithAutoPauseNotifications_import
--- PASS: TestAccPagerDutyServiceWithAutoPauseNotifications_import (15.27s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   15.493s
```