### PR TITLE
[TFPROVDEV-26] Add support for `SECURE` logging level

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-exec v0.15.0
 	github.com/hashicorp/terraform-json v0.13.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.1
-	github.com/heimweh/go-pagerduty v0.0.0-20230615223713-346f1359a346
+	github.com/heimweh/go-pagerduty v0.0.0-20230821205435-23a4af661dd7
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -668,8 +668,8 @@ github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/heimweh/go-pagerduty v0.0.0-20230615223713-346f1359a346 h1:ZPq/T5o8a6jcIJMPtjwadbXvbU/jc4b0DsVZlZ6iQNA=
-github.com/heimweh/go-pagerduty v0.0.0-20230615223713-346f1359a346/go.mod h1:t9vftsO1IjYHGdgJXeemZtomCWnxi2SRgu0PRcRb2oY=
+github.com/heimweh/go-pagerduty v0.0.0-20230821205435-23a4af661dd7 h1:3M7bz445Za+75nLsIcxn4u3Ld54LEJjhFdABjzT72qs=
+github.com/heimweh/go-pagerduty v0.0.0-20230821205435-23a4af661dd7/go.mod h1:t9vftsO1IjYHGdgJXeemZtomCWnxi2SRgu0PRcRb2oY=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/secure_logger.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/secure_logger.go
@@ -1,0 +1,135 @@
+package pagerduty
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+)
+
+const (
+	secureLogRequestHeading = `[SECURE] PagerDuty API Request Details:
+---[ REQUEST ]---------------------------------------`
+	secureLogResponseHeading = `[SECURE] PagerDuty API Response Details:
+---[ RESPONSE ]--------------------------------------`
+	secureLogBottomDelimiter = `-----------------------------------------------------`
+	obscuredLogTag           = `<OBSCURED>`
+)
+
+type secureLogger struct {
+	logger         *log.Logger
+	headersContent string
+	bodyContent    string
+	logsContent    string
+	canLog         bool
+}
+
+func (l *secureLogger) handleHeadersLogsContent(h http.Header) {
+	l.headersContent = ""
+	headers := make(http.Header)
+	for k, v := range h {
+		headers[k] = v
+	}
+
+	if _, ok := headers["Authorization"]; ok {
+		authHeader := headers["Authorization"][0]
+		last4AuthChars := authHeader
+		if len(authHeader) > 4 {
+			last4AuthChars = authHeader[len(authHeader)-4:]
+		}
+		headers["Authorization"] = []string{fmt.Sprintf("%s%s", obscuredLogTag, last4AuthChars)}
+	}
+
+	for k, v := range headers {
+		h := fmt.Sprintf("%s: %s", k, strings.Join(v, ";"))
+		l.headersContent = fmt.Sprintf("%s%s\n", l.headersContent, h)
+	}
+}
+
+func (l *secureLogger) handleBodyLogsContent(body io.ReadCloser) io.ReadCloser {
+	l.bodyContent = ""
+	if body != nil {
+		bodyBytes, err := io.ReadAll(body)
+		if err != nil {
+			log.Printf("[ERROR] Error reading body: %v\n", err)
+			return body
+		}
+
+		var jsonObj map[string]interface{}
+		err = json.Unmarshal(bodyBytes, &jsonObj)
+		if err != nil {
+			l.bodyContent = fmt.Sprintf("%s\n", string(bodyBytes))
+		} else {
+			prettyBody, err := json.MarshalIndent(jsonObj, "", " ")
+			if err != nil {
+				log.Printf("[ERROR] Error pretty-printing body: %v\n", err)
+			} else {
+				l.bodyContent = fmt.Sprintf("%s\n", prettyBody)
+			}
+		}
+
+		body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+	}
+
+	return body
+}
+
+func (l *secureLogger) putTogetherLogsContent(logsContent *string, heading string) {
+	content := *logsContent
+	content = fmt.Sprintf("%s\n%s\n%s\n", heading, content, l.headersContent)
+	if l.bodyContent != "" {
+		content = fmt.Sprintf("%s%s\n", content, l.bodyContent)
+	}
+
+	content = fmt.Sprintf("%s%s", content, secureLogBottomDelimiter)
+	*logsContent = content
+}
+
+func (l *secureLogger) LogReq(req *http.Request) {
+	if !l.canLog {
+		return
+	}
+
+	logsContent := fmt.Sprintf("%s %s %s", req.Method, req.URL.Path, req.Proto)
+	l.handleHeadersLogsContent(req.Header)
+	req.Body = l.handleBodyLogsContent(req.Body)
+	l.putTogetherLogsContent(&logsContent, secureLogRequestHeading)
+
+	l.logger.Print(logsContent)
+}
+
+func (l *secureLogger) LogRes(res *http.Response) {
+	if !l.canLog {
+		return
+	}
+
+	logsContent := fmt.Sprintf("%s %d %s", res.Proto, res.StatusCode, res.Status)
+	l.handleHeadersLogsContent(res.Header)
+	res.Body = l.handleBodyLogsContent(res.Body)
+	l.putTogetherLogsContent(&logsContent, secureLogResponseHeading)
+
+	l.logger.Print(logsContent)
+}
+
+func (l *secureLogger) SetCanLog(flag bool) {
+	l.canLog = flag
+}
+
+func newSecureLogger() *secureLogger {
+	pdLogFlag := os.Getenv("TF_LOG_PROVIDER_PAGERDUTY")
+	pdLogFlag = strings.ToUpper(pdLogFlag)
+	tfLogFlag := os.Getenv("TF_LOG")
+	tfLogFlag = strings.ToUpper(tfLogFlag)
+
+	secLogger := secureLogger{
+		logger: log.Default(),
+		canLog: tfLogFlag == "INFO" && pdLogFlag == "SECURE",
+	}
+	secLogger.logger.SetFlags(log.Flags() &^ (log.Ldate | log.Ltime))
+
+	return &secLogger
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -187,7 +187,7 @@ github.com/hashicorp/terraform-svchost
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 ## explicit
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20230615223713-346f1359a346
+# github.com/heimweh/go-pagerduty v0.0.0-20230821205435-23a4af661dd7
 ## explicit; go 1.17
 github.com/heimweh/go-pagerduty/pagerduty
 # github.com/klauspost/compress v1.15.9

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -57,3 +57,22 @@ The following arguments are supported:
 * `skip_credentials_validation` - (Optional) Skip validation of the token against the PagerDuty API.
 * `service_region` - (Optional) The PagerDuty service region to use. Default to empty (uses US region). Supported value: `eu`.
 * `api_url_override` - (Optional) It can be used to set a custom proxy endpoint as PagerDuty client api url overriding `service_region` setup.
+
+## Debugging Provider Output Using Logs
+
+In addition to the [log levels provided by Terraform](https://developer.hashicorp.com/terraform/internals/debugging), namely `TRACE`, `DEBUG`, `INFO`, `WARN`, and `ERROR` (in descending order of verbosity), the PagerDuty Provider introduces an extra level called `SECURE`. This level offers verbosity similar to Terraform's debug logging level, specifically for the output of API calls and HTTP request/response logs. The key difference is that API keys within the request's Authorization header will be obfuscated, revealing only the last four characters. An example is provided below:
+
+```sh
+---[ REQUEST ]---------------------------------------
+GET /teams/DER8RFS HTTP/1.1
+Accept: application/vnd.pagerduty+json;version=2
+Authorization: <OBSCURED>kCjQ
+Content-Type: application/json
+User-Agent: (darwin arm64) Terraform/1.5.1
+```
+
+To enable the `SECURE` log level, you must set two environment variables:
+
+* `TF_LOG=INFO`
+* `TF_LOG_PROVIDER_PAGERDUTY=SECURE`
+


### PR DESCRIPTION
This change is meant to add support for an extra logging level to the Provider called `SECURE`, which its purpose is to output logs for request/response API calls without disclosing the API Key at Authorization header.

## Documentation enhancement for Terraform Provider Overview section

![image](https://github.com/PagerDuty/terraform-provider-pagerduty/assets/24704624/21a44f7f-2b14-4851-a7dd-0d6d4e86b36a)

@depends on https://github.com/heimweh/go-pagerduty/pull/138