### PR TITLE
Condition should not be required for conditional incident workflow trigger

### DIFF
--- a/pagerduty/resource_pagerduty_incident_workflow_trigger.go
+++ b/pagerduty/resource_pagerduty_incident_workflow_trigger.go
@@ -133,9 +133,6 @@ func validateIncidentWorkflowTrigger(_ context.Context, d *schema.ResourceDiff, 
 	if triggerType == "manual" && hadCondition {
 		return fmt.Errorf("when trigger type manual is used, condition must not be specified")
 	}
-	if triggerType == "conditional" && !hadCondition {
-		return fmt.Errorf("when trigger type conditional is used, condition must be specified")
-	}
 
 	s, hadServices := d.GetOk("services")
 	all := d.Get("subscribed_to_all_services").(bool)

--- a/pagerduty/resource_pagerduty_incident_workflow_trigger_test.go
+++ b/pagerduty/resource_pagerduty_incident_workflow_trigger_test.go
@@ -102,29 +102,6 @@ resource "pagerduty_incident_workflow_trigger" "my_first_workflow_trigger" {
 	})
 }
 
-func TestAccPagerDutyIncidentWorkflowTrigger_ConditionalTypeWithoutCondition(t *testing.T) {
-	config := `
-resource "pagerduty_incident_workflow_trigger" "my_first_workflow_trigger" {
-  type             = "conditional"
-  workflow         = "ignored"
-  subscribed_to_all_services = true
-}
-`
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-			testAccPreCheckIncidentWorkflows(t)
-		},
-		ProviderFactories: testAccProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config:      config,
-				ExpectError: regexp.MustCompile("when trigger type conditional is used, condition must be specified"),
-			},
-		},
-	})
-}
-
 func TestAccPagerDutyIncidentWorkflowTrigger_SubscribedToAllWithInvalidServices(t *testing.T) {
 	config := `
 resource "pagerduty_incident_workflow_trigger" "my_first_workflow_trigger" {

--- a/pagerduty/resource_pagerduty_incident_workflow_trigger_test.go
+++ b/pagerduty/resource_pagerduty_incident_workflow_trigger_test.go
@@ -102,6 +102,30 @@ resource "pagerduty_incident_workflow_trigger" "my_first_workflow_trigger" {
 	})
 }
 
+func TestAccPagerDutyIncidentWorkflowTrigger_BasicConditionalNoCondition(t *testing.T) {
+	workflow := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckIncidentWorkflows(t)
+		},
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckPagerDutyIncidentWorkflowTriggerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyIncidentWorkflowTriggerConfigConditionalNoCondition(workflow),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyIncidentWorkflowTriggerExists("pagerduty_incident_workflow_trigger.test"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_incident_workflow_trigger.test", "type", "conditional"),
+					resource.TestCheckResourceAttr("pagerduty_incident_workflow_trigger.test", "subscribed_to_all_services", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccPagerDutyIncidentWorkflowTrigger_SubscribedToAllWithInvalidServices(t *testing.T) {
 	config := `
 resource "pagerduty_incident_workflow_trigger" "my_first_workflow_trigger" {
@@ -217,6 +241,19 @@ resource "pagerduty_incident_workflow_trigger" "test" {
   subscribed_to_all_services = true
 }
 `, testAccCheckPagerDutyIncidentWorkflowConfig(workflow), condition)
+}
+
+func testAccCheckPagerDutyIncidentWorkflowTriggerConfigConditionalNoCondition(workflow string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "pagerduty_incident_workflow_trigger" "test" {
+  type       = "conditional"
+  workflow   = pagerduty_incident_workflow.test.id
+  services   = []
+  subscribed_to_all_services = true
+}
+`, testAccCheckPagerDutyIncidentWorkflowConfig(workflow))
 }
 
 func testAccCheckPagerDutyIncidentWorkflowTriggerDestroy(s *terraform.State) error {


### PR DESCRIPTION
When creating an incident workflow trigger, available options are either `manual` or `conditional`. 
If `conditional` is set, a condition can be added to specify when the workflow should trigger, or omitted to trigger the workflow on every incident. 