### PR TITLE
Support for deleting remote configuration of Event Orchestration Paths

### DIFF
--- a/pagerduty/event_orchestration_path_util.go
+++ b/pagerduty/event_orchestration_path_util.go
@@ -350,3 +350,40 @@ func convertEventOrchestrationPathWarningsToDiagnostics(warnings []*pagerduty.Ev
 
 	return diags
 }
+
+func emptyOrchestrationPathStructBuilder(pathType string) *pagerduty.EventOrchestrationPath {
+	commonEmptyOrchestrationPath := func() *pagerduty.EventOrchestrationPath {
+		return &pagerduty.EventOrchestrationPath{
+			CatchAll: &pagerduty.EventOrchestrationPathCatchAll{
+				Actions: nil,
+			},
+			Sets: []*pagerduty.EventOrchestrationPathSet{
+				{
+					ID:    "start",
+					Rules: []*pagerduty.EventOrchestrationPathRule{},
+				},
+			},
+		}
+	}
+	routerEmptyOrchestrationPath := func() *pagerduty.EventOrchestrationPath {
+		return &pagerduty.EventOrchestrationPath{
+			CatchAll: &pagerduty.EventOrchestrationPathCatchAll{
+				Actions: &pagerduty.EventOrchestrationPathRuleActions{
+					RouteTo: "unrouted",
+				},
+			},
+			Sets: []*pagerduty.EventOrchestrationPathSet{
+				{
+					ID:    "start",
+					Rules: []*pagerduty.EventOrchestrationPathRule{},
+				},
+			},
+		}
+	}
+
+	if pathType == "router" {
+		return routerEmptyOrchestrationPath()
+	}
+
+	return commonEmptyOrchestrationPath()
+}

--- a/pagerduty/resource_pagerduty_event_orchestration_path_router.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_router.go
@@ -153,10 +153,31 @@ func resourcePagerDutyEventOrchestrationPathRouterCreate(ctx context.Context, d 
 }
 
 func resourcePagerDutyEventOrchestrationPathRouterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var diags diag.Diagnostics
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// In order to delete an Orchestration Router an empty orchestration path
+	// config should be sent as an update.
+	emptyPath := emptyOrchestrationPathStructBuilder("router")
+	routerID := d.Get("event_orchestration").(string)
+
+	log.Printf("[INFO] Deleting PagerDuty Event Orchestration Router Path: %s", routerID)
+
+	retryErr := resource.RetryContext(ctx, 30*time.Second, func() *resource.RetryError {
+		if _, _, err := client.EventOrchestrationPaths.UpdateContext(ctx, routerID, "router", emptyPath); err != nil {
+			return resource.RetryableError(err)
+		}
+		return nil
+	})
+
+	if retryErr != nil {
+		return diag.FromErr(retryErr)
+	}
 
 	d.SetId("")
-	return diags
+	return nil
 }
 
 func resourcePagerDutyEventOrchestrationPathRouterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {


### PR DESCRIPTION
This update implements API calls needed to delete remote configuration for the following Event Orchestration resources...

* `pagerduty_event_orchestration_router`.
* `pagerduty_event_orchestration_service`.
* `pagerduty_event_orchestration_unrouted`.
* `pagerduty_event_orchestration_global`.

## Test results...

```sh
```