### PR TITLE
Stop retrying on Schedule deletion when open incidents are untraceable

### DIFF
--- a/pagerduty/resource_pagerduty_schedule.go
+++ b/pagerduty/resource_pagerduty_schedule.go
@@ -455,6 +455,12 @@ func resourcePagerDutyScheduleDelete(d *schema.ResourceData, meta interface{}) e
 				return resource.NonRetryableError(fmt.Errorf("Before destroying Schedule %q You must first resolve or reassign the following incidents related with Escalation Policies using this Schedule... %s", scheduleId, urlLinksMessage))
 			}
 
+			// Returning at this point because the open incident (s) blocking the
+			// deletion of the Schedule can't be tracked.
+			if isErrorScheduleWOpenIncidents(e) && !hasToShowIncidentRemediationMessage {
+				return resource.NonRetryableError(e)
+			}
+
 			epsDataUsingThisSchedule, errFetchingFullEPs := fetchEPsDataUsingASchedule(epsUsingThisSchedule, client)
 			if errFetchingFullEPs != nil {
 				err = fmt.Errorf("%v; %w", err, errFetchingFullEPs)


### PR DESCRIPTION
When an Escalation Policy using and Schedule receives a new Incident, a [snapshot of the EP](https://support.pagerduty.com/docs/escalation-policies#escalation-policy-changes) gets created to trace the relation of the Incident with that EP and its dependencies during the Incident life cycle, however when a that Schedule gets moved from the EP before closing or reassigning the Incident, the traceability of the Schedule with the Incident is lost, therefore retrying on error **"[Schedule can't be deleted if it's being used by an escalation policy snapshot with open incidents]"** becomes meaningless, so this update is meant to return immediately after matching this scenario.

## Test results

```sh
$ PAGERDUTY_ACC_SCHEDULE_USED_BY_EP_W_1_LAYER=1 make testacc TESTARGS="-run TestAccPagerDutySchedule"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccPagerDutySchedule -timeout 120m
?       github.com/terraform-providers/terraform-provider-pagerduty     [no test files]
=== RUN   TestAccPagerDutySchedule_import
--- PASS: TestAccPagerDutySchedule_import (13.91s)
=== RUN   TestAccPagerDutySchedule_Basic
--- PASS: TestAccPagerDutySchedule_Basic (22.27s)
=== RUN   TestAccPagerDutyScheduleWithTeams_Basic
--- PASS: TestAccPagerDutyScheduleWithTeams_Basic (16.23s)
=== RUN   TestAccPagerDutySchedule_BasicWithExternalDestroyHandling
--- PASS: TestAccPagerDutySchedule_BasicWithExternalDestroyHandling (13.00s)
=== RUN   TestAccPagerDutyScheduleWithTeams_EscalationPolicyDependant
--- PASS: TestAccPagerDutyScheduleWithTeams_EscalationPolicyDependant (19.05s)
=== RUN   TestAccPagerDutyScheduleWithTeams_EscalationPolicyDependantWithOneLayer
--- PASS: TestAccPagerDutyScheduleWithTeams_EscalationPolicyDependantWithOneLayer (47.27s)
=== RUN   TestAccPagerDutyScheduleWithTeams_EscalationPolicyDependantWithOpenIncidents
--- PASS: TestAccPagerDutyScheduleWithTeams_EscalationPolicyDependantWithOpenIncidents (54.16s)
=== RUN   TestAccPagerDutySchedule_EscalationPolicyDependantWithOpenIncidents
--- PASS: TestAccPagerDutySchedule_EscalationPolicyDependantWithOpenIncidents (60.47s)
=== RUN   TestAccPagerDutyScheduleOverflow_Basic
--- PASS: TestAccPagerDutyScheduleOverflow_Basic (14.31s)
=== RUN   TestAccPagerDutySchedule_BasicWeek
--- PASS: TestAccPagerDutySchedule_BasicWeek (14.31s)
=== RUN   TestAccPagerDutySchedule_Multi
--- PASS: TestAccPagerDutySchedule_Multi (16.58s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   292.056s
```