### PR TITLE
Specify the default country code for contact methods

### DIFF
--- a/pagerduty/resource_pagerduty_user_contact_method.go
+++ b/pagerduty/resource_pagerduty_user_contact_method.go
@@ -62,6 +62,7 @@ func resourcePagerDutyUserContactMethod() *schema.Resource {
 			"country_code": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Default:  1,
 			},
 
 			"enabled": {

--- a/pagerduty/resource_pagerduty_user_contact_method.go
+++ b/pagerduty/resource_pagerduty_user_contact_method.go
@@ -62,7 +62,7 @@ func resourcePagerDutyUserContactMethod() *schema.Resource {
 			"country_code": {
 				Type:     schema.TypeInt,
 				Optional: true,
-				Default:  1,
+				Computed: true,
 			},
 
 			"enabled": {


### PR DESCRIPTION
If the default country code is not specified, the API will default to 1. It is creating a permanent diff if not specified in a provider.