### PR TITLE
[CSGI-2093] Patch - Service Orchestration enable status doesn't opt in

### DIFF
--- a/pagerduty/resource_pagerduty_event_orchestration_path_service_test.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_service_test.go
@@ -206,6 +206,23 @@ func TestAccPagerDutyEventOrchestrationPathService_Basic(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccCheckPagerDutyEventOrchestrationPathServiceResourceDeleteConfig(escalationPolicy, service),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyEventOrchestrationServicePathNotExists(resourceName),
+				),
+			},
+			// Disabling Service Orchestration at creation by setting
+			// `enable_event_orchestration_for_service`  attribute to false
+			{
+				Config: testAccCheckPagerDutyEventOrchestrationPathServiceEnableEOForServiceDisableUpdateConfig(escalationPolicy, service),
+				Check: resource.ComposeTestCheckFunc(
+					append(
+						baseChecks,
+						resource.TestCheckResourceAttr(resourceName, "enable_event_orchestration_for_service", "false"),
+					)...,
+				),
+			},
+			{
 				Config: testAccCheckPagerDutyEventOrchestrationPathServiceDefaultConfig(escalationPolicy, service),
 				Check: resource.ComposeTestCheckFunc(
 					append(


### PR DESCRIPTION

## Test cases extended...

```sh
$ make testacc TESTARGS="-run TestAccPagerDutyEventOrchestration"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccPagerDutyEventOrchestration -timeout 120m
?       github.com/terraform-providers/terraform-provider-pagerduty     [no test files]
=== RUN   TestAccPagerDutyEventOrchestrationIntegration_import
--- PASS: TestAccPagerDutyEventOrchestrationIntegration_import (8.89s)
=== RUN   TestAccPagerDutyEventOrchestrationPathGlobal_import
--- PASS: TestAccPagerDutyEventOrchestrationPathGlobal_import (13.50s)
=== RUN   TestAccPagerDutyEventOrchestrationPathRouter_import
--- PASS: TestAccPagerDutyEventOrchestrationPathRouter_import (16.98s)
=== RUN   TestAccPagerDutyEventOrchestrationPathService_import
--- PASS: TestAccPagerDutyEventOrchestrationPathService_import (15.16s)
=== RUN   TestAccPagerDutyEventOrchestrationPathUnrouted_import
--- PASS: TestAccPagerDutyEventOrchestrationPathUnrouted_import (15.75s)
=== RUN   TestAccPagerDutyEventOrchestration_import
--- PASS: TestAccPagerDutyEventOrchestration_import (8.64s)
=== RUN   TestAccPagerDutyEventOrchestrationNameOnly_import
--- PASS: TestAccPagerDutyEventOrchestrationNameOnly_import (5.25s)
=== RUN   TestAccPagerDutyEventOrchestrationIntegration_Basic
--- PASS: TestAccPagerDutyEventOrchestrationIntegration_Basic (33.56s)
=== RUN   TestAccPagerDutyEventOrchestrationPathGlobal_Basic
--- PASS: TestAccPagerDutyEventOrchestrationPathGlobal_Basic (78.60s)
=== RUN   TestAccPagerDutyEventOrchestrationPathRouter_Basic
--- PASS: TestAccPagerDutyEventOrchestrationPathRouter_Basic (67.69s)
=== RUN   TestAccPagerDutyEventOrchestrationPathService_Basic # 👈 Test case extended
--- PASS: TestAccPagerDutyEventOrchestrationPathService_Basic (140.49s)
=== RUN   TestAccPagerDutyEventOrchestrationPathUnrouted_Basic
--- PASS: TestAccPagerDutyEventOrchestrationPathUnrouted_Basic (58.41s)
=== RUN   TestAccPagerDutyEventOrchestration_Basic
--- PASS: TestAccPagerDutyEventOrchestration_Basic (22.38s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   485.809s

```