### PR TITLE
add attributes to `data.pagerduty_users.users` & `data.pagerduty_user`

### DIFF
--- a/pagerduty/data_source_pagerduty_user.go
+++ b/pagerduty/data_source_pagerduty_user.go
@@ -24,6 +24,22 @@ func dataSourcePagerDutyUser() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"role": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"job_title": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"time_zone": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -73,6 +89,10 @@ func dataSourcePagerDutyUserRead(d *schema.ResourceData, meta interface{}) error
 		d.SetId(found.ID)
 		d.Set("name", found.Name)
 		d.Set("email", found.Email)
+		d.Set("role", found.Role)
+		d.Set("job_title", found.JobTitle)
+		d.Set("time_zone", found.TimeZone)
+		d.Set("description", found.Description)
 
 		return nil
 	})

--- a/pagerduty/data_source_pagerduty_user_test.go
+++ b/pagerduty/data_source_pagerduty_user_test.go
@@ -13,7 +13,7 @@ func TestAccDataSourcePagerDutyUser_Basic(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	email := fmt.Sprintf("%s@foo.test", username)
 	jobTitle := fmt.Sprintf("%s-title", username)
-	timeZone := "UTC"
+	timeZone := "America/New_York"
 	role := "user"
 	description := fmt.Sprintf("%s-description", username)
 

--- a/pagerduty/data_source_pagerduty_user_test.go
+++ b/pagerduty/data_source_pagerduty_user_test.go
@@ -12,13 +12,17 @@ import (
 func TestAccDataSourcePagerDutyUser_Basic(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	email := fmt.Sprintf("%s@foo.test", username)
+	jobTitle := fmt.Sprintf("%s-title", username)
+	timeZone := "UTC"
+	role := "user"
+	description := fmt.Sprintf("%s-description", username)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourcePagerDutyUserConfig(username, email),
+				Config: testAccDataSourcePagerDutyUserConfig(username, email, jobTitle, timeZone, role, description),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourcePagerDutyUser("pagerduty_user.test", "data.pagerduty_user.by_email"),
 				),
@@ -40,7 +44,7 @@ func testAccDataSourcePagerDutyUser(src, n string) resource.TestCheckFunc {
 			return fmt.Errorf("Expected to get a user ID from PagerDuty")
 		}
 
-		testAtts := []string{"id", "name", "email"}
+		testAtts := []string{"id", "name", "email", "job_title", "time_zone", "role", "description"}
 
 		for _, att := range testAtts {
 			if a[att] != srcA[att] {
@@ -52,15 +56,19 @@ func testAccDataSourcePagerDutyUser(src, n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccDataSourcePagerDutyUserConfig(username, email string) string {
+func testAccDataSourcePagerDutyUserConfig(username, email, jobTitle, timeZone, role, description string) string {
 	return fmt.Sprintf(`
 resource "pagerduty_user" "test" {
   name = "%s"
   email = "%s"
+  job_title = "%s"
+  time_zone = "%s"
+  role = "%s"
+  description = "%s"
 }
 
 data "pagerduty_user" "by_email" {
 	email = pagerduty_user.test.email
 }
-`, username, email)
+`, username, email, jobTitle, timeZone, role, description)
 }

--- a/pagerduty/data_source_pagerduty_users.go
+++ b/pagerduty/data_source_pagerduty_users.go
@@ -41,6 +41,26 @@ func dataSourcePagerDutyUsers() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"role": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"job_title": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"time_zone": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},
@@ -82,9 +102,13 @@ func dataSourcePagerDutyUsersRead(d *schema.ResourceData, meta interface{}) erro
 		var users []map[string]interface{}
 		for _, user := range resp {
 			users = append(users, map[string]interface{}{
-				"id":    user.ID,
-				"name":  user.Name,
-				"email": user.Email,
+				"id":          user.ID,
+				"name":        user.Name,
+				"email":       user.Email,
+				"role":        user.Role,
+				"job_title":   user.JobTitle,
+				"time_zone":   user.TimeZone,
+				"description": user.Description,
 			})
 		}
 

--- a/pagerduty/data_source_pagerduty_users_test.go
+++ b/pagerduty/data_source_pagerduty_users_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAccDataSourcePagerDutyUsers_Basic(t *testing.T) {
-	timeZone := "UTC"
+	timeZone := "America/New_York"
 	teamname1 := fmt.Sprintf("tf-team-%s", acctest.RandString(5))
 	teamname2 := fmt.Sprintf("tf-team-%s", acctest.RandString(5))
 
@@ -73,7 +73,7 @@ func TestAccDataSourcePagerDutyUsers_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.pagerduty_users.test_by_1_team", "users.0.role", "user"),
 					resource.TestCheckResourceAttr(
-						"data.pagerduty_users.test_by_1_team", "users.0.title", title2),
+						"data.pagerduty_users.test_by_1_team", "users.0.job_title", title2),
 					resource.TestCheckResourceAttr(
 						"data.pagerduty_users.test_by_1_team", "users.0.time_zone", timeZone2),
 					resource.TestCheckResourceAttr(
@@ -89,7 +89,7 @@ func TestAccDataSourcePagerDutyUsers_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.pagerduty_users.test_by_2_team", "users.0.role", "user"),
 					resource.TestCheckResourceAttr(
-						"data.pagerduty_users.test_by_2_team", "users.0.title", title2),
+						"data.pagerduty_users.test_by_2_team", "users.0.job_title", title2),
 					resource.TestCheckResourceAttr(
 						"data.pagerduty_users.test_by_2_team", "users.0.time_zone", timeZone2),
 					resource.TestCheckResourceAttr(
@@ -101,7 +101,7 @@ func TestAccDataSourcePagerDutyUsers_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.pagerduty_users.test_by_2_team", "users.1.role", "user"),
 					resource.TestCheckResourceAttr(
-						"data.pagerduty_users.test_by_2_team", "users.1.title", title3),
+						"data.pagerduty_users.test_by_2_team", "users.1.job_title", title3),
 					resource.TestCheckResourceAttr(
 						"data.pagerduty_users.test_by_2_team", "users.1.time_zone", timeZone3),
 					resource.TestCheckResourceAttr(

--- a/pagerduty/data_source_pagerduty_users_test.go
+++ b/pagerduty/data_source_pagerduty_users_test.go
@@ -10,21 +10,34 @@ import (
 )
 
 func TestAccDataSourcePagerDutyUsers_Basic(t *testing.T) {
+	timeZone := "UTC"
 	teamname1 := fmt.Sprintf("tf-team-%s", acctest.RandString(5))
 	teamname2 := fmt.Sprintf("tf-team-%s", acctest.RandString(5))
+
 	username1 := fmt.Sprintf("tf-user1-%s", acctest.RandString(5))
 	email1 := fmt.Sprintf("%s@foo.test", username1)
+	title1 := fmt.Sprintf("%s-title", username1)
+	timeZone1 := timeZone
+	description1 := fmt.Sprintf("%s-description", username1)
+
 	username2 := fmt.Sprintf("tf-user2-%s", acctest.RandString(5))
 	email2 := fmt.Sprintf("%s@foo.test", username2)
+	title2 := fmt.Sprintf("%s-title", username2)
+	timeZone2 := timeZone
+	description2 := fmt.Sprintf("%s-description", username2)
+
 	username3 := fmt.Sprintf("tf-user3-%s", acctest.RandString(5))
 	email3 := fmt.Sprintf("%s@foo.test", username3)
+	title3 := fmt.Sprintf("%s-title", username3)
+	description3 := fmt.Sprintf("%s-description", username3)
+	timeZone3 := timeZone
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourcePagerDutyUsersConfig(teamname1, teamname2, username1, email1, username2, email2, username3, email3),
+				Config: testAccDataSourcePagerDutyUsersConfig(teamname1, teamname2, username1, email1, title1, timeZone1, description1, username2, email2, title2, timeZone2, description2, username3, email3, title3, timeZone3, description3),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourcePagerDutyUsersExists("data.pagerduty_users.test_all_users"),
 					testAccDataSourcePagerDutyUsersExists("data.pagerduty_users.test_by_1_team"),
@@ -58,6 +71,14 @@ func TestAccDataSourcePagerDutyUsers_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.pagerduty_users.test_by_1_team", "users.0.email", email2),
 					resource.TestCheckResourceAttr(
+						"data.pagerduty_users.test_by_1_team", "users.0.role", "user"),
+					resource.TestCheckResourceAttr(
+						"data.pagerduty_users.test_by_1_team", "users.0.title", title2),
+					resource.TestCheckResourceAttr(
+						"data.pagerduty_users.test_by_1_team", "users.0.time_zone", timeZone2),
+					resource.TestCheckResourceAttr(
+						"data.pagerduty_users.test_by_1_team", "users.0.description", description2),
+					resource.TestCheckResourceAttr(
 						"data.pagerduty_users.test_by_2_team", "users.#", "2"),
 					resource.TestCheckResourceAttrSet(
 						"data.pagerduty_users.test_by_2_team", "users.0.id"),
@@ -66,9 +87,25 @@ func TestAccDataSourcePagerDutyUsers_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.pagerduty_users.test_by_2_team", "users.0.email", email2),
 					resource.TestCheckResourceAttr(
+						"data.pagerduty_users.test_by_2_team", "users.0.role", "user"),
+					resource.TestCheckResourceAttr(
+						"data.pagerduty_users.test_by_2_team", "users.0.title", title2),
+					resource.TestCheckResourceAttr(
+						"data.pagerduty_users.test_by_2_team", "users.0.time_zone", timeZone2),
+					resource.TestCheckResourceAttr(
+						"data.pagerduty_users.test_by_2_team", "users.0.description", description2),
+					resource.TestCheckResourceAttr(
 						"data.pagerduty_users.test_by_2_team", "users.1.name", username3),
 					resource.TestCheckResourceAttr(
 						"data.pagerduty_users.test_by_2_team", "users.1.email", email3),
+					resource.TestCheckResourceAttr(
+						"data.pagerduty_users.test_by_2_team", "users.1.role", "user"),
+					resource.TestCheckResourceAttr(
+						"data.pagerduty_users.test_by_2_team", "users.1.title", title3),
+					resource.TestCheckResourceAttr(
+						"data.pagerduty_users.test_by_2_team", "users.1.time_zone", timeZone3),
+					resource.TestCheckResourceAttr(
+						"data.pagerduty_users.test_by_2_team", "users.1.description", description3),
 				),
 			},
 		},
@@ -89,7 +126,7 @@ func testAccDataSourcePagerDutyUsersExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccDataSourcePagerDutyUsersConfig(teamname1, teamname2, username1, email1, username2, email2, username3, email3 string) string {
+func testAccDataSourcePagerDutyUsersConfig(teamname1, teamname2, username1, email1, title1, timeZone1, description1, username2, email2, title2, timeZone2, description2, username3, email3, title3, timeZone3, description3 string) string {
 	return fmt.Sprintf(`
     resource "pagerduty_team" "test1" {
         name        = "%s"
@@ -101,14 +138,23 @@ func testAccDataSourcePagerDutyUsersConfig(teamname1, teamname2, username1, emai
     resource "pagerduty_user" "test_wo_team" {
       name = "%s"
       email = "%s"
+      job_title = "%s"
+      time_zone = "%s"
+      description = "%s"
     }
     resource "pagerduty_user" "test_w_team1" {
       name = "%s"
       email = "%s"
+      job_title = "%s"
+      time_zone = "%s"
+      description = "%s"
     }
     resource "pagerduty_user" "test_w_team2" {
       name = "%s"
       email = "%s"
+      job_title = "%s"
+      time_zone = "%s"
+      description = "%s"
     }
 
     resource "pagerduty_team_membership" "test1" {
@@ -133,5 +179,5 @@ func testAccDataSourcePagerDutyUsersConfig(teamname1, teamname2, username1, emai
       depends_on = [pagerduty_team_membership.test2]
       team_ids = [pagerduty_team.test1.id, pagerduty_team.test2.id]
     }
-`, teamname1, teamname2, username1, email1, username2, email2, username3, email3)
+`, teamname1, teamname2, username1, email1, title1, timeZone1, description1, username2, email2, title2, timeZone2, description2, username3, email3, title3, timeZone3, description3)
 }

--- a/website/docs/d/user.html.markdown
+++ b/website/docs/d/user.html.markdown
@@ -39,7 +39,12 @@ The following arguments are supported:
 * `email` - (Required) The email to use to find a user in the PagerDuty API.
 
 ## Attributes Reference
+
 * `id` - The ID of the found user.
 * `name` - The short name of the found user.
+* `role` - The role of the found user.
+* `job_title` - The job title of the found user.
+* `time_zone` - The timezone of the found user.
+* `description` - The human-friendly description of the found user.
 
 [1]: https://developer.pagerduty.com/api-reference/b3A6Mjc0ODIzMw-list-users

--- a/website/docs/d/users.html.markdown
+++ b/website/docs/d/users.html.markdown
@@ -53,6 +53,10 @@ The following arguments are supported:
 
 * `id` - The ID of the found user.
 * `name` - The short name of the found user.
-* `email` - The email to use to find a user in the PagerDuty API.
+* `email` - The email of the found user.
+* `role` - The role of the found user.
+* `job_title` - The job title of the found user.
+* `time_zone` - The timezone of the found user.
+* `description` - The human-friendly description of the found user.
 
 [1]: https://developer.pagerduty.com/api-reference/b3A6Mjc0ODIzMw-list-users


### PR DESCRIPTION
This seeks to address issue #718 and issue #720 by adding additional attributes to each user in the `data.pagerduty_users.users` list, as well as the `data.pagerduty_user`:

* `role`
* `job_title`
* `time_zone`
* `description`

## Acceptance tests results...

```sh
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccDataSourcePagerDutyUser_Basic -timeout 120m
?       github.com/PagerDuty/terraform-provider-pagerduty       [no test files]
=== RUN   TestAccDataSourcePagerDutyUser_Basic
--- PASS: TestAccDataSourcePagerDutyUser_Basic (20.74s)
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerduty     24.458s
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerdutyplugin       (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/util  (cached) [no tests to run]
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccDataSourcePagerDutyUsers_Basic -timeout 120m
?       github.com/PagerDuty/terraform-provider-pagerduty       [no test files]
=== RUN   TestAccDataSourcePagerDutyUsers_Basic
--- PASS: TestAccDataSourcePagerDutyUsers_Basic (31.29s)
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerduty     31.706s
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerdutyplugin       (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/util  (cached) [no tests to run]
```