### PR TITLE
Plan recreation of tag assignments and teams on external to Terraform deletion

### DIFF
--- a/pagerduty/resource_pagerduty_tag_assignment_test.go
+++ b/pagerduty/resource_pagerduty_tag_assignment_test.go
@@ -42,6 +42,15 @@ func TestAccPagerDutyTagAssignment_User(t *testing.T) {
 				),
 				ExpectNonEmptyPlan: true,
 			},
+			{
+				Config: testAccCheckPagerDutyTagAssignmentConfig(tagLabel, username, email),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr(
+						"pagerduty_tag_assignment.foo", "id"),
+				),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
 		},
 	})
 }
@@ -71,6 +80,15 @@ func TestAccPagerDutyTagAssignment_Team(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccExternallyDestroyTagAssignment("pagerduty_team.foo", "teams"),
 				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: testAccCheckPagerDutyTagAssignmentTeamConfig(tagLabel, team),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr(
+						"pagerduty_tag_assignment.foo", "id"),
+				),
+				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
 			},
 		},
@@ -104,6 +122,15 @@ func TestAccPagerDutyTagAssignment_EP(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccExternallyDestroyTagAssignment("pagerduty_escalation_policy.foo", "escalation_policies"),
 				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: testAccCheckPagerDutyTagAssignmentEPConfig(tagLabel, username, email, ep),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr(
+						"pagerduty_tag_assignment.foo", "id"),
+				),
+				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
 			},
 		},

--- a/pagerduty/resource_pagerduty_team.go
+++ b/pagerduty/resource_pagerduty_team.go
@@ -94,8 +94,11 @@ func resourcePagerDutyTeamRead(d *schema.ResourceData, meta interface{}) error {
 
 	return resource.Retry(30*time.Second, func() *resource.RetryError {
 		if team, _, err := client.Teams.Get(d.Id()); err != nil {
-			time.Sleep(2 * time.Second)
-			return resource.RetryableError(err)
+			errResp := handleNotFoundError(err, d)
+			if errResp != nil {
+				time.Sleep(2 * time.Second)
+				return resource.RetryableError(errResp)
+			}
 		} else if team != nil {
 			d.Set("name", team.Name)
 			d.Set("description", team.Description)

--- a/pagerduty/resource_pagerduty_team_test.go
+++ b/pagerduty/resource_pagerduty_team_test.go
@@ -92,6 +92,15 @@ func TestAccPagerDutyTeam_Basic(t *testing.T) {
 				),
 				ExpectNonEmptyPlan: true,
 			},
+			{
+				Config: testAccCheckPagerDutyTeamConfigUpdated(teamUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr(
+						"pagerduty_team.foo", "id"),
+				),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
 		},
 	})
 }


### PR DESCRIPTION
Handle external to Terraform deletion of `pagerduty_tag_assignment` and `pagerduty_team` resources generating a plan for recreating those resources.

## Test cases extended...

```sh
$ make testacc TESTARGS="-run TestAccPagerDutyTagAssignment"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccPagerDutyTagAssignment -timeout 120m
?       github.com/terraform-providers/terraform-provider-pagerduty     [no test files]
=== RUN   TestAccPagerDutyTagAssignment_import
--- PASS: TestAccPagerDutyTagAssignment_import (12.18s)
=== RUN   TestAccPagerDutyTagAssignment_User # 👈 Test extended
--- PASS: TestAccPagerDutyTagAssignment_User (13.39s)
=== RUN   TestAccPagerDutyTagAssignment_Team # 👈 Test extended
--- PASS: TestAccPagerDutyTagAssignment_Team (14.23s)
=== RUN   TestAccPagerDutyTagAssignment_EP # 👈 Test extended
--- PASS: TestAccPagerDutyTagAssignment_EP (17.65s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   57.945s

$ make testacc TESTARGS="-run TestAccPagerDutyTeam"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccPagerDutyTeam -timeout 120m
?       github.com/terraform-providers/terraform-provider-pagerduty     [no test files]
=== RUN   TestAccPagerDutyTeamMembership_import
--- PASS: TestAccPagerDutyTeamMembership_import (10.15s)
=== RUN   TestAccPagerDutyTeamMembership_importWithRole
--- PASS: TestAccPagerDutyTeamMembership_importWithRole (9.16s)
=== RUN   TestAccPagerDutyTeam_import
--- PASS: TestAccPagerDutyTeam_import (5.39s)
=== RUN   TestAccPagerDutyTeamMembership_Basic
--- PASS: TestAccPagerDutyTeamMembership_Basic (9.59s)
=== RUN   TestAccPagerDutyTeamMembership_WithRole
--- PASS: TestAccPagerDutyTeamMembership_WithRole (8.93s)
=== RUN   TestAccPagerDutyTeamMembership_WithRoleConsistentlyAssigned
--- PASS: TestAccPagerDutyTeamMembership_WithRoleConsistentlyAssigned (17.89s)
=== RUN   TestAccPagerDutyTeamMembership_DestroyWithEscalationPolicyDependant
--- PASS: TestAccPagerDutyTeamMembership_DestroyWithEscalationPolicyDependant (14.56s)
=== RUN   TestAccPagerDutyTeam_Basic # 👈 Test extended
--- PASS: TestAccPagerDutyTeam_Basic (11.08s)
=== RUN   TestAccPagerDutyTeam_Parent
--- PASS: TestAccPagerDutyTeam_Parent (9.58s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   96.813s
```