### PR TITLE
Address: Too long and unneeded timeouts for call retries with 400 http errors

### DIFF
--- a/pagerduty/data_source_pagerduty_automation_actions_action.go
+++ b/pagerduty/data_source_pagerduty_automation_actions_action.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -108,6 +109,10 @@ func dataSourcePagerDutyAutomationActionsActionRead(d *schema.ResourceData, meta
 	return resource.Retry(1*time.Minute, func() *resource.RetryError {
 		automationActionsAction, _, err := client.AutomationActionsAction.Get(d.Get("id").(string))
 		if err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			// Delaying retry by 30s as recommended by PagerDuty
 			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
 			time.Sleep(30 * time.Second)

--- a/pagerduty/data_source_pagerduty_automation_actions_runner.go
+++ b/pagerduty/data_source_pagerduty_automation_actions_runner.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -63,6 +64,10 @@ func dataSourcePagerDutyAutomationActionsRunnerRead(d *schema.ResourceData, meta
 	return resource.Retry(1*time.Minute, func() *resource.RetryError {
 		runner, _, err := client.AutomationActionsRunner.Get(d.Get("id").(string))
 		if err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			// Delaying retry by 30s as recommended by PagerDuty
 			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
 			time.Sleep(30 * time.Second)

--- a/pagerduty/data_source_pagerduty_business_service.go
+++ b/pagerduty/data_source_pagerduty_business_service.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -40,6 +41,10 @@ func dataSourcePagerDutyBusinessServiceRead(d *schema.ResourceData, meta interfa
 	return resource.Retry(5*time.Minute, func() *resource.RetryError {
 		resp, _, err := client.BusinessServices.List()
 		if err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			// Delaying retry by 30s as recommended by PagerDuty
 			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
 			time.Sleep(30 * time.Second)

--- a/pagerduty/data_source_pagerduty_escalation_policy.go
+++ b/pagerduty/data_source_pagerduty_escalation_policy.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -40,6 +41,10 @@ func dataSourcePagerDutyEscalationPolicyRead(d *schema.ResourceData, meta interf
 	return resource.Retry(5*time.Minute, func() *resource.RetryError {
 		resp, _, err := client.EscalationPolicies.List(o)
 		if err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			// Delaying retry by 30s as recommended by PagerDuty
 			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
 			time.Sleep(30 * time.Second)

--- a/pagerduty/data_source_pagerduty_event_orchestration.go
+++ b/pagerduty/data_source_pagerduty_event_orchestration.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -69,6 +70,10 @@ func dataSourcePagerDutyEventOrchestrationRead(d *schema.ResourceData, meta inte
 	return resource.Retry(5*time.Minute, func() *resource.RetryError {
 		resp, _, err := client.EventOrchestrations.List()
 		if err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			return resource.RetryableError(err)
 		}
 

--- a/pagerduty/data_source_pagerduty_event_orchestration_integration.go
+++ b/pagerduty/data_source_pagerduty_event_orchestration_integration.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -85,6 +86,10 @@ func getEventOrchestrationIntegrationById(ctx context.Context, d *schema.Resourc
 		log.Printf("[INFO] Reading Integration data source by ID '%s' for PagerDuty Event Orchestration '%s'", id, oid)
 
 		if integration, _, err := client.EventOrchestrationIntegrations.GetContext(ctx, oid, id); err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		} else if integration != nil {
@@ -117,6 +122,10 @@ func getEventOrchestrationIntegrationByLabel(ctx context.Context, d *schema.Reso
 		resp, _, err := client.EventOrchestrationIntegrations.ListContext(ctx, oid)
 
 		if err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		}

--- a/pagerduty/data_source_pagerduty_event_orchestrations.go
+++ b/pagerduty/data_source_pagerduty_event_orchestrations.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"regexp"
 	"time"
 
@@ -86,6 +87,10 @@ func dataSourcePagerDutyEventOrchestrationsRead(d *schema.ResourceData, meta int
 	retryErr := resource.Retry(30*time.Second, func() *resource.RetryError {
 		resp, _, err := client.EventOrchestrations.List()
 		if err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			return resource.RetryableError(err)
 		}
 
@@ -116,6 +121,10 @@ func dataSourcePagerDutyEventOrchestrationsRead(d *schema.ResourceData, meta int
 		retryErr := resource.Retry(30*time.Second, func() *resource.RetryError {
 			orch, _, err := client.EventOrchestrations.Get(orchestration.ID)
 			if err != nil {
+				if isErrCode(err, http.StatusBadRequest) {
+					return resource.NonRetryableError(err)
+				}
+
 				return resource.RetryableError(err)
 			}
 			orchestrations = append(orchestrations, orch)

--- a/pagerduty/data_source_pagerduty_extension_schema.go
+++ b/pagerduty/data_source_pagerduty_extension_schema.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"strings"
 	"time"
 
@@ -41,6 +42,10 @@ func dataSourcePagerDutyExtensionSchemaRead(d *schema.ResourceData, meta interfa
 	return resource.Retry(5*time.Minute, func() *resource.RetryError {
 		resp, _, err := client.ExtensionSchemas.List(&pagerduty.ListExtensionSchemasOptions{Query: searchName})
 		if err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			// Delaying retry by 30s as recommended by PagerDuty
 			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
 			time.Sleep(30 * time.Second)

--- a/pagerduty/data_source_pagerduty_incident_custom_field.go
+++ b/pagerduty/data_source_pagerduty_incident_custom_field.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -53,6 +54,10 @@ func dataSourcePagerDutyIncidentCustomFieldRead(ctx context.Context, d *schema.R
 	err = resource.RetryContext(ctx, 5*time.Minute, func() *resource.RetryError {
 		resp, _, err := client.IncidentCustomFields.ListContext(ctx, nil)
 		if err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			// Delaying retry by 30s as recommended by PagerDuty
 			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
 			time.Sleep(30 * time.Second)

--- a/pagerduty/data_source_pagerduty_incident_workflow.go
+++ b/pagerduty/data_source_pagerduty_incident_workflow.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -42,6 +43,10 @@ func dataSourcePagerDutyIncidentWorkflowRead(ctx context.Context, d *schema.Reso
 	err = resource.RetryContext(ctx, 5*time.Minute, func() *resource.RetryError {
 		resp, _, err := client.IncidentWorkflows.ListContext(ctx, &pagerduty.ListIncidentWorkflowOptions{})
 		if err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			// Delaying retry by 30s as recommended by PagerDuty
 			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
 			time.Sleep(30 * time.Second)

--- a/pagerduty/data_source_pagerduty_license.go
+++ b/pagerduty/data_source_pagerduty_license.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"strings"
 	"time"
 
@@ -90,6 +91,10 @@ func dataSourcePagerDutyLicenseRead(d *schema.ResourceData, meta interface{}) er
 	return resource.Retry(5*time.Minute, func() *resource.RetryError {
 		licenses, _, err := client.Licenses.List()
 		if err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			// Delaying retry by 30s as recommended by PagerDuty
 			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
 			time.Sleep(30 * time.Second)

--- a/pagerduty/data_source_pagerduty_licenses.go
+++ b/pagerduty/data_source_pagerduty_licenses.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -41,6 +42,10 @@ func dataSourcePagerDutyLicensesRead(d *schema.ResourceData, meta interface{}) e
 	return resource.Retry(5*time.Minute, func() *resource.RetryError {
 		licenses, _, err := client.Licenses.List()
 		if err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			// Delaying retry by 30s as recommended by PagerDuty
 			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
 			time.Sleep(30 * time.Second)

--- a/pagerduty/data_source_pagerduty_priority.go
+++ b/pagerduty/data_source_pagerduty_priority.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"strings"
 	"time"
 
@@ -42,6 +43,10 @@ func dataSourcePagerDutyPriorityRead(d *schema.ResourceData, meta interface{}) e
 	return resource.Retry(5*time.Minute, func() *resource.RetryError {
 		resp, _, err := client.Priorities.List()
 		if err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			// Delaying retry by 30s as recommended by PagerDuty
 			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
 			time.Sleep(30 * time.Second)

--- a/pagerduty/data_source_pagerduty_ruleset.go
+++ b/pagerduty/data_source_pagerduty_ruleset.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -43,6 +44,10 @@ func dataSourcePagerDutyRulesetRead(d *schema.ResourceData, meta interface{}) er
 	return resource.Retry(5*time.Minute, func() *resource.RetryError {
 		resp, _, err := client.Rulesets.List()
 		if err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			// Delaying retry by 30s as recommended by PagerDuty
 			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
 			time.Sleep(30 * time.Second)

--- a/pagerduty/data_source_pagerduty_schedule.go
+++ b/pagerduty/data_source_pagerduty_schedule.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -40,6 +41,10 @@ func dataSourcePagerDutyScheduleRead(d *schema.ResourceData, meta interface{}) e
 	return resource.Retry(5*time.Minute, func() *resource.RetryError {
 		resp, _, err := client.Schedules.List(o)
 		if err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			// Delaying retry by 30s as recommended by PagerDuty
 			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
 			time.Sleep(30 * time.Second)

--- a/pagerduty/data_source_pagerduty_service.go
+++ b/pagerduty/data_source_pagerduty_service.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -81,6 +82,10 @@ func dataSourcePagerDutyServiceRead(d *schema.ResourceData, meta interface{}) er
 	return resource.Retry(5*time.Minute, func() *resource.RetryError {
 		resp, _, err := client.Services.List(o)
 		if err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			// Delaying retry by 30s as recommended by PagerDuty
 			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
 			time.Sleep(30 * time.Second)

--- a/pagerduty/data_source_pagerduty_service_integration.go
+++ b/pagerduty/data_source_pagerduty_service_integration.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"strings"
 	"time"
 
@@ -52,6 +53,10 @@ func dataSourcePagerDutyServiceIntegrationRead(d *schema.ResourceData, meta inte
 	return resource.Retry(5*time.Minute, func() *resource.RetryError {
 		resp, _, err := client.Services.List(o)
 		if err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			return handleError(err)
 		}
 

--- a/pagerduty/data_source_pagerduty_tag.go
+++ b/pagerduty/data_source_pagerduty_tag.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -41,6 +42,10 @@ func dataSourcePagerDutyTagRead(d *schema.ResourceData, meta interface{}) error 
 	return resource.Retry(5*time.Minute, func() *resource.RetryError {
 		resp, _, err := client.Tags.List(o)
 		if err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			// Delaying retry by 30s as recommended by PagerDuty
 			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
 			time.Sleep(30 * time.Second)

--- a/pagerduty/data_source_pagerduty_team.go
+++ b/pagerduty/data_source_pagerduty_team.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -49,6 +50,10 @@ func dataSourcePagerDutyTeamRead(d *schema.ResourceData, meta interface{}) error
 	return resource.Retry(5*time.Minute, func() *resource.RetryError {
 		resp, _, err := client.Teams.List(o)
 		if err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			// Delaying retry by 30s as recommended by PagerDuty
 			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
 			time.Sleep(30 * time.Second)

--- a/pagerduty/data_source_pagerduty_user.go
+++ b/pagerduty/data_source_pagerduty_user.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -44,6 +45,10 @@ func dataSourcePagerDutyUserRead(d *schema.ResourceData, meta interface{}) error
 	return resource.Retry(5*time.Minute, func() *resource.RetryError {
 		resp, err := client.Users.ListAll(o)
 		if err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			// Delaying retry by 30s as recommended by PagerDuty
 			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
 			time.Sleep(30 * time.Second)

--- a/pagerduty/data_source_pagerduty_user_contact_method.go
+++ b/pagerduty/data_source_pagerduty_user_contact_method.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -73,6 +74,10 @@ func dataSourcePagerDutyUserContactMethodRead(d *schema.ResourceData, meta inter
 	return resource.Retry(5*time.Minute, func() *resource.RetryError {
 		resp, _, err := client.Users.ListContactMethods(userId)
 		if err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			errResp := handleNotFoundError(err, d)
 			if errResp != nil {
 				time.Sleep(2 * time.Second)

--- a/pagerduty/data_source_pagerduty_users.go
+++ b/pagerduty/data_source_pagerduty_users.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"log"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -68,6 +69,10 @@ func dataSourcePagerDutyUsersRead(d *schema.ResourceData, meta interface{}) erro
 	return resource.Retry(5*time.Minute, func() *resource.RetryError {
 		resp, err := client.Users.ListAll(o)
 		if err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			// Delaying retry by 30s as recommended by PagerDuty
 			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
 			time.Sleep(30 * time.Second)

--- a/pagerduty/data_source_pagerduty_vendor.go
+++ b/pagerduty/data_source_pagerduty_vendor.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"regexp"
 	"strings"
 	"time"
@@ -45,6 +46,10 @@ func dataSourcePagerDutyVendorRead(d *schema.ResourceData, meta interface{}) err
 	return resource.Retry(5*time.Minute, func() *resource.RetryError {
 		resp, _, err := client.Vendors.List(o)
 		if err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			// Delaying retry by 30s as recommended by PagerDuty
 			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
 			time.Sleep(30 * time.Second)

--- a/pagerduty/resource_pagerduty_addon.go
+++ b/pagerduty/resource_pagerduty_addon.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -51,6 +52,10 @@ func fetchPagerDutyAddon(d *schema.ResourceData, meta interface{}, errCallback f
 		addon, _, err := client.Addons.Get(d.Id())
 		if err != nil {
 			log.Printf("[WARN] Service read error")
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			errResp := errCallback(err, d)
 			if errResp != nil {
 				time.Sleep(2 * time.Second)

--- a/pagerduty/resource_pagerduty_automation_actions_action.go
+++ b/pagerduty/resource_pagerduty_automation_actions_action.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"errors"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -262,6 +263,10 @@ func resourcePagerDutyAutomationActionsActionRead(d *schema.ResourceData, meta i
 
 	return resource.Retry(30*time.Second, func() *resource.RetryError {
 		if automationActionsAction, _, err := client.AutomationActionsAction.Get(d.Id()); err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			time.Sleep(2 * time.Second)
 			return resource.RetryableError(err)
 		} else if automationActionsAction != nil {
@@ -335,6 +340,10 @@ func resourcePagerDutyAutomationActionsActionDelete(d *schema.ResourceData, meta
 
 	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if _, err := client.AutomationActionsAction.Delete(d.Id()); err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			return resource.RetryableError(err)
 		}
 		return nil

--- a/pagerduty/resource_pagerduty_automation_actions_action_service_association.go
+++ b/pagerduty/resource_pagerduty_automation_actions_action_service_association.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -74,6 +75,10 @@ func fetchPagerDutyAutomationActionsActionServiceAssociation(d *schema.ResourceD
 	return resource.Retry(30*time.Second, func() *resource.RetryError {
 		resp, _, err := client.AutomationActionsAction.GetAssociationToService(actionID, serviceID)
 		if err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			errResp := errCallback(err, d)
 			if errResp != nil {
 				time.Sleep(2 * time.Second)
@@ -111,6 +116,10 @@ func resourcePagerDutyAutomationActionsActionServiceAssociationDelete(d *schema.
 
 	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if _, err := client.AutomationActionsAction.DissociateFromService(actionID, serviceID); err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			return resource.RetryableError(err)
 		}
 		return nil

--- a/pagerduty/resource_pagerduty_automation_actions_runner.go
+++ b/pagerduty/resource_pagerduty_automation_actions_runner.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"errors"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -143,6 +144,10 @@ func resourcePagerDutyAutomationActionsRunnerRead(d *schema.ResourceData, meta i
 
 	return resource.Retry(30*time.Second, func() *resource.RetryError {
 		if automationActionsRunner, _, err := client.AutomationActionsRunner.Get(d.Id()); err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			time.Sleep(2 * time.Second)
 			return resource.RetryableError(err)
 		} else if automationActionsRunner != nil {
@@ -197,6 +202,10 @@ func resourcePagerDutyAutomationActionsRunnerDelete(d *schema.ResourceData, meta
 
 	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if _, err := client.AutomationActionsRunner.Delete(d.Id()); err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			return resource.RetryableError(err)
 		}
 		return nil

--- a/pagerduty/resource_pagerduty_business_service.go
+++ b/pagerduty/resource_pagerduty_business_service.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -130,6 +131,10 @@ func resourcePagerDutyBusinessServiceRead(d *schema.ResourceData, meta interface
 
 	retryErr := resource.Retry(5*time.Minute, func() *resource.RetryError {
 		if businessService, _, err := client.BusinessServices.Get(d.Id()); err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			return resource.RetryableError(err)
 		} else if businessService != nil {
 			d.Set("name", businessService.Name)

--- a/pagerduty/resource_pagerduty_business_service_subscriber.go
+++ b/pagerduty/resource_pagerduty_business_service_subscriber.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"strings"
 	"time"
 
@@ -98,6 +99,10 @@ func resourcePagerDutyBusinessServiceSubscriberRead(d *schema.ResourceData, meta
 
 	return resource.Retry(5*time.Minute, func() *resource.RetryError {
 		if subscriberResponse, _, err := client.BusinessServiceSubscribers.List(businessServiceId); err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			time.Sleep(2 * time.Second)
 			return resource.RetryableError(err)
 		} else if subscriberResponse != nil {

--- a/pagerduty/resource_pagerduty_escalation_policy.go
+++ b/pagerduty/resource_pagerduty_escalation_policy.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -155,6 +156,10 @@ func fetchEscalationPolicy(d *schema.ResourceData, meta interface{}, errCallback
 	return resource.Retry(5*time.Minute, func() *resource.RetryError {
 		escalationPolicy, _, err := client.EscalationPolicies.Get(d.Id(), o)
 		if err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			errResp := errCallback(err, d)
 			log.Printf("[WARN] Escalation Policy read error")
 			if errResp != nil {

--- a/pagerduty/resource_pagerduty_event_orchestration.go
+++ b/pagerduty/resource_pagerduty_event_orchestration.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -138,6 +139,10 @@ func resourcePagerDutyEventOrchestrationRead(d *schema.ResourceData, meta interf
 	return resource.Retry(2*time.Minute, func() *resource.RetryError {
 		orch, _, err := client.EventOrchestrations.Get(d.Id())
 		if err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			errResp := handleNotFoundError(err, d)
 			if errResp != nil {
 				time.Sleep(2 * time.Second)

--- a/pagerduty/resource_pagerduty_event_orchestration_integration.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_integration.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"strings"
 	"time"
 
@@ -146,6 +147,10 @@ func resourcePagerDutyEventOrchestrationIntegrationRead(ctx context.Context, d *
 		log.Printf("[INFO] Reading Integration '%s' for PagerDuty Event Orchestration: %s", id, oid)
 
 		if _, err := fetchPagerDutyEventOrchestrationIntegration(ctx, d, meta, oid, id, false); err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			return resource.RetryableError(err)
 		}
 
@@ -250,6 +255,10 @@ func resourcePagerDutyEventOrchestrationIntegrationDelete(ctx context.Context, d
 	retryErr := resource.RetryContext(ctx, 2*time.Minute, func() *resource.RetryError {
 		log.Printf("[INFO] Deleting Integration '%s' for PagerDuty Event Orchestration: %s", id, oid)
 		if _, err := client.EventOrchestrationIntegrations.DeleteContext(ctx, oid, id); err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			return resource.RetryableError(err)
 		} else {
 			// Try reading an integration after deletion, retry if still found:
@@ -282,6 +291,10 @@ func resourcePagerDutyEventOrchestrationIntegrationImport(ctx context.Context, d
 		log.Printf("[INFO] Reading Integration '%s' for PagerDuty Event Orchestration: %s", id, oid)
 
 		if _, err := fetchPagerDutyEventOrchestrationIntegration(ctx, d, meta, oid, id, false); err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			return resource.RetryableError(err)
 		}
 		return nil

--- a/pagerduty/resource_pagerduty_event_orchestration_path_service.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_service.go
@@ -191,6 +191,10 @@ func resourcePagerDutyEventOrchestrationPathServiceRead(ctx context.Context, d *
 		path, _, err = client.EventOrchestrationPaths.GetContext(ctx, id, t)
 
 		if err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			time.Sleep(2 * time.Second)
 			return resource.RetryableError(err)
 		}
@@ -214,6 +218,10 @@ func resourcePagerDutyEventOrchestrationPathServiceRead(ctx context.Context, d *
 				return nil
 			}
 			if err != nil {
+				if isErrCode(err, http.StatusBadRequest) {
+					return resource.NonRetryableError(err)
+				}
+
 				time.Sleep(2 * time.Second)
 				return resource.RetryableError(err)
 			}
@@ -254,6 +262,10 @@ func resourcePagerDutyEventOrchestrationPathServiceUpdate(ctx context.Context, d
 
 	retryErr := resource.RetryContext(ctx, 30*time.Second, func() *resource.RetryError {
 		if response, _, err := client.EventOrchestrationPaths.UpdateContext(ctx, serviceID, "service", payload); err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			return resource.RetryableError(err)
 		} else if response != nil {
 			d.SetId(response.OrchestrationPath.Parent.ID)
@@ -279,6 +291,10 @@ func resourcePagerDutyEventOrchestrationPathServiceUpdate(ctx context.Context, d
 				return nil
 			}
 			if err != nil {
+				if isErrCode(err, http.StatusBadRequest) {
+					return resource.NonRetryableError(err)
+				}
+
 				time.Sleep(2 * time.Second)
 				return resource.RetryableError(err)
 			}
@@ -329,6 +345,10 @@ func resourcePagerDutyEventOrchestrationPathServiceDelete(ctx context.Context, d
 
 	retryErr := resource.RetryContext(ctx, 30*time.Second, func() *resource.RetryError {
 		if _, _, err := client.EventOrchestrationPaths.UpdateContext(ctx, serviceID, "service", emptyPath); err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			return resource.RetryableError(err)
 		}
 		return nil

--- a/pagerduty/resource_pagerduty_event_orchestration_path_unrouted.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_unrouted.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -175,6 +176,10 @@ func resourcePagerDutyEventOrchestrationPathUnroutedRead(ctx context.Context, d 
 		log.Printf("[INFO] Reading PagerDuty Event Orchestration Path of type: %s for orchestration: %s", "unrouted", d.Id())
 
 		if unroutedPath, _, err := client.EventOrchestrationPaths.GetContext(ctx, d.Id(), "unrouted"); err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			time.Sleep(2 * time.Second)
 			return resource.RetryableError(err)
 		} else if unroutedPath != nil {
@@ -217,6 +222,10 @@ func resourcePagerDutyEventOrchestrationPathUnroutedDelete(ctx context.Context, 
 
 	retryErr := resource.RetryContext(ctx, 30*time.Second, func() *resource.RetryError {
 		if _, _, err := client.EventOrchestrationPaths.UpdateContext(ctx, orchestrationID, "unrouted", emptyPath); err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			return resource.RetryableError(err)
 		}
 		return nil
@@ -246,6 +255,10 @@ func resourcePagerDutyEventOrchestrationPathUnroutedUpdate(ctx context.Context, 
 	retryErr := resource.RetryContext(ctx, 30*time.Second, func() *resource.RetryError {
 		response, _, err := client.EventOrchestrationPaths.UpdateContext(ctx, unroutedPath.Parent.ID, "unrouted", unroutedPath)
 		if err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			return resource.RetryableError(err)
 		}
 

--- a/pagerduty/resource_pagerduty_extension.go
+++ b/pagerduty/resource_pagerduty_extension.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -95,6 +96,10 @@ func fetchPagerDutyExtension(d *schema.ResourceData, meta interface{}, errCallba
 	return resource.Retry(2*time.Minute, func() *resource.RetryError {
 		extension, _, err := client.Extensions.Get(d.Id())
 		if err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			errResp := errCallback(err, d)
 			if errResp != nil {
 				time.Sleep(2 * time.Second)

--- a/pagerduty/resource_pagerduty_extension_servicenow.go
+++ b/pagerduty/resource_pagerduty_extension_servicenow.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -130,6 +131,10 @@ func fetchPagerDutyExtensionServiceNowCreate(d *schema.ResourceData, meta interf
 	return resource.Retry(2*time.Minute, func() *resource.RetryError {
 		extension, _, err := client.Extensions.Get(d.Id())
 		if err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			errResp := errCallback(err, d)
 			if errResp != nil {
 				time.Sleep(2 * time.Second)

--- a/pagerduty/resource_pagerduty_incident_custom_field.go
+++ b/pagerduty/resource_pagerduty_incident_custom_field.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"context"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -133,6 +134,10 @@ func fetchField(ctx context.Context, d *schema.ResourceData, meta interface{}, e
 		field, _, err := client.IncidentCustomFields.GetContext(ctx, d.Id(), nil)
 		if err != nil {
 			log.Printf("[WARN] Incident custom field read error")
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			errResp := errorCallback(err, d)
 			if errResp != nil {
 				time.Sleep(2 * time.Second)

--- a/pagerduty/resource_pagerduty_incident_custom_field_option.go
+++ b/pagerduty/resource_pagerduty_incident_custom_field_option.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -168,6 +169,10 @@ func fetchFieldOption(ctx context.Context, fieldID string, d *schema.ResourceDat
 			log.Printf("[WARN] Field option read error")
 			errResp := errorCallback(err, d)
 			if errResp != nil {
+				if isErrCode(err, http.StatusBadRequest) {
+					return resource.NonRetryableError(err)
+				}
+
 				time.Sleep(2 * time.Second)
 				return resource.RetryableError(errResp)
 			}

--- a/pagerduty/resource_pagerduty_incident_workflow.go
+++ b/pagerduty/resource_pagerduty_incident_workflow.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"context"
 	"log"
+	"net/http"
 	"regexp"
 	"strconv"
 	"time"
@@ -245,6 +246,10 @@ func fetchIncidentWorkflow(ctx context.Context, d *schema.ResourceData, meta int
 		iw, _, err := client.IncidentWorkflows.GetContext(ctx, d.Id())
 		if err != nil {
 			log.Printf("[WARN] Incident workflow read error")
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			errResp := errorCallback(err, d)
 			if errResp != nil {
 				time.Sleep(2 * time.Second)

--- a/pagerduty/resource_pagerduty_incident_workflow_trigger.go
+++ b/pagerduty/resource_pagerduty_incident_workflow_trigger.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -155,6 +156,10 @@ func fetchIncidentWorkflowTrigger(ctx context.Context, d *schema.ResourceData, m
 		iwt, _, err := client.IncidentWorkflowTriggers.GetContext(ctx, d.Id())
 		if err != nil {
 			log.Printf("[WARN] Incident workflow trigger read error")
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			errResp := errorCallback(err, d)
 			if errResp != nil {
 				time.Sleep(2 * time.Second)

--- a/pagerduty/resource_pagerduty_maintenance_window.go
+++ b/pagerduty/resource_pagerduty_maintenance_window.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -93,6 +94,10 @@ func resourcePagerDutyMaintenanceWindowRead(d *schema.ResourceData, meta interfa
 	return resource.Retry(2*time.Minute, func() *resource.RetryError {
 		window, _, err := client.MaintenanceWindows.Get(d.Id())
 		if err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			errResp := handleNotFoundError(err, d)
 			if errResp != nil {
 				time.Sleep(2 * time.Second)

--- a/pagerduty/resource_pagerduty_response_play.go
+++ b/pagerduty/resource_pagerduty_response_play.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"strings"
 	"time"
 
@@ -238,6 +239,10 @@ func resourcePagerDutyResponsePlayCreate(d *schema.ResourceData, meta interface{
 
 	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if responsePlay, _, err := client.ResponsePlays.Create(responsePlay); err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			return resource.RetryableError(err)
 		} else if responsePlay != nil {
 			d.SetId(responsePlay.ID)
@@ -264,6 +269,10 @@ func resourcePagerDutyResponsePlayRead(d *schema.ResourceData, meta interface{})
 
 	return resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if responsePlay, _, err := client.ResponsePlays.Get(d.Id(), from); err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			time.Sleep(2 * time.Second)
 			return resource.RetryableError(err)
 		} else if responsePlay != nil {
@@ -305,6 +314,10 @@ func resourcePagerDutyResponsePlayUpdate(d *schema.ResourceData, meta interface{
 
 	retryErr := resource.Retry(30*time.Second, func() *resource.RetryError {
 		if _, _, err := client.ResponsePlays.Update(d.Id(), responsePlay); err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			return resource.RetryableError(err)
 		}
 		return nil
@@ -327,6 +340,10 @@ func resourcePagerDutyResponsePlayDelete(d *schema.ResourceData, meta interface{
 
 	retryErr := resource.Retry(30*time.Second, func() *resource.RetryError {
 		if _, err := client.ResponsePlays.Delete(d.Id(), from); err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			return resource.RetryableError(err)
 		}
 		return nil

--- a/pagerduty/resource_pagerduty_ruleset.go
+++ b/pagerduty/resource_pagerduty_ruleset.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -109,6 +110,10 @@ func fetchPagerDutyRuleset(d *schema.ResourceData, meta interface{}, errCallback
 	return resource.Retry(2*time.Minute, func() *resource.RetryError {
 		ruleset, _, err := client.Rulesets.Get(d.Id())
 		if err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			errResp := errCallback(err, d)
 			if errResp != nil {
 				time.Sleep(2 * time.Second)

--- a/pagerduty/resource_pagerduty_ruleset_rule.go
+++ b/pagerduty/resource_pagerduty_ruleset_rule.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"strings"
 	"time"
 
@@ -796,6 +797,10 @@ func resourcePagerDutyRulesetRuleCreate(d *schema.ResourceData, meta interface{}
 
 	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if rule, _, err := client.Rulesets.CreateRule(rule.Ruleset.ID, rule); err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			return resource.RetryableError(err)
 		} else if rule != nil {
 			d.SetId(rule.ID)
@@ -827,6 +832,10 @@ func resourcePagerDutyRulesetRuleRead(d *schema.ResourceData, meta interface{}) 
 
 	return resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if rule, _, err := client.Rulesets.GetRule(rulesetID, d.Id()); err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			time.Sleep(2 * time.Second)
 			return resource.RetryableError(err)
 		} else if rule != nil {
@@ -867,6 +876,10 @@ func resourcePagerDutyRulesetRuleUpdate(d *schema.ResourceData, meta interface{}
 func performRulesetRuleUpdate(rulesetID string, id string, rule *pagerduty.RulesetRule, client *pagerduty.Client) error {
 	retryErr := resource.Retry(30*time.Second, func() *resource.RetryError {
 		if updatedRule, _, err := client.Rulesets.UpdateRule(rulesetID, id, rule); err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			return resource.RetryableError(err)
 		} else if rule.Position != nil && *updatedRule.Position != *rule.Position && rule.CatchAll != true {
 			log.Printf("[INFO] PagerDuty ruleset rule %s position %d needs to be %d", updatedRule.ID, *updatedRule.Position, *rule.Position)
@@ -924,6 +937,10 @@ func resourcePagerDutyRulesetRuleDelete(d *schema.ResourceData, meta interface{}
 
 	retryErr := resource.Retry(30*time.Second, func() *resource.RetryError {
 		if _, err := client.Rulesets.DeleteRule(rulesetID, d.Id()); err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			return resource.RetryableError(err)
 		}
 		return nil

--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -411,6 +412,10 @@ func fetchService(d *schema.ResourceData, meta interface{}, errCallback func(err
 		})
 		if err != nil {
 			log.Printf("[WARN] Service read error")
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			errResp := errCallback(err, d)
 			if errResp != nil {
 				time.Sleep(2 * time.Second)

--- a/pagerduty/resource_pagerduty_service_event_rule.go
+++ b/pagerduty/resource_pagerduty_service_event_rule.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"strings"
 	"time"
 
@@ -341,6 +342,10 @@ func resourcePagerDutyServiceEventRuleCreate(d *schema.ResourceData, meta interf
 
 	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if rule, _, err := client.Services.CreateEventRule(rule.Service.ID, rule); err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			return resource.RetryableError(err)
 		} else if rule != nil {
 			d.SetId(rule.ID)
@@ -372,6 +377,10 @@ func resourcePagerDutyServiceEventRuleRead(d *schema.ResourceData, meta interfac
 
 	return resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if rule, _, err := client.Services.GetEventRule(serviceID, d.Id()); err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			time.Sleep(2 * time.Second)
 			return resource.RetryableError(err)
 		} else if rule != nil {
@@ -408,6 +417,10 @@ func resourcePagerDutyServiceEventRuleUpdate(d *schema.ResourceData, meta interf
 
 	retryErr := resource.Retry(30*time.Second, func() *resource.RetryError {
 		if updatedRule, _, err := client.Services.UpdateEventRule(serviceID, d.Id(), rule); err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			return resource.RetryableError(err)
 		} else if rule.Position != nil && *updatedRule.Position != *rule.Position {
 			log.Printf("[INFO] Service Event Rule %s position %v needs to be %v", updatedRule.ID, *updatedRule.Position, *rule.Position)
@@ -434,6 +447,10 @@ func resourcePagerDutyServiceEventRuleDelete(d *schema.ResourceData, meta interf
 
 	retryErr := resource.Retry(30*time.Second, func() *resource.RetryError {
 		if _, err := client.Services.DeleteEventRule(serviceID, d.Id()); err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			return resource.RetryableError(err)
 		}
 		return nil

--- a/pagerduty/resource_pagerduty_service_integration.go
+++ b/pagerduty/resource_pagerduty_service_integration.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"strings"
 	"time"
 
@@ -627,6 +628,10 @@ func fetchPagerDutyServiceIntegration(d *schema.ResourceData, meta interface{}, 
 		serviceIntegration, _, err := client.Services.GetIntegration(service, d.Id(), o)
 		if err != nil {
 			log.Printf("[WARN] Service integration read error")
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			errResp := errCallback(err, d)
 			if errResp != nil {
 				time.Sleep(2 * time.Second)

--- a/pagerduty/resource_pagerduty_slack_connection.go
+++ b/pagerduty/resource_pagerduty_slack_connection.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"strings"
 	"time"
 
@@ -151,6 +152,10 @@ func resourcePagerDutySlackConnectionRead(d *schema.ResourceData, meta interface
 
 	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if slackConn, _, err := client.SlackConnections.Get(workspaceID, d.Id()); err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			return resource.RetryableError(err)
 		} else if slackConn != nil {
 			d.Set("source_id", slackConn.SourceID)

--- a/pagerduty/resource_pagerduty_tag_assignment.go
+++ b/pagerduty/resource_pagerduty_tag_assignment.go
@@ -118,6 +118,10 @@ func resourcePagerDutyTagAssignmentRead(d *schema.ResourceData, meta interface{}
 
 	return resource.Retry(30*time.Second, func() *resource.RetryError {
 		if tagResponse, _, err := client.Tags.ListTagsForEntity(assignment.EntityType, assignment.EntityID); err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			time.Sleep(2 * time.Second)
 			return resource.RetryableError(err)
 		} else if tagResponse != nil {
@@ -246,6 +250,10 @@ func isFoundTagAssignmentEntity(entityID, entityType string, meta interface{}) (
 		if err != nil {
 			return resource.RetryableError(err)
 		}
+		if isErrCode(err, http.StatusBadRequest) {
+			return resource.NonRetryableError(err)
+		}
+
 		isFound = true
 
 		return nil

--- a/pagerduty/resource_pagerduty_team.go
+++ b/pagerduty/resource_pagerduty_team.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -69,6 +70,10 @@ func resourcePagerDutyTeamCreate(d *schema.ResourceData, meta interface{}) error
 
 	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if team, _, err := client.Teams.Create(team); err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			return resource.RetryableError(err)
 		} else if team != nil {
 			d.SetId(team.ID)
@@ -94,6 +99,10 @@ func resourcePagerDutyTeamRead(d *schema.ResourceData, meta interface{}) error {
 
 	return resource.Retry(30*time.Second, func() *resource.RetryError {
 		if team, _, err := client.Teams.Get(d.Id()); err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			errResp := handleNotFoundError(err, d)
 			if errResp != nil {
 				time.Sleep(2 * time.Second)
@@ -141,6 +150,10 @@ func resourcePagerDutyTeamDelete(d *schema.ResourceData, meta interface{}) error
 
 	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if _, err := client.Teams.Delete(d.Id()); err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			return resource.RetryableError(err)
 		}
 		return nil

--- a/pagerduty/resource_pagerduty_user.go
+++ b/pagerduty/resource_pagerduty_user.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"strings"
 	"time"
 
@@ -184,6 +185,10 @@ func resourcePagerDutyUserRead(d *schema.ResourceData, meta interface{}) error {
 	return resource.Retry(2*time.Minute, func() *resource.RetryError {
 		user, err := client.Users.GetWithLicense(d.Id(), &pagerduty.GetUserOptions{})
 		if err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			errResp := handleNotFoundError(err, d)
 			if errResp != nil {
 				time.Sleep(2 * time.Second)

--- a/pagerduty/resource_pagerduty_user_contact_method.go
+++ b/pagerduty/resource_pagerduty_user_contact_method.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -119,6 +120,10 @@ func fetchPagerDutyUserContactMethod(d *schema.ResourceData, meta interface{}, e
 	return resource.Retry(2*time.Minute, func() *resource.RetryError {
 		resp, _, err := client.Users.GetContactMethod(userID, d.Id())
 		if err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			errResp := handleNotFoundError(err, d)
 			if errResp != nil {
 				time.Sleep(2 * time.Second)

--- a/pagerduty/resource_pagerduty_user_notification_rule.go
+++ b/pagerduty/resource_pagerduty_user_notification_rule.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"regexp"
 	"strings"
 	"time"
@@ -82,6 +83,10 @@ func fetchPagerDutyUserNotificationRule(d *schema.ResourceData, meta interface{}
 	return resource.Retry(2*time.Minute, func() *resource.RetryError {
 		resp, _, err := client.Users.GetNotificationRule(userID, d.Id())
 		if err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			errResp := errCallback(err, d)
 			if errResp != nil {
 				time.Sleep(2 * time.Second)

--- a/pagerduty/resource_pagerduty_webhook_subscription.go
+++ b/pagerduty/resource_pagerduty_webhook_subscription.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -171,6 +172,10 @@ func resourcePagerDutyWebhookSubscriptionRead(d *schema.ResourceData, meta inter
 
 	return resource.Retry(30*time.Second, func() *resource.RetryError {
 		if webhook, _, err := client.WebhookSubscriptions.Get(d.Id()); err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
 			time.Sleep(2 * time.Second)
 			return resource.RetryableError(err)
 		} else if webhook != nil {


### PR DESCRIPTION
Close #544 

In order to avoid too long and unneeded timeouts on API calls with retries that receive 400 http error, this update is catching those errors and returning immediately without further retries, due to the lack of sense on retrying for input errors till timeout elapses.