### PR TITLE
Ensure case-insensitive email search

### DIFF
--- a/pagerduty/data_source_pagerduty_user.go
+++ b/pagerduty/data_source_pagerduty_user.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -58,7 +59,7 @@ func dataSourcePagerDutyUserRead(d *schema.ResourceData, meta interface{}) error
 		var found *pagerduty.FullUser
 
 		for _, user := range resp {
-			if user.Email == searchEmail {
+			if strings.EqualFold(user.Email, searchEmail) {
 				found = user
 				break
 			}


### PR DESCRIPTION
Now, when users search for someone by email, it's case-sensitive. Updated to returns results irrespective of the letter casing in the provided email.