### PR TITLE
add missing properties to incident_custom_field resource documentation

### DIFF
--- a/website/docs/r/incident_custom_field.html.markdown
+++ b/website/docs/r/incident_custom_field.html.markdown
@@ -14,15 +14,25 @@ An [Incident Custom Field](https://support.pagerduty.com/docs/custom-fields-on-i
 
 ```hcl
 resource "pagerduty_incident_custom_field" "cs_impact" {
-  name       = "impact"
-  data_type  = "string"
-  field_type = "single_value"
+  name         = "impact"
+  display_name = "Customer Impact"
+  data_type    = "string"
+  field_type   = "single_value"
 }
 
 resource "pagerduty_incident_custom_field" "sre_environment" {
-  name       = "environment"
-  data_type  = "string"
-  field_type = "single_value_fixed"
+  name         = "environment"
+  display_name = "Environment"
+  data_type    = "string"
+  field_type   = "single_value_fixed"
+}
+
+resource "pagerduty_incident_custom_field" "false_alarm" {
+  name          = "false_alarm"
+  display_name  = "False Alarm"
+  data_type     = "boolean"
+  field_type    = "single_value"
+  default_value = "false"
 }
 ```
 
@@ -31,8 +41,11 @@ resource "pagerduty_incident_custom_field" "sre_environment" {
 The following arguments are supported:
 
   * `name` - (Required) The name of the field.
+  * `display_name` - (Required) The display name of the field.
+  * `description` - (Optional) The description of the field.
   * `data_type` - (Required) The data type of the field. Must be one of `string`, `integer`, `float`, `boolean`, `datetime`, or `url`.
-  * `field_type` - (Required) The field type of the field. Must be one of `single_value`, `single_value_fixed`, `multi_value`, or `multi_value_fixed`. 
+  * `field_type` - (Required) The field type of the field. Must be one of `single_value`, `single_value_fixed`, `multi_value`, or `multi_value_fixed`.
+  * `default_value` - (Optional) The default value to set when new incidents are created. Always specified as a string.
 
 ## Attributes Reference
 

--- a/website/docs/r/incident_custom_field_option.html.markdown
+++ b/website/docs/r/incident_custom_field_option.html.markdown
@@ -15,15 +15,16 @@ i.e. has the `field_type` of `single_value_fixed` or `multi_value_fixed`.
 
 ```hcl
 resource "pagerduty_incident_custom_field" "sre_environment" {
-  name       = "environment"
-  data_type   = "string"
-  field_type = "single_value_fixed"
+  name         = "environment"
+  display_name = "Environment"
+  data_type    = "string"
+  field_type   = "single_value_fixed"
 }
 
 resource "pagerduty_incident_custom_field_option" "dev_environment" {
-  field    = pagerduty_incident_custom_field.sre_environment.id
+  field     = pagerduty_incident_custom_field.sre_environment.id
   data_type = "string"
-  value    = "dev"
+  value     = "dev"
 }
 
 resource "pagerduty_incident_custom_field_option" "stage_environment" {


### PR DESCRIPTION
It appears that in executing the series of changes related to the `incident_custom_field` resource, the documentation ended up in a state where a subset of properties were omitted. Of chief import is that the `display_name` property is not documented -- this is required and thus really important to have documented correctly.

Closes #767 