### PR TITLE
Update handling of format errors on `pagerduty_schedule.start`

### DIFF
--- a/pagerduty/resource_pagerduty_schedule.go
+++ b/pagerduty/resource_pagerduty_schedule.go
@@ -86,9 +86,18 @@ func resourcePagerDutySchedule() *schema.Resource {
 						},
 
 						"start": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateFunc:     validateRFC3339,
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: func(v interface{}, k string) ([]string, []error) {
+								var errors []error
+								value := v.(string)
+								_, err := time.Parse(time.RFC3339, value)
+								if err != nil {
+									errors = append(errors, genErrorTimeFormatRFC339(value, k))
+								}
+
+								return nil, errors
+							},
 							DiffSuppressFunc: suppressScheduleLayerStartDiff,
 						},
 

--- a/pagerduty/util.go
+++ b/pagerduty/util.go
@@ -28,13 +28,17 @@ func validateRFC3339(v interface{}, k string) (we []string, errors []error) {
 	value := v.(string)
 	t, err := time.Parse(time.RFC3339, value)
 	if err != nil {
-		errors = append(errors, fmt.Errorf("%s is not a valid format for argument: %s. Expected format: %s (RFC3339)", value, k, time.RFC3339))
+		errors = append(errors, genErrorTimeFormatRFC339(value, k))
 	}
 	if t.Second() > 0 {
 		errors = append(errors, fmt.Errorf("please set the time %s to a full minute, e.g. 11:23:00, not 11:23:05", value))
 	}
 
 	return
+}
+
+func genErrorTimeFormatRFC339(value, k string) error {
+	return fmt.Errorf("%s is not a valid format for argument: %s. Expected format: %s (RFC3339)", value, k, time.RFC3339)
 }
 
 func suppressRFC3339Diff(k, oldTime, newTime string, d *schema.ResourceData) bool {


### PR DESCRIPTION
Close #659 

## Tests cases extended...

```sh
$ make testacc TESTARGS="-run TestAccPagerDutySchedule"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccPagerDutySchedule -timeout 120m
?       github.com/terraform-providers/terraform-provider-pagerduty     [no test files]
=== RUN   TestAccPagerDutySchedule_import
--- PASS: TestAccPagerDutySchedule_import (10.47s)
=== RUN   TestAccPagerDutySchedule_Basic # 👈 This test was extended
--- PASS: TestAccPagerDutySchedule_Basic (20.38s)
=== RUN   TestAccPagerDutyScheduleWithTeams_Basic
--- PASS: TestAccPagerDutyScheduleWithTeams_Basic (15.55s)
=== RUN   TestAccPagerDutySchedule_BasicWithExternalDestroyHandling
--- PASS: TestAccPagerDutySchedule_BasicWithExternalDestroyHandling (11.44s)
=== RUN   TestAccPagerDutyScheduleWithTeams_EscalationPolicyDependant
--- PASS: TestAccPagerDutyScheduleWithTeams_EscalationPolicyDependant (18.24s)
=== RUN   TestAccPagerDutyScheduleWithTeams_EscalationPolicyDependantWithOpenIncidents
--- PASS: TestAccPagerDutyScheduleWithTeams_EscalationPolicyDependantWithOpenIncidents (48.04s)
=== RUN   TestAccPagerDutySchedule_EscalationPolicyDependantWithOpenIncidents
--- PASS: TestAccPagerDutySchedule_EscalationPolicyDependantWithOpenIncidents (50.39s)
=== RUN   TestAccPagerDutyScheduleOverflow_Basic
--- PASS: TestAccPagerDutyScheduleOverflow_Basic (13.01s)
=== RUN   TestAccPagerDutySchedule_BasicWeek
--- PASS: TestAccPagerDutySchedule_BasicWeek (13.31s)
=== RUN   TestAccPagerDutySchedule_Multi
--- PASS: TestAccPagerDutySchedule_Multi (14.61s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   215.920s
```