### PR TITLE
add `pagerduty_team_members` data source

### DIFF
--- a/pagerduty/data_source_pagerduty_team_members.go
+++ b/pagerduty/data_source_pagerduty_team_members.go
@@ -1,0 +1,117 @@
+package pagerduty
+
+import (
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+func dataSourcePagerDutyTeamMembers() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourcePagerDutyTeamMembersRead,
+
+		Schema: map[string]*schema.Schema{
+			"team_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The ID of the team to find via the PagerDuty API",
+			},
+			"members": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The set of team memberships associated with the team",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"summary": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"role": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourcePagerDutyTeamMembersRead(d *schema.ResourceData, meta interface{}) error {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] Reading PagerDuty team members")
+
+	teamID := d.Get("team_id").(string)
+
+	return resource.Retry(5*time.Minute, func() *resource.RetryError {
+		allMembers, err := collectAllTeamMembers(client, teamID)
+		if err != nil {
+			if isErrCode(err, http.StatusBadRequest) {
+				return resource.NonRetryableError(err)
+			}
+
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
+			return resource.RetryableError(err)
+		}
+
+		var mems []map[string]interface{}
+		for _, member := range allMembers {
+			mems = append(mems, map[string]interface{}{
+				"id":      member.User.ID,
+				"type":    member.User.Type,
+				"summary": member.User.Summary,
+				"role":    member.Role,
+			})
+		}
+
+		// Since this data doesn't have an unique ID, this forces the data to be
+		// refreshed with each Terraform apply.
+		d.SetId(strconv.FormatInt(time.Now().Unix(), 10))
+
+		d.Set("members", mems)
+		d.Set("team_id", teamID)
+
+		return nil
+	})
+}
+
+func collectAllTeamMembers(c *pagerduty.Client, teamID string) ([]*pagerduty.Member, error) {
+	var members []*pagerduty.Member
+	opts := &pagerduty.GetMembersOptions{
+		Limit:  100,
+		Offset: 0,
+	}
+
+	for {
+		resp, _, err := c.Teams.GetMembers(teamID, opts)
+		if err != nil {
+			return nil, err
+		}
+
+		members = append(members, resp.Members...)
+		if !resp.More {
+			return members, nil
+		}
+
+		opts.Offset = opts.Offset + opts.Limit
+	}
+}

