### PR TITLE
Service response play no op update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,3 +17,5 @@ require (
 	google.golang.org/genproto v0.0.0-20201109203340-2640f1f9cdfb // indirect
 	google.golang.org/grpc v1.33.2 // indirect
 )
+
+replace github.com/heimweh/go-pagerduty => github.com/imjaroiswebdev/go-pagerduty v0.0.0-20230421004526-7468c4a9a540

--- a/go.sum
+++ b/go.sum
@@ -224,14 +224,14 @@ github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/heimweh/go-pagerduty v0.0.0-20230412193603-8e5264a6ca23 h1:Kid5+wLm4t1R2JS9AMMJCQHCXBxYM0Xv5VBHlM3y26A=
-github.com/heimweh/go-pagerduty v0.0.0-20230412193603-8e5264a6ca23/go.mod h1:t9vftsO1IjYHGdgJXeemZtomCWnxi2SRgu0PRcRb2oY=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
+github.com/imjaroiswebdev/go-pagerduty v0.0.0-20230421004526-7468c4a9a540 h1:KzM6xoCzZekVNUSYaMS0l93PEzRo0kTsbWPVGRzqz9k=
+github.com/imjaroiswebdev/go-pagerduty v0.0.0-20230421004526-7468c4a9a540/go.mod h1:t9vftsO1IjYHGdgJXeemZtomCWnxi2SRgu0PRcRb2oY=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=

--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -305,6 +305,7 @@ func resourcePagerDutyService() *schema.Resource {
 			"response_play": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 		},
 	}

--- a/pagerduty/resource_pagerduty_service_test.go
+++ b/pagerduty/resource_pagerduty_service_test.go
@@ -884,6 +884,7 @@ func TestAccPagerDutyService_ResponsePlay(t *testing.T) {
 						"pagerduty_service.foo", "html_url"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "type", "service"),
+					testAccCheckPagerDutyServiceResponsePlayNotExist("pagerduty_service.foo"),
 				),
 			},
 		},
@@ -954,6 +955,32 @@ func testAccCheckPagerDutyServiceExists(n string) resource.TestCheckFunc {
 
 		if found.ID != rs.Primary.ID {
 			return fmt.Errorf("Service not found: %v - %v", rs.Primary.ID, found)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckPagerDutyServiceResponsePlayNotExist(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Service ID is set")
+		}
+
+		client, _ := testAccProvider.Meta().(*Config).Client()
+
+		found, _, err := client.Services.Get(rs.Primary.ID, &pagerduty.GetServiceOptions{})
+		if err != nil {
+			return err
+		}
+
+		if found.ID == rs.Primary.ID && found.ResponsePlay != nil {
+			return fmt.Errorf("Service %s still has a response play configured", rs.Primary.ID)
 		}
 
 		return nil

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/service.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/service.go
@@ -140,7 +140,7 @@ type Service struct {
 	CreatedAt                        string                            `json:"created_at,omitempty"`
 	Description                      string                            `json:"description,omitempty"`
 	EscalationPolicy                 *EscalationPolicyReference        `json:"escalation_policy,omitempty"`
-	ResponsePlay                     *ResponsePlayReference            `json:"response_play,omitempty"`
+	ResponsePlay                     *ResponsePlayReference            `json:"response_play"`
 	HTMLURL                          string                            `json:"html_url,omitempty"`
 	ID                               string                            `json:"id,omitempty"`
 	IncidentUrgencyRule              *IncidentUrgencyRule              `json:"incident_urgency_rule,omitempty"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -123,7 +123,7 @@ github.com/hashicorp/terraform-registry-address
 github.com/hashicorp/terraform-svchost
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20230412193603-8e5264a6ca23
+# github.com/heimweh/go-pagerduty v0.0.0-20230412193603-8e5264a6ca23 => github.com/imjaroiswebdev/go-pagerduty v0.0.0-20230421004526-7468c4a9a540
 ## explicit
 github.com/heimweh/go-pagerduty/pagerduty
 # github.com/klauspost/compress v1.15.9
@@ -350,3 +350,4 @@ google.golang.org/protobuf/types/known/anypb
 google.golang.org/protobuf/types/known/durationpb
 google.golang.org/protobuf/types/known/emptypb
 google.golang.org/protobuf/types/known/timestamppb
+# github.com/heimweh/go-pagerduty => github.com/imjaroiswebdev/go-pagerduty v0.0.0-20230421004526-7468c4a9a540


### PR DESCRIPTION
Complements #573 

## Tests extended...

```sh
$ make testacc TESTARGS="-run TestAccPagerDutyService_ResponsePlay"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccPagerDutyService_ResponsePlay -timeout 120m
?       github.com/terraform-providers/terraform-provider-pagerduty     [no test files]
=== RUN   TestAccPagerDutyService_ResponsePlay
--- PASS: TestAccPagerDutyService_ResponsePlay (28.35s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   28.890s
```

depends on: https://github.com/heimweh/go-pagerduty/pull/130