### PR TITLE
Add schedule's users as query param when listing open incidents associated to EP snashot

### DIFF
--- a/pagerduty/resource_pagerduty_schedule.go
+++ b/pagerduty/resource_pagerduty_schedule.go
@@ -609,9 +609,14 @@ func listIncidentsOpenedRelatedToSchedule(c *pagerduty.Client, schedule *pagerdu
 	var incidents []*pagerduty.Incident
 	retryErr := resource.Retry(10*time.Second, func() *resource.RetryError {
 		var err error
+		var userIDs []string
+		for _, u := range schedule.Users {
+			userIDs = append(userIDs, u.ID)
+		}
 		incidents, err = c.Incidents.ListAll(&pagerduty.ListIncidentsOptions{
 			DateRange: "all",
 			Statuses:  []string{"triggered", "acknowledged"},
+			UserIDs:   userIDs,
 			Limit:     100,
 		})
 		if err != nil {
@@ -646,7 +651,6 @@ func listIncidentsOpenedRelatedToSchedule(c *pagerduty.Client, schedule *pagerdu
 	}
 	return linksToIncidents, nil
 }
-
 func extractEPsAssociatedToSchedule(c *pagerduty.Client, schedule *pagerduty.Schedule) ([]string, error) {
 	eps := []string{}
 	for _, ep := range schedule.EscalationPolicies {


### PR DESCRIPTION
This update is meant to improve the open incidents list results that is shown when a Schedule is trying to be deleted, but It has open incidents associated with the Escalation Policy snapshot using the Schedule.

## Test results

```sh
$ make testacc TESTARGS="-run TestAccPagerDutySchedule"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccPagerDutySchedule -timeout 120m
?       github.com/terraform-providers/terraform-provider-pagerduty     [no test files]
=== RUN   TestAccPagerDutySchedule_import
--- PASS: TestAccPagerDutySchedule_import (11.65s)
=== RUN   TestAccPagerDutySchedule_Basic
--- PASS: TestAccPagerDutySchedule_Basic (14.82s)
=== RUN   TestAccPagerDutyScheduleWithTeams_Basic
--- PASS: TestAccPagerDutyScheduleWithTeams_Basic (15.44s)
=== RUN   TestAccPagerDutySchedule_BasicWithExternalDestroyHandling
--- PASS: TestAccPagerDutySchedule_BasicWithExternalDestroyHandling (13.25s)
=== RUN   TestAccPagerDutyScheduleWithTeams_EscalationPolicyDependant
--- PASS: TestAccPagerDutyScheduleWithTeams_EscalationPolicyDependant (19.61s)
=== RUN   TestAccPagerDutyScheduleWithTeams_EscalationPolicyDependantWithOpenIncidents
--- PASS: TestAccPagerDutyScheduleWithTeams_EscalationPolicyDependantWithOpenIncidents (49.51s)
=== RUN   TestAccPagerDutySchedule_EscalationPolicyDependantWithOpenIncidents
--- PASS: TestAccPagerDutySchedule_EscalationPolicyDependantWithOpenIncidents (47.57s)
=== RUN   TestAccPagerDutyScheduleOverflow_Basic
--- PASS: TestAccPagerDutyScheduleOverflow_Basic (14.34s)
=== RUN   TestAccPagerDutySchedule_BasicWeek
--- PASS: TestAccPagerDutySchedule_BasicWeek (13.82s)
=== RUN   TestAccPagerDutySchedule_Multi
--- PASS: TestAccPagerDutySchedule_Multi (14.79s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   215.461s
```