### PR TITLE
[TFPROVDEV-30] Address update user role failed as license is not re-computed correctly

### DIFF
--- a/pagerduty/resource_pagerduty_user.go
+++ b/pagerduty/resource_pagerduty_user.go
@@ -229,6 +229,12 @@ func resourcePagerDutyUserUpdate(d *schema.ResourceData, meta interface{}) error
 
 	user := buildUserStruct(d)
 
+	if ok := d.HasChangeExcept("license"); ok {
+		// When not explicitely assigning a new license it's better to the backend
+		// logic assign the license's id.
+		user.License = nil
+	}
+
 	log.Printf("[INFO] Updating PagerDuty user %s", d.Id())
 
 	// Retrying to give other resources (such as escalation policies) to delete

--- a/pagerduty/resource_pagerduty_user_test.go
+++ b/pagerduty/resource_pagerduty_user_test.go
@@ -85,7 +85,7 @@ func TestAccPagerDutyUser_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckPagerDutyUserConfigUpdated(usernameUpdated, emailUpdated),
+				Config: testAccCheckPagerDutyUserConfigUpdated(usernameUpdated, emailUpdated, "observer"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyUserExists("pagerduty_user.foo"),
 					resource.TestCheckResourceAttr(
@@ -100,6 +100,22 @@ func TestAccPagerDutyUser_Basic(t *testing.T) {
 						"pagerduty_user.foo", "job_title", "bar"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_user.foo", "description", "bar"),
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyUserConfigUpdated(usernameUpdated, emailUpdated, "read_only_user"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyUserExists("pagerduty_user.foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_user.foo", "role", "read_only_user"),
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyUserConfigUpdated(usernameUpdated, emailUpdated, "restricted_access"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyUserExists("pagerduty_user.foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_user.foo", "role", "restricted_access"),
 				),
 			},
 		},
@@ -274,17 +290,17 @@ resource "pagerduty_user" "foo" {
 }`, username, email)
 }
 
-func testAccCheckPagerDutyUserConfigUpdated(username, email string) string {
+func testAccCheckPagerDutyUserConfigUpdated(username, email, role string) string {
 	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
   name        = "%s"
   email       = "%s"
   color       = "red"
-  role        = "observer"
+  role        = "%s"
   job_title   = "bar"
   description = "bar"
   time_zone   = "Europe/Dublin"
-}`, username, email)
+}`, username, email, role)
 }
 
 func testAccCheckPagerDutyUserWithTeamsConfig(team, username, email string) string {


### PR DESCRIPTION
Close #715 

## Test case extended...

```
$ PAGERDUTY_ACC_LICENSE_NAME="Full User" make testacc TESTARGS="-run TestAccPagerDutyUser"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccPagerDutyUser -timeout 120m
?       github.com/terraform-providers/terraform-provider-pagerduty     [no test files]
=== RUN   TestAccPagerDutyUserContactMethod_import
--- PASS: TestAccPagerDutyUserContactMethod_import (10.09s)
=== RUN   TestAccPagerDutyUserNotificationRule_import
--- PASS: TestAccPagerDutyUserNotificationRule_import (11.99s)
=== RUN   TestAccPagerDutyUser_import
--- PASS: TestAccPagerDutyUser_import (8.92s)
=== RUN   TestAccPagerDutyUserContactMethodEmail_Basic
--- PASS: TestAccPagerDutyUserContactMethodEmail_Basic (17.88s)
=== RUN   TestAccPagerDutyUserContactMethodPhone_Basic
--- PASS: TestAccPagerDutyUserContactMethodPhone_Basic (17.22s)
=== RUN   TestAccPagerDutyUserContactMethodPhone_EnforceUpdateIfAlreadyExist
--- PASS: TestAccPagerDutyUserContactMethodPhone_EnforceUpdateIfAlreadyExist (17.45s)
=== RUN   TestAccPagerDutyUserContactMethodSMS_Basic
--- PASS: TestAccPagerDutyUserContactMethodSMS_Basic (14.74s)
=== RUN   TestAccPagerDutyUserNotificationRuleContactMethod_Basic
--- PASS: TestAccPagerDutyUserNotificationRuleContactMethod_Basic (21.88s)
=== RUN   TestAccPagerDutyUserNotificationRuleContactMethod_Invalid
--- PASS: TestAccPagerDutyUserNotificationRuleContactMethod_Invalid (7.08s)
=== RUN   TestAccPagerDutyUserNotificationRuleContactMethod_Missing_id
--- PASS: TestAccPagerDutyUserNotificationRuleContactMethod_Missing_id (6.22s)
=== RUN   TestAccPagerDutyUserNotificationRuleContactMethod_Missing_type
--- PASS: TestAccPagerDutyUserNotificationRuleContactMethod_Missing_type (6.42s)
=== RUN   TestAccPagerDutyUserNotificationRuleContactMethod_Unknown_key
--- PASS: TestAccPagerDutyUserNotificationRuleContactMethod_Unknown_key (6.29s)
=== RUN   TestAccPagerDutyUser_Basic # 👈 This test case was extended
--- PASS: TestAccPagerDutyUser_Basic (23.31s)
=== RUN   TestAccPagerDutyUserWithTeams_Basic
--- PASS: TestAccPagerDutyUserWithTeams_Basic (19.89s)
=== RUN   TestAccPagerDutyUserWithLicenses_Basic
--- PASS: TestAccPagerDutyUserWithLicenses_Basic (12.19s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   202.160s
```