### PR TITLE
Adding links to PagerDuty resources on doc index

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -57,3 +57,8 @@ The following arguments are supported:
 * `skip_credentials_validation` - (Optional) Skip validation of the token against the PagerDuty API.
 * `service_region` - (Optional) The PagerDuty service region to use. Default to empty (uses US region). Supported value: `eu`.
 * `api_url_override` - (Optional) It can be used to set a custom proxy endpoint as PagerDuty client api url overriding `service_region` setup.
+
+## Additional Resources
+
+- [PagerDuty Knowledge Base](https://support.pagerduty.com/)
+- [List of Incident Workflow Actions](https://support.pagerduty.com/docs/incident-workflows#add-actions)


### PR DESCRIPTION
There's been feedback and requests for information about incident workflow actions and terraform. I am adding a small section at the bottom of the docs for links to the PD knowledge base and incident workflow actions, to help close the loop between terraform and PD resources.