### PR TITLE
Fix - Provider crashing on Terraform state snapshot validation

### DIFF
--- a/pagerduty/terraform_state_snapshot_helper.go
+++ b/pagerduty/terraform_state_snapshot_helper.go
@@ -29,7 +29,7 @@ func (state *tfStateSnapshot) GetResourceStateById(id string) *tfjson.StateResou
 		return resourceState
 	}
 	for _, s := range state.State.Values.RootModule.Resources {
-		if s.AttributeValues["id"].(string) == id {
+		if resId, ok := s.AttributeValues["id"].(string); ok && resId == id {
 			resourceState = s
 			break
 		}


### PR DESCRIPTION
Fixes following Provider crashing scenario...

```
Error: Plugin did not respond The plugin encountered an error, and failed to respond to the plugin.(*GRPCProvider).ApplyResourceChange call. The plugin logs may contain more details. Stack trace from the terraform-provider-pagerduty_v2.15.3 plugin: panic: interface conversion:
interface {} is nil, not string goroutine 185 [running]: [github.com/terraform-providers/terraform-provider-pagerduty](https://github.com/terraform-providers/terraform-provider-pagerduty)/pagerduty.(*tfStateSnapshot).GetResourceStateById(0xc000b82020, {0xc000a88688, 0x7})
[github.com/terraform-providers/terraform-provider-pagerduty/pagerduty/terraform_state_snapshot_helper.go:32](https://github.com/terraform-providers/terraform-provider-pagerduty/pagerduty/terraform_state_snapshot_helper.go:32) +0x13d [github.com/terraform-providers/terraform-provider-pagerduty/pagerduty.detectUseOfScheduleByEPsWithOneLayer](https://github.com/terraform-providers/terraform-provider-pagerduty/pagerduty.detectUseOfScheduleByEPsWithOneLayer)({0xc000b2c1f6, 0x7}, {0xc0005d2118, 0x1, 0x1}) [github.com/terraform-providers/terraform-provider-pagerduty/pagerduty/resource_pagerduty_schedule.go:829](https://github.com/terraform-providers/terraform-provider-pagerduty/pagerduty/resource_pagerduty_schedule.go:829) +0x2b7 [github.com/terraform-providers/terraform-provider-pagerduty/pagerduty.resourcePagerDutyScheduleDelete.func2()](https://github.com/terraform-providers/terraform-provider-pagerduty/pagerduty.resourcePagerDutyScheduleDelete.func2()) [github.com/terraform-providers/terraform-provider-pagerduty/pagerduty/resource_pagerduty_schedule.go:470](https://github.com/terraform-providers/terraform-provider-pagerduty/pagerduty/resource_pagerduty_schedule.go:470) +0x3c9 [github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource.RetryContext.func1()](https://github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource.RetryContext.func1()) [github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.1/helper/resource/wait.go:27](https://github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.1/helper/resource/wait.go:27) +0x56 [github.com/hashicorp/terraform-plugin-sdk/v2/helper](https://github.com/hashicorp/terraform-plugin-sdk/v2/helper)/resource.(*StateChangeConf).WaitForStateContext.func1() [github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.1/helper/resource/state.go:110](https://github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.1/helper/resource/state.go:110) +0x21f created by [github.com/hashicorp/terraform-plugin-sdk/v2/helper](https://github.com/hashicorp/terraform-plugin-sdk/v2/helper)/resource.(*StateChangeConf).WaitForStateContext [github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.1/helper/resource/state.go:83](https://github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.1/helper/resource/state.go:83) +0x1dd Error: The terraform-provider-pagerduty_v2.15.3 plugin crashed! This is always indicative of a bug within the plugin. It would be immensely helpful if you could report the crash with the plugin's maintainers so that it can be fixed. The output above should help diagnose the issue.
```

## Acceptance tests results...

```
$ PAGERDUTY_ACC_SCHEDULE_USED_BY_EP_W_1_LAYER=1 make testacc TESTARGS="-count=1 -run TestAccPagerDutySchedule"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -count=1 -run TestAccPagerDutySchedule -timeout 120m
?       github.com/terraform-providers/terraform-provider-pagerduty     [no test files]
=== RUN   TestAccPagerDutySchedule_import
--- PASS: TestAccPagerDutySchedule_import (12.07s)
=== RUN   TestAccPagerDutySchedule_Basic
--- PASS: TestAccPagerDutySchedule_Basic (21.80s)
=== RUN   TestAccPagerDutyScheduleWithTeams_Basic
--- PASS: TestAccPagerDutyScheduleWithTeams_Basic (15.93s)
=== RUN   TestAccPagerDutySchedule_BasicWithExternalDestroyHandling
--- PASS: TestAccPagerDutySchedule_BasicWithExternalDestroyHandling (12.70s)
=== RUN   TestAccPagerDutyScheduleWithTeams_EscalationPolicyDependant
--- PASS: TestAccPagerDutyScheduleWithTeams_EscalationPolicyDependant (21.61s)
=== RUN   TestAccPagerDutyScheduleWithTeams_EscalationPolicyDependantWithOneLayer
--- PASS: TestAccPagerDutyScheduleWithTeams_EscalationPolicyDependantWithOneLayer (54.92s)
=== RUN   TestAccPagerDutyScheduleWithTeams_EscalationPolicyDependantWithOpenIncidents
--- PASS: TestAccPagerDutyScheduleWithTeams_EscalationPolicyDependantWithOpenIncidents (53.96s)
=== RUN   TestAccPagerDutySchedule_EscalationPolicyDependantWithOpenIncidents
--- PASS: TestAccPagerDutySchedule_EscalationPolicyDependantWithOpenIncidents (55.24s)
=== RUN   TestAccPagerDutyScheduleOverflow_Basic
--- PASS: TestAccPagerDutyScheduleOverflow_Basic (13.89s)
=== RUN   TestAccPagerDutySchedule_BasicWeek
--- PASS: TestAccPagerDutySchedule_BasicWeek (14.23s)
=== RUN   TestAccPagerDutySchedule_Multi
--- PASS: TestAccPagerDutySchedule_Multi (15.09s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   291.783s
```