### PR TITLE
Address name format validation on Escalation Policies

### DIFF
--- a/pagerduty/resource_pagerduty_escalation_policy.go
+++ b/pagerduty/resource_pagerduty_escalation_policy.go
@@ -22,8 +22,9 @@ func resourcePagerDutyEscalationPolicy() *schema.Resource {
 		},
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateDiagFunc: validateCantBeBlankOrNotPrintableChars,
 			},
 			"description": {
 				Type:     schema.TypeString,

--- a/pagerduty/resource_pagerduty_escalation_policy_test.go
+++ b/pagerduty/resource_pagerduty_escalation_policy_test.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -104,6 +105,31 @@ func TestAccPagerDutyEscalationPolicy_Basic(t *testing.T) {
 					testAccExternallyDestroyEscalationPolicy("pagerduty_escalation_policy.foo"),
 				),
 				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccPagerDutyEscalationPolicy_FormatValidation(t *testing.T) {
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.test", username)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyEscalationPolicyDestroy,
+		Steps: []resource.TestStep{
+			// Blank Name
+			{
+				Config:      testAccCheckPagerDutyEscalationPolicyConfig(username, email, ""),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("Name can't be blank neither contain.*, nor non-printable characters."),
+			},
+			// Name with & in it
+			{
+				Config:      testAccCheckPagerDutyEscalationPolicyConfig(username, email, "this name has an ampersand (&)"),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("Name can't be blank neither contain.*, nor non-printable characters."),
 			},
 		},
 	})

--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"regexp"
 	"strconv"
 	"time"
 
@@ -35,9 +34,9 @@ func resourcePagerDutyService() *schema.Resource {
 		},
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringDoesNotMatch(regexp.MustCompile(`^$|^[ ]+$|[/\\<>&]`), "Service name can't be blank or contain '\\', '/', '&', '<', '>' or non-printable characters. "),
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateDiagFunc: validateCantBeBlankOrNotPrintableChars,
 			},
 			"html_url": {
 				Type:     schema.TypeString,

--- a/pagerduty/resource_pagerduty_service_test.go
+++ b/pagerduty/resource_pagerduty_service_test.go
@@ -130,6 +130,32 @@ func TestAccPagerDutyService_Basic(t *testing.T) {
 	})
 }
 
+func TestAccPagerDutyService_FormatValidation(t *testing.T) {
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.test", username)
+	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyServiceDestroy,
+		Steps: []resource.TestStep{
+			// Blank Name
+			{
+				Config:      testAccCheckPagerDutyServiceConfig(username, email, escalationPolicy, ""),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("Name can't be blank neither contain.*, nor non-printable characters."),
+			},
+			// Name with & in it
+			{
+				Config:      testAccCheckPagerDutyServiceConfig(username, email, escalationPolicy, "this name has an ampersand (&)"),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("Name can't be blank neither contain.*, nor non-printable characters."),
+			},
+		},
+	})
+}
+
 func TestAccPagerDutyService_AlertGrouping(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	email := fmt.Sprintf("%s@foo.test", username)

--- a/pagerduty/util.go
+++ b/pagerduty/util.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"math"
 	"reflect"
+	"regexp"
 	"strings"
 	"time"
 
@@ -111,6 +112,24 @@ func validateValueDiagFunc(values []string) schema.SchemaValidateDiagFunc {
 		}
 		return diags
 	}
+}
+
+func validateCantBeBlankOrNotPrintableChars(v interface{}, p cty.Path) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	value := v.(string)
+	matcher := regexp.MustCompile(`^$|^[ ]+$|[/\\<>&]`)
+	matches := matcher.MatchString(value)
+
+	if matches {
+		diags = append(diags, diag.Diagnostic{
+			Severity:      diag.Error,
+			Summary:       "Name can't be blank neither contain '\\', '/', '&', '<', '>', nor non-printable characters.",
+			AttributePath: p,
+		})
+	}
+
+	return diags
 }
 
 // Takes the result of flatmap.Expand for an array of strings


### PR DESCRIPTION
Close #699 

Address name format validation on Escalation Policies, following the next pattern **"Name can't be blank neither contain '\\', '/', '&', '<', '>', nor non-printable characters."**, to match API field validation during plan.

Additionally refactor name format validation for Service into a reusable util, which is being used and tested for EP and Service.

## New tests cases introduced...

```sh
$ make testacc TESTARGS="-run TestAccPagerDutyEscalationPolicy_FormatValidation"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccPagerDutyEscalationPolicy_FormatValidation -timeout 120m
?       github.com/terraform-providers/terraform-provider-pagerduty     [no test files]
=== RUN   TestAccPagerDutyEscalationPolicy_FormatValidation
--- PASS: TestAccPagerDutyEscalationPolicy_FormatValidation (0.39s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   1.365s

$ make testacc TESTARGS="-run TestAccPagerDutyService_FormatValidation"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccPagerDutyService_FormatValidation -timeout 120m
?       github.com/terraform-providers/terraform-provider-pagerduty     [no test files]
=== RUN   TestAccPagerDutyService_FormatValidation
--- PASS: TestAccPagerDutyService_FormatValidation (0.39s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   0.976s
```