### PR TITLE
[CSGI-1926] Add delays to API calls retries lacking of them on various TF Objects

### DIFF
--- a/pagerduty/data_source_pagerduty_event_orchestration.go
+++ b/pagerduty/data_source_pagerduty_event_orchestration.go
@@ -74,6 +74,9 @@ func dataSourcePagerDutyEventOrchestrationRead(d *schema.ResourceData, meta inte
 				return resource.NonRetryableError(err)
 			}
 
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		}
 
@@ -96,6 +99,9 @@ func dataSourcePagerDutyEventOrchestrationRead(d *schema.ResourceData, meta inte
 		// since the list ndpoint does not return it
 		orch, _, err := client.EventOrchestrations.Get(found.ID)
 		if err != nil {
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		}
 

--- a/pagerduty/data_source_pagerduty_event_orchestrations.go
+++ b/pagerduty/data_source_pagerduty_event_orchestrations.go
@@ -91,6 +91,7 @@ func dataSourcePagerDutyEventOrchestrationsRead(d *schema.ResourceData, meta int
 				return resource.NonRetryableError(err)
 			}
 
+			time.Sleep(10 * time.Second)
 			return resource.RetryableError(err)
 		}
 
@@ -125,6 +126,7 @@ func dataSourcePagerDutyEventOrchestrationsRead(d *schema.ResourceData, meta int
 					return resource.NonRetryableError(err)
 				}
 
+				time.Sleep(10 * time.Second)
 				return resource.RetryableError(err)
 			}
 			orchestrations = append(orchestrations, orch)

--- a/pagerduty/resource_pagerduty_automation_actions_action.go
+++ b/pagerduty/resource_pagerduty_automation_actions_action.go
@@ -344,6 +344,9 @@ func resourcePagerDutyAutomationActionsActionDelete(d *schema.ResourceData, meta
 				return resource.NonRetryableError(err)
 			}
 
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		}
 		return nil

--- a/pagerduty/resource_pagerduty_automation_actions_action_service_association.go
+++ b/pagerduty/resource_pagerduty_automation_actions_action_service_association.go
@@ -120,6 +120,9 @@ func resourcePagerDutyAutomationActionsActionServiceAssociationDelete(d *schema.
 				return resource.NonRetryableError(err)
 			}
 
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		}
 		return nil

--- a/pagerduty/resource_pagerduty_automation_actions_action_team_association.go
+++ b/pagerduty/resource_pagerduty_automation_actions_action_team_association.go
@@ -124,6 +124,9 @@ func resourcePagerDutyAutomationActionsActionTeamAssociationDelete(d *schema.Res
 				return resource.NonRetryableError(err)
 			}
 
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		}
 		return nil

--- a/pagerduty/resource_pagerduty_automation_actions_runner.go
+++ b/pagerduty/resource_pagerduty_automation_actions_runner.go
@@ -206,6 +206,9 @@ func resourcePagerDutyAutomationActionsRunnerDelete(d *schema.ResourceData, meta
 				return resource.NonRetryableError(err)
 			}
 
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		}
 		return nil

--- a/pagerduty/resource_pagerduty_automation_actions_runner_team_association.go
+++ b/pagerduty/resource_pagerduty_automation_actions_runner_team_association.go
@@ -120,6 +120,9 @@ func resourcePagerDutyAutomationActionsRunnerTeamAssociationDelete(d *schema.Res
 				return resource.NonRetryableError(err)
 			}
 
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		}
 		return nil