--- a/pagerduty/data_source_pagerduty_team_members_test.go
+++ b/pagerduty/data_source_pagerduty_team_members_test.go
@@ -1,0 +1,75 @@
+package pagerduty
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccDataSourcePagerDutyTeamMembers_Basic(t *testing.T) {
+	teamName := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	userName := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	userEmail := fmt.Sprintf("%s@pagerduty.com", userName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourcePagerDutyTeamMembersConfig(teamName, userName, userEmail),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.pagerduty_team_members.test", "members.#", "1"),
+					resource.TestCheckResourceAttr("data.pagerduty_team_members.test", "members.0.summary", userName),
+					resource.TestCheckResourceAttr("data.pagerduty_team_members.test", "members.0.role", "manager"),
+					resource.TestCheckResourceAttr("data.pagerduty_team_members.test", "members.0.type", "user_reference"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourcePagerDutyTeamMembers(teamResource, userResource, teamMembershipDataSource string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		userR := s.RootModule().Resources[userResource]
+		userRAs := userR.Primary.Attributes
+
+		teamMembershipDS := s.RootModule().Resources[teamMembershipDataSource]
+		as := teamMembershipDS.Primary.Attributes
+
+		if as["id"] != "" {
+			return fmt.Errorf("Expected team members ID not to be empty")
+		}
+
+		if as["members.0.id"] != userRAs["id"] {
+			return fmt.Errorf("Expected team member ID to match user ID")
+		}
+
+		return nil
+	}
+}
+
+func testAccDataSourcePagerDutyTeamMembersConfig(teamName, userName, userEmail string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_team" "test" {
+  name        = "%s"
+  description = "%s"
+}
+
+resource "pagerduty_user" "test" {
+  name = "%s"
+  email = "%s"
+}
+
+resource "pagerduty_team_membership" "test" {
+  user_id = pagerduty_user.test.id
+  team_id = pagerduty_team.test.id
+}
+
+data "pagerduty_team_members" "test" {
+	team_id = pagerduty_team.test.id
+}
+`, teamName, teamName, userName, userEmail)
+}

--- a/pagerduty/provider.go
+++ b/pagerduty/provider.go
@@ -98,6 +98,7 @@ func Provider() *schema.Provider {
 			"pagerduty_automation_actions_action":       dataSourcePagerDutyAutomationActionsAction(),
 			"pagerduty_incident_workflow":               dataSourcePagerDutyIncidentWorkflow(),
 			"pagerduty_incident_custom_field":           dataSourcePagerDutyIncidentCustomField(),
+			"pagerduty_team_members":                    dataSourcePagerDutyTeamMembers(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/website/docs/d/team_members.html.markdown
+++ b/website/docs/d/team_members.html.markdown
@@ -1,0 +1,46 @@
+---
+layout: "pagerduty"
+page_title: "PagerDuty: pagerduty_team_members"
+sidebar_current: "docs-pagerduty-datasource-team-members"
+description: |-
+  Get information about a team's members..
+---
+
+# pagerduty\_team\_members
+
+Use this data source to get information about a specific [team's members][1].
+
+## Example Usage
+
+```hcl
+data "pagerduty_team" "devops" {
+  name = "devops"
+}
+
+data "pagerduty_team_members" "devops_members" {
+  team_id = data.pagerduty_team.devops.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `team_id` - (Required) The ID of the team to find in the PagerDuty API.
+
+## Attributes Reference
+
+* `id` - The ID of the found team.
+* `members` - The users of the found team.
+
+### Members (`members`) supports the following:
+
+* `id` - The ID of the found user.
+* `name` - The short name of the found user.
+* `email` - The email of the found user.
+* `role` - The team role of the found user.
+* `job_title` - The job title of the found user.
+* `time_zone` - The timezone of the found user.
+* `description` - The human-friendly description of the found user.
+
+[1]: https://developer.pagerduty.com/api-reference/e35802f3c4ba4-list-members-of-a-team

--- a/website/docs/d/team_members.html.markdown
+++ b/website/docs/d/team_members.html.markdown
@@ -36,11 +36,8 @@ The following arguments are supported:
 ### Members (`members`) supports the following:
 
 * `id` - The ID of the found user.
-* `name` - The short name of the found user.
-* `email` - The email of the found user.
 * `role` - The team role of the found user.
-* `job_title` - The job title of the found user.
-* `time_zone` - The timezone of the found user.
-* `description` - The human-friendly description of the found user.
+* `type` - The type of object. The value returned will be `user_reference`. Can be used for passing to another object as dependency.
+* `summary` - A short-form, server-generated string that provides succinct, important information about an object suitable for primary labeling of an entity in a client. In many cases, this will be identical to name, though it is not intended to be an identifier.
 
 [1]: https://developer.pagerduty.com/api-reference/e35802f3c4ba4-list-members-of-a-team

--- a/website/pagerduty.erb
+++ b/website/pagerduty.erb
@@ -40,6 +40,9 @@
                 <li<%= sidebar_current("docs-pagerduty-datasource-team") %>>
                     <a href="/docs/providers/pagerduty/d/team.html">pagerduty_team</a>
                 </li>
+                <li<%= sidebar_current("docs-pagerduty-datasource-team-members") %>>
+                    <a href="/docs/providers/pagerduty/d/team_members.html">pagerduty_team_members</a>
+                </li>
                 <li<%= sidebar_current("docs-pagerduty-datasource-tag") %>>
                     <a href="/docs/providers/pagerduty/d/tag.html">pagerduty_tag</a>
                 </li>


### PR DESCRIPTION
This addresses issue #716 and adds a `pagerduty_team_members` data source for fetching the team members associated with a team, including the team role associated with each.

Example usage:

```hcl
data "pagerduty_team_members" "foo" {
  team_id = resource.pagerduty_team.foo.id
}
```

Closes #716 