### PR TITLE
[TFPROVDEV-39] Update name validation func to not accept white spaces at the end

### DIFF
--- a/pagerduty/resource_pagerduty_escalation_policy_test.go
+++ b/pagerduty/resource_pagerduty_escalation_policy_test.go
@@ -120,6 +120,12 @@ func TestAccPagerDutyEscalationPolicy_FormatValidation(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyEscalationPolicyDestroy,
 		Steps: []resource.TestStep{
+			// Just a valid name
+			{
+				Config:             testAccCheckPagerDutyEscalationPolicyConfig(username, email, "SRE Escalation Policy"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
 			// Blank Name
 			{
 				Config:      testAccCheckPagerDutyEscalationPolicyConfig(username, email, ""),

--- a/pagerduty/resource_pagerduty_escalation_policy_test.go
+++ b/pagerduty/resource_pagerduty_escalation_policy_test.go
@@ -113,6 +113,7 @@ func TestAccPagerDutyEscalationPolicy_Basic(t *testing.T) {
 func TestAccPagerDutyEscalationPolicy_FormatValidation(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	email := fmt.Sprintf("%s@foo.test", username)
+	errMessageMatcher := "Name must not be blank, nor contain the characters.*, or any non-printable characters. White spaces at the end are also not allowed."
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -123,13 +124,25 @@ func TestAccPagerDutyEscalationPolicy_FormatValidation(t *testing.T) {
 			{
 				Config:      testAccCheckPagerDutyEscalationPolicyConfig(username, email, ""),
 				PlanOnly:    true,
-				ExpectError: regexp.MustCompile("Name can't be blank neither contain.*, nor non-printable characters."),
+				ExpectError: regexp.MustCompile(errMessageMatcher),
 			},
 			// Name with & in it
 			{
 				Config:      testAccCheckPagerDutyEscalationPolicyConfig(username, email, "this name has an ampersand (&)"),
 				PlanOnly:    true,
-				ExpectError: regexp.MustCompile("Name can't be blank neither contain.*, nor non-printable characters."),
+				ExpectError: regexp.MustCompile(errMessageMatcher),
+			},
+			// Name with one white space at the end
+			{
+				Config:      testAccCheckPagerDutyEscalationPolicyConfig(username, email, "this name has a white space at the end "),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(errMessageMatcher),
+			},
+			// Name with multiple white space at the end
+			{
+				Config:      testAccCheckPagerDutyEscalationPolicyConfig(username, email, "this name has white spaces at the end    "),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(errMessageMatcher),
 			},
 		},
 	})

--- a/pagerduty/resource_pagerduty_service_test.go
+++ b/pagerduty/resource_pagerduty_service_test.go
@@ -141,6 +141,12 @@ func TestAccPagerDutyService_FormatValidation(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyServiceDestroy,
 		Steps: []resource.TestStep{
+			// Just a valid name
+			{
+				Config:             testAccCheckPagerDutyServiceConfig(username, email, escalationPolicy, "DB Technical Service"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
 			// Blank Name
 			{
 				Config:      testAccCheckPagerDutyServiceConfig(username, email, escalationPolicy, ""),

--- a/pagerduty/resource_pagerduty_service_test.go
+++ b/pagerduty/resource_pagerduty_service_test.go
@@ -134,6 +134,7 @@ func TestAccPagerDutyService_FormatValidation(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	email := fmt.Sprintf("%s@foo.test", username)
 	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	errMessageMatcher := "Name must not be blank, nor contain the characters.*, or any non-printable characters. White spaces at the end are also not allowed."
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -144,13 +145,25 @@ func TestAccPagerDutyService_FormatValidation(t *testing.T) {
 			{
 				Config:      testAccCheckPagerDutyServiceConfig(username, email, escalationPolicy, ""),
 				PlanOnly:    true,
-				ExpectError: regexp.MustCompile("Name can't be blank neither contain.*, nor non-printable characters."),
+				ExpectError: regexp.MustCompile(errMessageMatcher),
 			},
 			// Name with & in it
 			{
 				Config:      testAccCheckPagerDutyServiceConfig(username, email, escalationPolicy, "this name has an ampersand (&)"),
 				PlanOnly:    true,
-				ExpectError: regexp.MustCompile("Name can't be blank neither contain.*, nor non-printable characters."),
+				ExpectError: regexp.MustCompile(errMessageMatcher),
+			},
+			// Name with one white space at the end
+			{
+				Config:      testAccCheckPagerDutyServiceConfig(username, email, escalationPolicy, "this name has a white space at the end "),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(errMessageMatcher),
+			},
+			// Name with multiple white space at the end
+			{
+				Config:      testAccCheckPagerDutyServiceConfig(username, email, escalationPolicy, "this name has white spaces at the end    "),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(errMessageMatcher),
 			},
 		},
 	})

--- a/pagerduty/util.go
+++ b/pagerduty/util.go
@@ -118,13 +118,13 @@ func validateCantBeBlankOrNotPrintableChars(v interface{}, p cty.Path) diag.Diag
 	var diags diag.Diagnostics
 
 	value := v.(string)
-	matcher := regexp.MustCompile(`^$|^[ ]+$|[/\\<>&]`)
+	matcher := regexp.MustCompile(`^$|^[ ]+$|[/\\<>&]|\s+$`)
 	matches := matcher.MatchString(value)
 
 	if matches {
 		diags = append(diags, diag.Diagnostic{
 			Severity:      diag.Error,
-			Summary:       "Name can't be blank neither contain '\\', '/', '&', '<', '>', nor non-printable characters.",
+			Summary:       "Name must not be blank, nor contain the characters '\\', '/', '&', '<', '>', or any non-printable characters. White spaces at the end are also not allowed.",
 			AttributePath: p,
 		})
 	}


### PR DESCRIPTION
Address: https://github.com/PagerDuty/terraform-provider-pagerduty/pull/712#issuecomment-1660654613

## Test cases extended...

```
$ make testacc TESTARGS="-count=1 -run TestAccPagerDutyEscalationPolicy_FormatValidation"                                                                                                   2 ↵
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -count=1 -run TestAccPagerDutyEscalationPolicy_FormatValidation -timeout 120m
?       github.com/terraform-providers/terraform-provider-pagerduty     [no test files]
=== RUN   TestAccPagerDutyEscalationPolicy_FormatValidation
--- PASS: TestAccPagerDutyEscalationPolicy_FormatValidation (0.86s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   1.342s
$ make testacc TESTARGS="-count=1 -run TestAccPagerDutyService_FormatValidation"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -count=1 -run TestAccPagerDutyService_FormatValidation -timeout 120m
?       github.com/terraform-providers/terraform-provider-pagerduty     [no test files]
=== RUN   TestAccPagerDutyService_FormatValidation
--- PASS: TestAccPagerDutyService_FormatValidation (0.76s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   0.999s


```