--- a/pagerduty/resource_pagerduty_business_service.go
+++ b/pagerduty/resource_pagerduty_business_service.go
@@ -107,6 +107,9 @@ func resourcePagerDutyBusinessServiceCreate(d *schema.ResourceData, meta interfa
 		}
 		log.Printf("[INFO] Creating PagerDuty business service %s", businessService.Name)
 		if businessService, _, err = client.BusinessServices.Create(businessService); err != nil {
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		} else if businessService != nil {
 			d.SetId(businessService.ID)
@@ -135,6 +138,9 @@ func resourcePagerDutyBusinessServiceRead(d *schema.ResourceData, meta interface
 				return resource.NonRetryableError(err)
 			}
 
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		} else if businessService != nil {
 			d.Set("name", businessService.Name)

--- a/pagerduty/resource_pagerduty_business_service_subscriber.go
+++ b/pagerduty/resource_pagerduty_business_service_subscriber.go
@@ -70,6 +70,9 @@ func resourcePagerDutyBusinessServiceSubscriberCreate(d *schema.ResourceData, me
 
 		log.Printf("[INFO] Creating PagerDuty business service %s subscriber %s type %s", businessServiceId, businessServiceSubscriber.ID, businessServiceSubscriber.Type)
 		if _, err = client.BusinessServiceSubscribers.Create(businessServiceId, businessServiceSubscriber); err != nil {
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		} else if businessServiceSubscriber != nil {
 			// create subscriber assignment it as PagerDuty API does not return one

--- a/pagerduty/resource_pagerduty_escalation_policy.go
+++ b/pagerduty/resource_pagerduty_escalation_policy.go
@@ -198,6 +198,9 @@ func resourcePagerDutyEscalationPolicyUpdate(d *schema.ResourceData, meta interf
 
 	retryErr := resource.Retry(5*time.Minute, func() *resource.RetryError {
 		if _, _, err := client.EscalationPolicies.Update(d.Id(), escalationPolicy); err != nil {
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		}
 		return nil
@@ -222,6 +225,7 @@ func resourcePagerDutyEscalationPolicyDelete(d *schema.ResourceData, meta interf
 	retryErr := resource.Retry(30*time.Second, func() *resource.RetryError {
 		if _, err := client.EscalationPolicies.Delete(d.Id()); err != nil {
 			if isErrCode(err, 400) {
+				time.Sleep(10 * time.Second)
 				return resource.RetryableError(err)
 			}
 

--- a/pagerduty/resource_pagerduty_event_orchestration.go
+++ b/pagerduty/resource_pagerduty_event_orchestration.go
@@ -110,6 +110,7 @@ func resourcePagerDutyEventOrchestrationCreate(d *schema.ResourceData, meta inte
 	retryErr := resource.Retry(10*time.Second, func() *resource.RetryError {
 		if orch, _, err := client.EventOrchestrations.Create(payload); err != nil {
 			if isErrCode(err, 400) || isErrCode(err, 429) {
+				time.Sleep(2 * time.Second)
 				return resource.RetryableError(err)
 			}
 
@@ -171,6 +172,7 @@ func resourcePagerDutyEventOrchestrationUpdate(d *schema.ResourceData, meta inte
 	retryErr := resource.Retry(10*time.Second, func() *resource.RetryError {
 		if _, _, err := client.EventOrchestrations.Update(d.Id(), orchestration); err != nil {
 			if isErrCode(err, 400) || isErrCode(err, 429) {
+				time.Sleep(2 * time.Second)
 				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)

--- a/pagerduty/resource_pagerduty_event_orchestration_integration.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_integration.go
@@ -120,10 +120,14 @@ func resourcePagerDutyEventOrchestrationIntegrationCreate(ctx context.Context, d
 			if isErrCode(err, 400) {
 				return resource.NonRetryableError(err)
 			}
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		} else if integration != nil {
 			// Try reading an integration after creation, retry if not found:
 			if _, readErr := fetchPagerDutyEventOrchestrationIntegration(ctx, d, meta, oid, integration.ID, true); readErr != nil {
+				time.Sleep(30 * time.Second)
 				log.Printf("[WARN] Cannot locate Integration '%s' on PagerDuty Event Orchestration '%s'. Retrying creation...", integration.ID, oid)
 				return resource.RetryableError(readErr)
 			}
@@ -151,6 +155,9 @@ func resourcePagerDutyEventOrchestrationIntegrationRead(ctx context.Context, d *
 				return resource.NonRetryableError(err)
 			}
 
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		}
 
@@ -185,6 +192,9 @@ func resourcePagerDutyEventOrchestrationIntegrationUpdate(ctx context.Context, d
 				if isErrCode(err, 400) {
 					return resource.NonRetryableError(err)
 				}
+				// Delaying retry by 30s as recommended by PagerDuty
+				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			} else {
 				// try reading the migrated integration from destination and source:
@@ -193,12 +203,14 @@ func resourcePagerDutyEventOrchestrationIntegrationUpdate(ctx context.Context, d
 
 				// retry migration if the read request returned an error:
 				if readDestErr != nil {
+					time.Sleep(30 * time.Second)
 					log.Printf("[WARN] Integration '%s' cannot be found on the destination PagerDuty Event Orchestration '%s'. Retrying migration....", id, destinationOrchId)
 					return resource.RetryableError(readDestErr)
 				}
 
 				// retry migration if the integration still exists on the source:
 				if readSrcErr == nil && srcInt != nil {
+					time.Sleep(30 * time.Second)
 					log.Printf("[WARN] Integration '%s' still exists on the source PagerDuty Event Orchestration '%s'. Retrying migration....", id, sourceOrchId)
 					return resource.RetryableError(fmt.Errorf("Integration '%s' still exists on the source PagerDuty Event Orchestration '%s'.", id, sourceOrchId))
 				}
@@ -227,6 +239,9 @@ func resourcePagerDutyEventOrchestrationIntegrationUpdate(ctx context.Context, d
 			} else if integration != nil {
 				// Try reading an integration after updating the label, retry if the label is not updated:
 				if updInt, readErr := fetchPagerDutyEventOrchestrationIntegration(ctx, d, meta, oid, id, true); readErr != nil && updInt != nil {
+					// Delaying retry by 30s as recommended by PagerDuty
+					// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+					time.Sleep(30 * time.Second)
 					log.Printf("[WARN] Label for Integration '%s' on PagerDuty Event Orchestration '%s' was not updated. Expected: '%s', actual: '%s'. Retrying update...", id, oid, payload.Label, updInt.Label)
 					return resource.RetryableError(readErr)
 				}
@@ -259,10 +274,14 @@ func resourcePagerDutyEventOrchestrationIntegrationDelete(ctx context.Context, d
 				return resource.NonRetryableError(err)
 			}
 
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		} else {
 			// Try reading an integration after deletion, retry if still found:
 			if integr, _, readErr := client.EventOrchestrationIntegrations.GetContext(ctx, oid, id); readErr == nil && integr != nil {
+				time.Sleep(30 * time.Second)
 				log.Printf("[WARN] Integration '%s' still exists on PagerDuty Event Orchestration '%s'. Retrying deletion...", id, oid)
 				return resource.RetryableError(fmt.Errorf("Integration '%s' still exists on PagerDuty Event Orchestration '%s'.", id, oid))
 			}
@@ -295,6 +314,9 @@ func resourcePagerDutyEventOrchestrationIntegrationImport(ctx context.Context, d
 				return resource.NonRetryableError(err)
 			}
 
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		}
 		return nil

--- a/pagerduty/resource_pagerduty_event_orchestration_path_global.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_global.go
@@ -220,6 +220,7 @@ func resourcePagerDutyEventOrchestrationPathGlobalUpdate(ctx context.Context, d 
 				return resource.NonRetryableError(err)
 			}
 
+			time.Sleep(10 * time.Second)
 			return resource.RetryableError(err)
 		} else if response != nil {
 			d.SetId(response.OrchestrationPath.Parent.ID)
@@ -257,6 +258,7 @@ func resourcePagerDutyEventOrchestrationPathGlobalDelete(ctx context.Context, d 
 				return resource.NonRetryableError(err)
 			}
 
+			time.Sleep(10 * time.Second)
 			return resource.RetryableError(err)
 		}
 		return nil

--- a/pagerduty/resource_pagerduty_event_orchestration_path_router.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_router.go
@@ -176,6 +176,7 @@ func resourcePagerDutyEventOrchestrationPathRouterDelete(ctx context.Context, d 
 				return resource.NonRetryableError(err)
 			}
 
+			time.Sleep(10 * time.Second)
 			return resource.RetryableError(err)
 		}
 		return nil
@@ -209,6 +210,7 @@ func resourcePagerDutyEventOrchestrationPathRouterUpdate(ctx context.Context, d 
 				return resource.NonRetryableError(err)
 			}
 
+			time.Sleep(10 * time.Second)
 			return resource.RetryableError(err)
 		}
 		if response == nil {

--- a/pagerduty/resource_pagerduty_event_orchestration_path_service.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_service.go
@@ -266,6 +266,7 @@ func resourcePagerDutyEventOrchestrationPathServiceUpdate(ctx context.Context, d
 				return resource.NonRetryableError(err)
 			}
 
+			time.Sleep(10 * time.Second)
 			return resource.RetryableError(err)
 		} else if response != nil {
 			d.SetId(response.OrchestrationPath.Parent.ID)
@@ -349,6 +350,7 @@ func resourcePagerDutyEventOrchestrationPathServiceDelete(ctx context.Context, d
 				return resource.NonRetryableError(err)
 			}
 
+			time.Sleep(10 * time.Second)
 			return resource.RetryableError(err)
 		}
 		return nil

--- a/pagerduty/resource_pagerduty_event_orchestration_path_unrouted.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_unrouted.go
@@ -226,6 +226,7 @@ func resourcePagerDutyEventOrchestrationPathUnroutedDelete(ctx context.Context, 
 				return resource.NonRetryableError(err)
 			}
 
+			time.Sleep(10 * time.Second)
 			return resource.RetryableError(err)
 		}
 		return nil
@@ -259,6 +260,7 @@ func resourcePagerDutyEventOrchestrationPathUnroutedUpdate(ctx context.Context, 
 				return resource.NonRetryableError(err)
 			}
 
+			time.Sleep(10 * time.Second)
 			return resource.RetryableError(err)
 		}
 

--- a/pagerduty/resource_pagerduty_service_dependency.go
+++ b/pagerduty/resource_pagerduty_service_dependency.go
@@ -157,6 +157,9 @@ func resourcePagerDutyServiceDependencyAssociate(ctx context.Context, d *schema.
 
 		if err != nil {
 			if isErrCode(err, 404) {
+				// Delaying retry by 30s as recommended by PagerDuty
+				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)
@@ -202,7 +205,6 @@ func resourcePagerDutyServiceDependencyDisassociate(ctx context.Context, d *sche
 			// Delaying retry by 30s as recommended by PagerDuty
 			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
 			time.Sleep(30 * time.Second)
-
 			return resource.RetryableError(err)
 		} else if dependencies != nil {
 			for _, rel := range dependencies.Relationships {
@@ -247,7 +249,6 @@ func resourcePagerDutyServiceDependencyDisassociate(ctx context.Context, d *sche
 			// Delaying retry by 30s as recommended by PagerDuty
 			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
 			time.Sleep(30 * time.Second)
-
 			return resource.RetryableError(err)
 		}
 		return nil
@@ -326,7 +327,6 @@ func findDependencySetState(ctx context.Context, depID, serviceID, serviceType s
 			// Delaying retry by 30s as recommended by PagerDuty
 			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
 			time.Sleep(30 * time.Second)
-
 			return resource.RetryableError(err)
 		} else if dependencies != nil {
 			depFound := false

--- a/pagerduty/resource_pagerduty_service_event_rule.go
+++ b/pagerduty/resource_pagerduty_service_event_rule.go
@@ -346,6 +346,9 @@ func resourcePagerDutyServiceEventRuleCreate(d *schema.ResourceData, meta interf
 				return resource.NonRetryableError(err)
 			}
 
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		} else if rule != nil {
 			d.SetId(rule.ID)
@@ -421,8 +424,10 @@ func resourcePagerDutyServiceEventRuleUpdate(d *schema.ResourceData, meta interf
 				return resource.NonRetryableError(err)
 			}
 
+			time.Sleep(5 * time.Second)
 			return resource.RetryableError(err)
 		} else if rule.Position != nil && *updatedRule.Position != *rule.Position {
+			time.Sleep(5 * time.Second)
 			log.Printf("[INFO] Service Event Rule %s position %v needs to be %v", updatedRule.ID, *updatedRule.Position, *rule.Position)
 			return resource.RetryableError(fmt.Errorf("Error updating service event rule %s position %d needs to be %d", updatedRule.ID, *updatedRule.Position, *rule.Position))
 		}
@@ -451,6 +456,7 @@ func resourcePagerDutyServiceEventRuleDelete(d *schema.ResourceData, meta interf
 				return resource.NonRetryableError(err)
 			}
 
+			time.Sleep(5 * time.Second)
 			return resource.RetryableError(err)
 		}
 		return nil

--- a/pagerduty/resource_pagerduty_service_integration.go
+++ b/pagerduty/resource_pagerduty_service_integration.go
@@ -634,77 +634,115 @@ func fetchPagerDutyServiceIntegration(d *schema.ResourceData, meta interface{}, 
 
 			errResp := errCallback(err, d)
 			if errResp != nil {
-				time.Sleep(2 * time.Second)
-				return resource.RetryableError(errResp)
+				// Delaying retry by 30s as recommended by PagerDuty
+				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+				time.Sleep(30 * time.Second)
+				return resource.RetryableError(err)
 			}
 
 			return nil
 		}
 
 		if err := d.Set("name", serviceIntegration.Name); err != nil {
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		}
 
 		if err := d.Set("type", serviceIntegration.Type); err != nil {
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		}
 
 		if serviceIntegration.Service != nil {
 			if err := d.Set("service", serviceIntegration.Service.ID); err != nil {
+				// Delaying retry by 30s as recommended by PagerDuty
+				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 		}
 
 		if serviceIntegration.Vendor != nil {
 			if err := d.Set("vendor", serviceIntegration.Vendor.ID); err != nil {
+				// Delaying retry by 30s as recommended by PagerDuty
+				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 		}
 
 		if serviceIntegration.IntegrationKey != "" {
 			if err := d.Set("integration_key", serviceIntegration.IntegrationKey); err != nil {
+				// Delaying retry by 30s as recommended by PagerDuty
+				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 		}
 
 		if serviceIntegration.IntegrationEmail != "" {
 			if err := d.Set("integration_email", serviceIntegration.IntegrationEmail); err != nil {
+				// Delaying retry by 30s as recommended by PagerDuty
+				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 		}
 
 		if serviceIntegration.EmailIncidentCreation != "" {
 			if err := d.Set("email_incident_creation", serviceIntegration.EmailIncidentCreation); err != nil {
+				// Delaying retry by 30s as recommended by PagerDuty
+				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 		}
 
 		if serviceIntegration.EmailFilterMode != "" {
 			if err := d.Set("email_filter_mode", serviceIntegration.EmailFilterMode); err != nil {
+				// Delaying retry by 30s as recommended by PagerDuty
+				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 		}
 
 		if serviceIntegration.EmailParsingFallback != "" {
 			if err := d.Set("email_parsing_fallback", serviceIntegration.EmailParsingFallback); err != nil {
+				// Delaying retry by 30s as recommended by PagerDuty
+				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 		}
 
 		if serviceIntegration.HTMLURL != "" {
 			if err := d.Set("html_url", serviceIntegration.HTMLURL); err != nil {
+				// Delaying retry by 30s as recommended by PagerDuty
+				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 		}
 
 		if serviceIntegration.EmailFilters != nil {
 			if err := d.Set("email_filter", flattenEmailFilters(serviceIntegration.EmailFilters)); err != nil {
+				// Delaying retry by 30s as recommended by PagerDuty
+				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 		}
 
 		if serviceIntegration.EmailParsers != nil {
 			if err := d.Set("email_parser", flattenEmailParsers(serviceIntegration.EmailParsers)); err != nil {
+				// Delaying retry by 30s as recommended by PagerDuty
+				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 		}

--- a/pagerduty/resource_pagerduty_slack_connection.go
+++ b/pagerduty/resource_pagerduty_slack_connection.go
@@ -125,6 +125,9 @@ func resourcePagerDutySlackConnectionCreate(d *schema.ResourceData, meta interfa
 		log.Printf("[INFO] Creating PagerDuty slack connection for source %s and slack channel %s", slackConn.SourceID, slackConn.ChannelID)
 
 		if slackConn, _, err = client.SlackConnections.Create(slackConn.WorkspaceID, slackConn); err != nil {
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		} else if slackConn != nil {
 			d.SetId(slackConn.ID)
@@ -156,6 +159,9 @@ func resourcePagerDutySlackConnectionRead(d *schema.ResourceData, meta interface
 				return resource.NonRetryableError(err)
 			}
 
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		} else if slackConn != nil {
 			d.Set("source_id", slackConn.SourceID)

--- a/pagerduty/resource_pagerduty_tag.go
+++ b/pagerduty/resource_pagerduty_tag.go
@@ -62,6 +62,7 @@ func resourcePagerDutyTagCreate(d *schema.ResourceData, meta interface{}) error 
 	retryErr := resource.Retry(10*time.Second, func() *resource.RetryError {
 		if tag, _, err := client.Tags.Create(tag); err != nil {
 			if isErrCode(err, 400) || isErrCode(err, 429) {
+				time.Sleep(2 * time.Second)
 				return resource.RetryableError(err)
 			}
 
@@ -127,6 +128,9 @@ func resourcePagerDutyTagDelete(d *schema.ResourceData, meta interface{}) error 
 				return resource.NonRetryableError(err)
 			}
 
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		}
 		return nil

--- a/pagerduty/resource_pagerduty_tag_assignment.go
+++ b/pagerduty/resource_pagerduty_tag_assignment.go
@@ -76,6 +76,9 @@ func resourcePagerDutyTagAssignmentCreate(d *schema.ResourceData, meta interface
 	retryErr := resource.Retry(5*time.Minute, func() *resource.RetryError {
 		if _, err := client.Tags.Assign(assignment.EntityType, assignment.EntityID, assignments); err != nil {
 			if isErrCode(err, 400) || isErrCode(err, 429) {
+				// Delaying retry by 30s as recommended by PagerDuty
+				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 
@@ -158,6 +161,7 @@ func resourcePagerDutyTagAssignmentDelete(d *schema.ResourceData, meta interface
 	retryErr := resource.Retry(10*time.Second, func() *resource.RetryError {
 		if _, err := client.Tags.Assign(assignment.EntityType, assignment.EntityID, assignments); err != nil {
 			if isErrCode(err, 400) || isErrCode(err, 429) {
+				time.Sleep(2 * time.Second)
 				return resource.RetryableError(err)
 			}
 
@@ -248,6 +252,7 @@ func isFoundTagAssignmentEntity(entityID, entityType string, meta interface{}) (
 			return nil
 		}
 		if err != nil {
+			time.Sleep(10 * time.Second)
 			return resource.RetryableError(err)
 		}
 		if isErrCode(err, http.StatusBadRequest) {

--- a/pagerduty/resource_pagerduty_team.go
+++ b/pagerduty/resource_pagerduty_team.go
@@ -74,6 +74,9 @@ func resourcePagerDutyTeamCreate(d *schema.ResourceData, meta interface{}) error
 				return resource.NonRetryableError(err)
 			}
 
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		} else if team != nil {
 			d.SetId(team.ID)
@@ -129,6 +132,7 @@ func resourcePagerDutyTeamUpdate(d *schema.ResourceData, meta interface{}) error
 
 	retryErr := resource.Retry(30*time.Second, func() *resource.RetryError {
 		if _, _, err := client.Teams.Update(d.Id(), team); err != nil {
+			time.Sleep(5 * time.Second)
 			return resource.RetryableError(err)
 		}
 		return nil
@@ -154,6 +158,9 @@ func resourcePagerDutyTeamDelete(d *schema.ResourceData, meta interface{}) error
 				return resource.NonRetryableError(err)
 			}
 
+			// Delaying retry by 30s as recommended by PagerDuty
+			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		}
 		return nil

--- a/pagerduty/resource_pagerduty_team_membership.go
+++ b/pagerduty/resource_pagerduty_team_membership.go
@@ -131,6 +131,9 @@ func resourcePagerDutyTeamMembershipCreate(d *schema.ResourceData, meta interfac
 	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if _, err := client.Teams.AddUserWithRole(teamID, userID, role); err != nil {
 			if isErrCode(err, 500) {
+				// Delaying retry by 30s as recommended by PagerDuty
+				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 
@@ -168,6 +171,9 @@ func resourcePagerDutyTeamMembershipUpdate(d *schema.ResourceData, meta interfac
 	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if _, err := client.Teams.AddUserWithRole(teamID, userID, role); err != nil {
 			if isErrCode(err, 500) {
+				// Delaying retry by 30s as recommended by PagerDuty
+				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 
@@ -210,6 +216,9 @@ func resourcePagerDutyTeamMembershipDelete(d *schema.ResourceData, meta interfac
 	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if _, err := client.Teams.RemoveUser(teamID, userID); err != nil {
 			if isErrCode(err, 400) {
+				// Delaying retry by 30s as recommended by PagerDuty
+				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 

--- a/pagerduty/resource_pagerduty_user.go
+++ b/pagerduty/resource_pagerduty_user.go
@@ -241,6 +241,9 @@ func resourcePagerDutyUserUpdate(d *schema.ResourceData, meta interface{}) error
 	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if _, _, err := client.Users.Update(d.Id(), user); err != nil {
 			if isErrCode(err, 400) {
+				// Delaying retry by 30s as recommended by PagerDuty
+				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 
@@ -308,6 +311,9 @@ func resourcePagerDutyUserDelete(d *schema.ResourceData, meta interface{}) error
 	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if _, err := client.Users.Delete(d.Id()); err != nil {
 			if isErrCode(err, 400) {
+				// Delaying retry by 30s as recommended by PagerDuty
+				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 

--- a/pagerduty/resource_pagerduty_webhook_subscription.go
+++ b/pagerduty/resource_pagerduty_webhook_subscription.go
@@ -144,6 +144,9 @@ func resourcePagerDutyWebhookSubscriptionCreate(d *schema.ResourceData, meta int
 	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if webhook, _, err := client.WebhookSubscriptions.Create(webhook); err != nil {
 			if isErrCode(err, 400) || isErrCode(err, 429) {
+				// Delaying retry by 30s as recommended by PagerDuty
+				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 


### PR DESCRIPTION
Add delays to API call retries in the definitions of various resources and data sources, as the lack of these is causing API rate limiting issues for a significant number of TF provider users.