### PR TITLE
[TFPROVDEV-77] Update name validation logic for technical services

### DIFF
--- a/pagerduty/resource_pagerduty_escalation_policy.go
+++ b/pagerduty/resource_pagerduty_escalation_policy.go
@@ -25,7 +25,7 @@ func resourcePagerDutyEscalationPolicy() *schema.Resource {
 			"name": {
 				Type:             schema.TypeString,
 				Required:         true,
-				ValidateDiagFunc: validateCantBeBlankOrNotPrintableChars,
+				ValidateDiagFunc: validateIsAllowedString(NoNonPrintableCharsOrSpecialChars),
 			},
 			"description": {
 				Type:     schema.TypeString,

--- a/pagerduty/resource_pagerduty_escalation_policy_test.go
+++ b/pagerduty/resource_pagerduty_escalation_policy_test.go
@@ -113,7 +113,7 @@ func TestAccPagerDutyEscalationPolicy_Basic(t *testing.T) {
 func TestAccPagerDutyEscalationPolicy_FormatValidation(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	email := fmt.Sprintf("%s@foo.test", username)
-	errMessageMatcher := "Name must not be blank, nor contain the characters.*, or any non-printable characters. White spaces at the end are also not allowed."
+	errMessageMatcher := "Name can not be blank, nor contain the characters.*, or any non-printable characters. Trailing white spaces are not allowed either."
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -147,6 +147,12 @@ func TestAccPagerDutyEscalationPolicy_FormatValidation(t *testing.T) {
 			// Name with multiple white space at the end
 			{
 				Config:      testAccCheckPagerDutyEscalationPolicyConfig(username, email, "this name has white spaces at the end    "),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(errMessageMatcher),
+			},
+			// Name with non printable characters
+			{
+				Config:      testAccCheckPagerDutyEscalationPolicyConfig(username, email, "this name has a non printable\\n character"),
 				PlanOnly:    true,
 				ExpectError: regexp.MustCompile(errMessageMatcher),
 			},

--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -37,7 +37,7 @@ func resourcePagerDutyService() *schema.Resource {
 			"name": {
 				Type:             schema.TypeString,
 				Required:         true,
-				ValidateDiagFunc: validateCantBeBlankOrNotPrintableChars,
+				ValidateDiagFunc: validateIsAllowedString(NoNonPrintableChars),
 			},
 			"html_url": {
 				Type:     schema.TypeString,

--- a/pagerduty/resource_pagerduty_service_test.go
+++ b/pagerduty/resource_pagerduty_service_test.go
@@ -134,7 +134,7 @@ func TestAccPagerDutyService_FormatValidation(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	email := fmt.Sprintf("%s@foo.test", username)
 	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	errMessageMatcher := "Name must not be blank, nor contain the characters.*, or any non-printable characters. White spaces at the end are also not allowed."
+	errMessageMatcher := "Name can not be blank, nor contain non-printable characters. Trailing white spaces are not allowed either."
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -153,12 +153,6 @@ func TestAccPagerDutyService_FormatValidation(t *testing.T) {
 				PlanOnly:    true,
 				ExpectError: regexp.MustCompile(errMessageMatcher),
 			},
-			// Name with & in it
-			{
-				Config:      testAccCheckPagerDutyServiceConfig(username, email, escalationPolicy, "this name has an ampersand (&)"),
-				PlanOnly:    true,
-				ExpectError: regexp.MustCompile(errMessageMatcher),
-			},
 			// Name with one white space at the end
 			{
 				Config:      testAccCheckPagerDutyServiceConfig(username, email, escalationPolicy, "this name has a white space at the end "),
@@ -168,6 +162,12 @@ func TestAccPagerDutyService_FormatValidation(t *testing.T) {
 			// Name with multiple white space at the end
 			{
 				Config:      testAccCheckPagerDutyServiceConfig(username, email, escalationPolicy, "this name has white spaces at the end    "),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(errMessageMatcher),
+			},
+			// Name with non printable characters
+			{
+				Config:      testAccCheckPagerDutyServiceConfig(username, email, escalationPolicy, "this name has a non printable\\n character"),
 				PlanOnly:    true,
 				ExpectError: regexp.MustCompile(errMessageMatcher),
 			},


### PR DESCRIPTION
Address: https://github.com/PagerDuty/terraform-provider-pagerduty/pull/731#discussion_r1332438910

## Test cases extended...

```sh
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -count=1 -run TestAccPagerDutyService_FormatValidation -timeout 120m
?       github.com/terraform-providers/terraform-provider-pagerduty     [no test files]
=== RUN   TestAccPagerDutyService_FormatValidation
--- PASS: TestAccPagerDutyService_FormatValidation (1.35s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   1.868s
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -count=1 -run TestAccPagerDutyEscalationPolicy_FormatValidation -timeout 120m
?       github.com/terraform-providers/terraform-provider-pagerduty     [no test files]
=== RUN   TestAccPagerDutyEscalationPolicy_FormatValidation
--- PASS: TestAccPagerDutyEscalationPolicy_FormatValidation (1.18s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   1.492s

```