### PR TITLE
Custom Fields - remove early access marker from incident custom fields pages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-exec v0.15.0
 	github.com/hashicorp/terraform-json v0.13.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.1
-	github.com/heimweh/go-pagerduty v0.0.0-20230530212721-f8e623cf74a8
+	github.com/heimweh/go-pagerduty v0.0.0-20230615223713-346f1359a346
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -249,6 +249,8 @@ github.com/heimweh/go-pagerduty v0.0.0-20230421012559-75399decbf4a h1:+Vx9G90IRa
 github.com/heimweh/go-pagerduty v0.0.0-20230421012559-75399decbf4a/go.mod h1:t9vftsO1IjYHGdgJXeemZtomCWnxi2SRgu0PRcRb2oY=
 github.com/heimweh/go-pagerduty v0.0.0-20230530212721-f8e623cf74a8 h1:y46roLd2yPkE31WQyTsosxKOJtzY0CUfA/w4toqtR2U=
 github.com/heimweh/go-pagerduty v0.0.0-20230530212721-f8e623cf74a8/go.mod h1:t9vftsO1IjYHGdgJXeemZtomCWnxi2SRgu0PRcRb2oY=
+github.com/heimweh/go-pagerduty v0.0.0-20230615223713-346f1359a346 h1:ZPq/T5o8a6jcIJMPtjwadbXvbU/jc4b0DsVZlZ6iQNA=
+github.com/heimweh/go-pagerduty v0.0.0-20230615223713-346f1359a346/go.mod h1:t9vftsO1IjYHGdgJXeemZtomCWnxi2SRgu0PRcRb2oY=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/incident_custom_field.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/incident_custom_field.go
@@ -121,12 +121,6 @@ type GetIncidentCustomFieldOptions struct {
 	Includes []string `url:"include,brackets,omitempty"`
 }
 
