### PR TITLE
[CSGI-2016] Address `pagerduty_schedule` validation error on weekly restriction wihtout Start of week day

### DIFF
--- a/pagerduty/resource_pagerduty_schedule.go
+++ b/pagerduty/resource_pagerduty_schedule.go
@@ -27,8 +27,13 @@ func resourcePagerDutySchedule() *schema.Resource {
 				rn := diff.Get(fmt.Sprintf("layer.%d.restriction.#", li)).(int)
 				for ri := 0; ri <= rn; ri++ {
 					t := diff.Get(fmt.Sprintf("layer.%d.restriction.%d.type", li, ri)).(string)
-					if t == "daily_restriction" && diff.Get(fmt.Sprintf("layer.%d.restriction.%d.start_day_of_week", li, ri)).(int) != 0 {
+					isStartDayOfWeekSetWhenDailyRestrictionType := t == "daily_restriction" && diff.Get(fmt.Sprintf("layer.%d.restriction.%d.start_day_of_week", li, ri)).(int) != 0
+					if isStartDayOfWeekSetWhenDailyRestrictionType {
 						return fmt.Errorf("start_day_of_week must only be set for a weekly_restriction schedule restriction type")
+					}
+					isStartDayOfWeekNotSetWhenWeeklyRestrictionType := t == "weekly_restriction" && diff.Get(fmt.Sprintf("layer.%d.restriction.%d.start_day_of_week", li, ri)).(int) == 0
+					if isStartDayOfWeekNotSetWhenWeeklyRestrictionType {
+						return fmt.Errorf("start_day_of_week must be set for a weekly_restriction schedule restriction type")
 					}
 					ds := diff.Get(fmt.Sprintf("layer.%d.restriction.%d.duration_seconds", li, ri)).(int)
 					if t == "daily_restriction" && ds >= 3600*24 {

--- a/pagerduty/resource_pagerduty_schedule_test.go
+++ b/pagerduty/resource_pagerduty_schedule_test.go
@@ -114,6 +114,13 @@ func TestAccPagerDutySchedule_Basic(t *testing.T) {
 				Config:      testAccCheckPagerDutyScheduleConfigRestrictionType(username, email, schedule, location, start, rotationVirtualStart),
 				ExpectError: regexp.MustCompile("start_day_of_week must only be set for a weekly_restriction schedule restriction type"),
 			},
+			// Validating that a Weekly Restriction with no Start Day of Week set
+			// returns a format error.
+			{
+				Config:      testAccCheckPagerDutyScheduleConfigRestrictionTypeWeeklyWithoutStartDayOfWeekSet(username, email, schedule, location, start, rotationVirtualStart),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("start_day_of_week must be set for a weekly_restriction schedule restriction type"),
+			},
 			// Validating that wrong formatted values for "start" attribute return a
 			// format error.
 			{
@@ -864,6 +871,36 @@ resource "pagerduty_schedule" "foo" {
       start_time_of_day = "08:00:00"
       duration_seconds  = 32101
 	  start_day_of_week = 5
+    }
+  }
+}
+`, username, email, schedule, location, start, rotationVirtualStart)
+}
+
+func testAccCheckPagerDutyScheduleConfigRestrictionTypeWeeklyWithoutStartDayOfWeekSet(username, email, schedule, location, start, rotationVirtualStart string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "foo" {
+  name  = "%s"
+  email = "%s"
+}
+
+resource "pagerduty_schedule" "foo" {
+  name = "%s"
+
+  time_zone   = "%s"
+  description = "foo"
+
+  layer {
+    name                         = "foo"
+    start                        = "%s"
+    rotation_virtual_start       = "%s"
+    rotation_turn_length_seconds = 86400
+    users                        = [pagerduty_user.foo.id]
+
+    restriction {
+      type              = "weekly_restriction"
+      start_time_of_day = "08:00:00"
+      duration_seconds  = 32101
     }
   }
 }


### PR DESCRIPTION
When a `pagerduty_schedule` layer is configured with a `weekly_restriction` type, without setting a `start_day_of_week` a validation error will be returned during planning stage, like the following...

```sh
╷
│ Error: start_day_of_week must be set for a weekly_restriction schedule restriction type
│
```

## Test case extended...

```sh
$ make testacc TESTARGS="-run TestAccPagerDutySchedule_Basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccPagerDutySchedule_Basic -timeout 120m
?       github.com/terraform-providers/terraform-provider-pagerduty     [no test files]
=== RUN   TestAccPagerDutySchedule_Basic # 👈 Test case extended
--- PASS: TestAccPagerDutySchedule_Basic (28.08s)
=== RUN   TestAccPagerDutySchedule_BasicWithExternalDestroyHandling
--- PASS: TestAccPagerDutySchedule_BasicWithExternalDestroyHandling (15.25s)
=== RUN   TestAccPagerDutySchedule_BasicWeek
--- PASS: TestAccPagerDutySchedule_BasicWeek (17.00s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   61.092s

```