### PR TITLE
Feat/add iw inline steps inputs support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-exec v0.16.0
 	github.com/hashicorp/terraform-json v0.13.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.11.0
-	github.com/heimweh/go-pagerduty v0.0.0-20231125004736-fa2590da432f
+	github.com/heimweh/go-pagerduty v0.0.0-20231201163338-a11b2f79dfcf
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/heimweh/go-pagerduty v0.0.0-20231125004736-fa2590da432f h1:vxbb7MQHNvhgBJ7RlN6ZmvDbP87ez+U2ZMWRwSjX9zE=
-github.com/heimweh/go-pagerduty v0.0.0-20231125004736-fa2590da432f/go.mod h1:r59w5iyN01Qvi734yA5hZldbSeJJmsJzee/1kQ/MK7s=
+github.com/heimweh/go-pagerduty v0.0.0-20231201163338-a11b2f79dfcf h1:LyQb5eb/+R5VSA7aP5bBjDW4nHndclJQ2bG5N4lGmik=
+github.com/heimweh/go-pagerduty v0.0.0-20231201163338-a11b2f79dfcf/go.mod h1:r59w5iyN01Qvi734yA5hZldbSeJJmsJzee/1kQ/MK7s=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/pagerduty/resource_pagerduty_incident_workflow_trigger.go
+++ b/pagerduty/resource_pagerduty_incident_workflow_trigger.go
@@ -27,6 +27,7 @@ func resourcePagerDutyIncidentWorkflowTrigger() *schema.Resource {
 			"type": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 				ValidateDiagFunc: validateValueDiagFunc([]string{
 					"manual",
 					"conditional",

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/incident_workflow.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/incident_workflow.go
@@ -31,14 +31,33 @@ type IncidentWorkflowStep struct {
 
 // IncidentWorkflowActionConfiguration represents the configuration for an incident workflow action
 type IncidentWorkflowActionConfiguration struct {
-	ActionID    string                         `json:"action_id,omitempty"`
-	Description *string                        `json:"description,omitempty"`
-	Inputs      []*IncidentWorkflowActionInput `json:"inputs,omitempty"`
+	ActionID          string                                    `json:"action_id,omitempty"`
+	Description       *string                                   `json:"description,omitempty"`
+	Inputs            []*IncidentWorkflowActionInput            `json:"inputs,omitempty"`
+	InlineStepsInputs []*IncidentWorkflowActionInlineStepsInput `json:"inline_steps_inputs,omitempty"`
 }
 
+// IncidentWorkflowActionInput represents the configuration for an incident workflow action input with a serialized string as the value
 type IncidentWorkflowActionInput struct {
 	Name  string `json:"name,omitempty"`
 	Value string `json:"value,omitempty"`
+}
+
+// IncidentWorkflowActionInlineStepsInput represents the configuration for an incident workflow action input with a series of inlined steps as the value
+type IncidentWorkflowActionInlineStepsInput struct {
+	Name  string `json:"name,omitempty"`
+	Value *IncidentWorkflowActionInlineStepsInputValue `json:"value,omitempty"`
+}
+
+// IncidentWorkflowActionInlineStepsInputValue represents the value for an inline_steps_input input
+type IncidentWorkflowActionInlineStepsInputValue struct {
+	Steps []*IncidentWorkflowActionInlineStep `json:"steps,omitempty"`
+}
+
+// IncidentWorkflowActionInlineStep represents a single step within an inline_steps_input input's value
+type IncidentWorkflowActionInlineStep struct {
+	Name          string                               `json:"name,omitempty"`
+	Configuration *IncidentWorkflowActionConfiguration `json:"action_configuration,omitempty"`
 }
 
 // ListIncidentWorkflowResponse represents a list response of incident workflows.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -182,7 +182,7 @@ github.com/hashicorp/terraform-svchost
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 ## explicit
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20231125004736-fa2590da432f
+# github.com/heimweh/go-pagerduty v0.0.0-20231201163338-a11b2f79dfcf
 ## explicit; go 1.17
 github.com/heimweh/go-pagerduty/pagerduty
 github.com/heimweh/go-pagerduty/persistentconfig

--- a/website/docs/r/incident_workflow.html.markdown
+++ b/website/docs/r/incident_workflow.html.markdown
@@ -39,13 +39,19 @@ The following arguments are supported:
 Each incident workflow step (`step`) supports the following:
 
 * `name` - (Required) The name of the workflow step.
-* `action` - (Required) The action id for the workflow step, including the version. A list of actions available can be retrieved using the [PagerDuty API](https://developer.pagerduty.com/api-reference/aa192a25fac39-list-actions). 
-* `input` - (Optional) The list of inputs for the workflow action.
+* `action` - (Required) The action id for the workflow step, including the version. A list of actions available can be retrieved using the [PagerDuty API](https://developer.pagerduty.com/api-reference/aa192a25fac39-list-actions).
+* `input` - (Optional) The list of standard inputs for the workflow action.
+* `inline_steps_input` - (Optional) The list of inputs that contain a series of inline steps for the workflow action.
 
-Each incident workflow step input (`input`) supports the following:
+Each incident workflow step standard input (`input`) supports the following:
 
 * `name` - (Required) The name of the input.
 * `value` - (Required) The value of the input.
+
+Each incident workflow step inline steps input (`inline_steps_input`) points to an input whose metadata describes the `format` as `inlineSteps` and supports the following:
+
+* `name` - (Required) The name of the input.
+* `step` - (Required) The inline steps of the input. An inline step adheres to the step schema described above.
 
 ## Attributes Reference
 

--- a/website/docs/r/incident_workflow_trigger.html.markdown
+++ b/website/docs/r/incident_workflow_trigger.html.markdown
@@ -54,7 +54,7 @@ resource "pagerduty_incident_workflow_trigger" "manual_trigger" {
 
 The following arguments are supported:
 
-* `type` - (Required) May be either `manual` or `conditional`.
+* `type` - (Required) [Updating causes resource replacement] May be either `manual` or `conditional`.
 * `workflow` - (Required) The workflow ID for the workflow to trigger.
 * `services` - (Optional) A list of service IDs. Incidents in any of the listed services are eligible to fire this trigger.
 * `subscribed_to_all_services` - (Required) Set to `true` if the trigger should be eligible for firing on all services. Only allowed to be `true` if the services list is not defined or empty.


### PR DESCRIPTION
This update brings support for using `inline_steps_input`s when building Incident Workflows. `inline_steps_input`s are specialized inputs of certain Actions that can be identified by looking for `@metadata.format="inlineSteps".

These specialized inputs diverge from the standard value format of `string`, and instead are composed of a specific schema that allows inline steps to be configured. This allows for a series of inline steps to be executed conditionally, or within a loop, while still being defined as part of a single workflow.

I have also included several fixes for configured workflows with inputs that have default values, or are ordered differently from the canonical action input ordering. These changes will prevent plan diffs from always existing, even after having just applied the current config.

Test cases were extended for both IncidentWorkflow and IncidentWorkflowTrigger:

```sh
$ PAGERDUTY_ACC_INCIDENT_WORKFLOWS=1 make testacc TESTARGS="-run IncidentWorkflow"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run IncidentWorkflow -timeout 120m
?   	github.com/terraform-providers/terraform-provider-pagerduty	[no test files]
=== RUN   TestAccDataSourcePagerDutyIncidentWorkflow
--- PASS: TestAccDataSourcePagerDutyIncidentWorkflow (8.33s)
=== RUN   TestAccDataSourcePagerDutyIncidentWorkflow_Missing
--- PASS: TestAccDataSourcePagerDutyIncidentWorkflow_Missing (1.51s)
=== RUN   TestAccPagerDutyIncidentWorkflow_import
--- PASS: TestAccPagerDutyIncidentWorkflow_import (6.61s)
=== RUN   TestAccPagerDutyIncidentWorkflowTrigger_import
--- PASS: TestAccPagerDutyIncidentWorkflowTrigger_import (15.93s)
=== RUN   TestAccPagerDutyIncidentWorkflow_Basic
--- PASS: TestAccPagerDutyIncidentWorkflow_Basic (10.48s)
=== RUN   TestAccPagerDutyIncidentWorkflow_Team
--- PASS: TestAccPagerDutyIncidentWorkflow_Team (7.98s)
=== RUN   TestAccPagerDutyIncidentWorkflow_InlineInputs
--- PASS: TestAccPagerDutyIncidentWorkflow_InlineInputs (10.30s)
=== RUN   TestFlattenIncidentWorkflowStepsOneGenerated
--- PASS: TestFlattenIncidentWorkflowStepsOneGenerated (0.00s)
=== RUN   TestAccPagerDutyIncidentWorkflowTrigger_BadType
--- PASS: TestAccPagerDutyIncidentWorkflowTrigger_BadType (1.10s)
=== RUN   TestAccPagerDutyIncidentWorkflowTrigger_ConditionWithManualType
--- PASS: TestAccPagerDutyIncidentWorkflowTrigger_ConditionWithManualType (1.09s)
=== RUN   TestAccPagerDutyIncidentWorkflowTrigger_ConditionalTypeWithoutCondition
--- PASS: TestAccPagerDutyIncidentWorkflowTrigger_ConditionalTypeWithoutCondition (1.09s)
=== RUN   TestAccPagerDutyIncidentWorkflowTrigger_SubscribedToAllWithInvalidServices
--- PASS: TestAccPagerDutyIncidentWorkflowTrigger_SubscribedToAllWithInvalidServices (1.08s)
=== RUN   TestAccPagerDutyIncidentWorkflowTrigger_BasicManual
--- PASS: TestAccPagerDutyIncidentWorkflowTrigger_BasicManual (13.52s)
=== RUN   TestAccPagerDutyIncidentWorkflowTrigger_BasicConditionalAllServices
--- PASS: TestAccPagerDutyIncidentWorkflowTrigger_BasicConditionalAllServices (9.97s)
=== RUN   TestAccPagerDutyIncidentWorkflowTrigger_CannotChangeType
--- PASS: TestAccPagerDutyIncidentWorkflowTrigger_CannotChangeType (13.27s)
PASS
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	102.852s
```

## Merging depends on https://github.com/heimweh/go-pagerduty/pull/141