-var incidentCustomFieldsEarlyAccessHeader = RequestOptions{
-	Type:  "header",
-	Label: "X-EARLY-ACCESS",
-	Value: "flex-service-early-access",
-}
-
 // ListContext lists existing custom fields. If a non-zero Limit is passed as an option, only a single page of results will be
 // returned. Otherwise, the entire list of fields will be returned.
 func (s *IncidentCustomFieldService) ListContext(ctx context.Context, o *ListIncidentCustomFieldOptions) (*ListIncidentCustomFieldResponse, *Response, error) {
@@ -137,7 +131,7 @@ func (s *IncidentCustomFieldService) ListContext(ctx context.Context, o *ListInc
 		o = &ListIncidentCustomFieldOptions{}
 	}
 
-	resp, err := s.client.newRequestDoOptionsContext(ctx, "GET", u, o, nil, v, incidentCustomFieldsEarlyAccessHeader)
+	resp, err := s.client.newRequestDoContext(ctx, "GET", u, o, nil, v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -150,7 +144,7 @@ func (s *IncidentCustomFieldService) GetContext(ctx context.Context, id string, 
 	u := fmt.Sprintf("/incidents/custom_fields/%s", id)
 	v := new(IncidentCustomFieldPayload)
 
-	resp, err := s.client.newRequestDoOptionsContext(ctx, "GET", u, o, nil, v, incidentCustomFieldsEarlyAccessHeader)
+	resp, err := s.client.newRequestDoContext(ctx, "GET", u, o, nil, v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -163,7 +157,7 @@ func (s *IncidentCustomFieldService) CreateContext(ctx context.Context, field *I
 	u := "/incidents/custom_fields"
 	v := new(IncidentCustomFieldPayload)
 
-	resp, err := s.client.newRequestDoOptionsContext(ctx, "POST", u, nil, &IncidentCustomFieldPayload{Field: field}, &v, incidentCustomFieldsEarlyAccessHeader)
+	resp, err := s.client.newRequestDoContext(ctx, "POST", u, nil, &IncidentCustomFieldPayload{Field: field}, &v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -174,7 +168,7 @@ func (s *IncidentCustomFieldService) CreateContext(ctx context.Context, field *I
 // DeleteContext removes an existing custom field.
 func (s *IncidentCustomFieldService) DeleteContext(ctx context.Context, id string) (*Response, error) {
 	u := fmt.Sprintf("/incidents/custom_fields/%s", id)
-	return s.client.newRequestDoOptionsContext(ctx, "DELETE", u, nil, nil, nil, incidentCustomFieldsEarlyAccessHeader)
+	return s.client.newRequestDoContext(ctx, "DELETE", u, nil, nil, nil)
 }
 
 // UpdateContext updates an existing custom field.
@@ -182,7 +176,7 @@ func (s *IncidentCustomFieldService) UpdateContext(ctx context.Context, id strin
 	u := fmt.Sprintf("/incidents/custom_fields/%s", id)
 	v := new(IncidentCustomFieldPayload)
 
-	resp, err := s.client.newRequestDoOptionsContext(ctx, "PUT", u, nil, &IncidentCustomFieldPayload{Field: field}, &v, incidentCustomFieldsEarlyAccessHeader)
+	resp, err := s.client.newRequestDoContext(ctx, "PUT", u, nil, &IncidentCustomFieldPayload{Field: field}, &v)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/incident_custom_field_option.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/incident_custom_field_option.go
@@ -33,7 +33,7 @@ func (s *IncidentCustomFieldService) CreateFieldOptionContext(ctx context.Contex
 	u := fmt.Sprintf("/incidents/custom_fields/%s/field_options", fieldID)
 	v := new(IncidentCustomFieldOptionPayload)
 
-	resp, err := s.client.newRequestDoOptionsContext(ctx, "POST", u, nil, &IncidentCustomFieldOptionPayload{FieldOption: fieldOption}, &v, incidentCustomFieldsEarlyAccessHeader)
+	resp, err := s.client.newRequestDoContext(ctx, "POST", u, nil, &IncidentCustomFieldOptionPayload{FieldOption: fieldOption}, &v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -46,7 +46,7 @@ func (s *IncidentCustomFieldService) UpdateFieldOptionContext(ctx context.Contex
 	u := fmt.Sprintf("/incidents/custom_fields/%s/field_options/%s", fieldID, fieldOptionID)
 	v := new(IncidentCustomFieldOptionPayload)
 
-	resp, err := s.client.newRequestDoOptionsContext(ctx, "PUT", u, nil, &IncidentCustomFieldOptionPayload{FieldOption: fieldOption}, &v, incidentCustomFieldsEarlyAccessHeader)
+	resp, err := s.client.newRequestDoContext(ctx, "PUT", u, nil, &IncidentCustomFieldOptionPayload{FieldOption: fieldOption}, &v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -75,7 +75,7 @@ func (s *IncidentCustomFieldService) ListFieldOptionsContext(ctx context.Context
 	u := fmt.Sprintf("/incidents/custom_fields/%s/field_options", fieldID)
 	v := new(ListIncidentCustomFieldOptionsResponse)
 
-	resp, err := s.client.newRequestDoOptionsContext(ctx, "GET", u, nil, nil, &v, incidentCustomFieldsEarlyAccessHeader)
+	resp, err := s.client.newRequestDoContext(ctx, "GET", u, nil, nil, &v)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -86,5 +86,5 @@ func (s *IncidentCustomFieldService) ListFieldOptionsContext(ctx context.Context
 // DeleteFieldOptionContext disables an existing field option.
 func (s *IncidentCustomFieldService) DeleteFieldOptionContext(ctx context.Context, fieldID string, fieldOptionID string) (*Response, error) {
 	u := fmt.Sprintf("/incidents/custom_fields/%s/field_options/%s", fieldID, fieldOptionID)
-	return s.client.newRequestDoOptionsContext(ctx, "DELETE", u, nil, nil, nil, incidentCustomFieldsEarlyAccessHeader)
+	return s.client.newRequestDoContext(ctx, "DELETE", u, nil, nil, nil)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -185,7 +185,7 @@ github.com/hashicorp/terraform-svchost
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 ## explicit
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20230530212721-f8e623cf74a8
+# github.com/heimweh/go-pagerduty v0.0.0-20230615223713-346f1359a346
 ## explicit; go 1.17
 github.com/heimweh/go-pagerduty/pagerduty
 # github.com/klauspost/compress v1.15.9

--- a/website/docs/d/incident_custom_field.html.markdown
+++ b/website/docs/d/incident_custom_field.html.markdown
@@ -10,8 +10,6 @@ description: |-
 
 Use this data source to get information about a specific [Incident Custom Field](https://support.pagerduty.com/docs/custom-fields-on-incidents).
 
--> The Custom Fields on Incidents feature is currently available in Early Access.
-
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/incident_custom_field.html.markdown
+++ b/website/docs/r/incident_custom_field.html.markdown
@@ -10,8 +10,6 @@ description: |-
 
 An [Incident Custom Field](https://support.pagerduty.com/docs/custom-fields-on-incidents) defines a field which can be set on incidents in the target account.
 
--> The Custom Fields on Incidents feature is currently available in Early Access.
-
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/incident_custom_field_option.html.markdown
+++ b/website/docs/r/incident_custom_field_option.html.markdown
@@ -11,8 +11,6 @@ description: |-
 A Incident Custom Field Option is a specific value that can be used for an [Incident Custom Field](https://support.pagerduty.com/docs/custom-fields-on-incidents) that only allow values from a set of fixed options,
 i.e. has the `field_type` of `single_value_fixed` or `multi_value_fixed`.
 
--> The Custom Fields on Incidents feature is currently available in Early Access.
-
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
Incorporates https://github.com/heimweh/go-pagerduty/pull/134

as well as updating the documentation pages now that Custom Fields is Generally Available