### PR TITLE
[CSGI-2263] Revert add remaining delays for retries

### DIFF
--- a/pagerduty/data_source_pagerduty_event_orchestration.go
+++ b/pagerduty/data_source_pagerduty_event_orchestration.go
@@ -74,9 +74,6 @@ func dataSourcePagerDutyEventOrchestrationRead(d *schema.ResourceData, meta inte
 				return resource.NonRetryableError(err)
 			}
 
-			// Delaying retry by 30s as recommended by PagerDuty
-			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		}
 
@@ -99,9 +96,6 @@ func dataSourcePagerDutyEventOrchestrationRead(d *schema.ResourceData, meta inte
 		// since the list ndpoint does not return it
 		orch, _, err := client.EventOrchestrations.Get(found.ID)
 		if err != nil {
-			// Delaying retry by 30s as recommended by PagerDuty
-			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		}
 

--- a/pagerduty/data_source_pagerduty_event_orchestrations.go
+++ b/pagerduty/data_source_pagerduty_event_orchestrations.go
@@ -91,7 +91,6 @@ func dataSourcePagerDutyEventOrchestrationsRead(d *schema.ResourceData, meta int
 				return resource.NonRetryableError(err)
 			}
 
-			time.Sleep(10 * time.Second)
 			return resource.RetryableError(err)
 		}
 
@@ -126,7 +125,6 @@ func dataSourcePagerDutyEventOrchestrationsRead(d *schema.ResourceData, meta int
 					return resource.NonRetryableError(err)
 				}
 
-				time.Sleep(10 * time.Second)
 				return resource.RetryableError(err)
 			}
 			orchestrations = append(orchestrations, orch)

--- a/pagerduty/resource_pagerduty_automation_actions_action.go
+++ b/pagerduty/resource_pagerduty_automation_actions_action.go
@@ -344,9 +344,6 @@ func resourcePagerDutyAutomationActionsActionDelete(d *schema.ResourceData, meta
 				return resource.NonRetryableError(err)
 			}
 
-			// Delaying retry by 30s as recommended by PagerDuty
-			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		}
 		return nil

--- a/pagerduty/resource_pagerduty_automation_actions_action_service_association.go
+++ b/pagerduty/resource_pagerduty_automation_actions_action_service_association.go
@@ -120,9 +120,6 @@ func resourcePagerDutyAutomationActionsActionServiceAssociationDelete(d *schema.
 				return resource.NonRetryableError(err)
 			}
 
-			// Delaying retry by 30s as recommended by PagerDuty
-			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		}
 		return nil

--- a/pagerduty/resource_pagerduty_automation_actions_action_team_association.go
+++ b/pagerduty/resource_pagerduty_automation_actions_action_team_association.go
@@ -124,9 +124,6 @@ func resourcePagerDutyAutomationActionsActionTeamAssociationDelete(d *schema.Res
 				return resource.NonRetryableError(err)
 			}
 
-			// Delaying retry by 30s as recommended by PagerDuty
-			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		}
 		return nil

--- a/pagerduty/resource_pagerduty_automation_actions_runner.go
+++ b/pagerduty/resource_pagerduty_automation_actions_runner.go
@@ -206,9 +206,6 @@ func resourcePagerDutyAutomationActionsRunnerDelete(d *schema.ResourceData, meta
 				return resource.NonRetryableError(err)
 			}
 
-			// Delaying retry by 30s as recommended by PagerDuty
-			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		}
 		return nil

--- a/pagerduty/resource_pagerduty_automation_actions_runner_team_association.go
+++ b/pagerduty/resource_pagerduty_automation_actions_runner_team_association.go
@@ -120,9 +120,6 @@ func resourcePagerDutyAutomationActionsRunnerTeamAssociationDelete(d *schema.Res
 				return resource.NonRetryableError(err)
 			}
 
-			// Delaying retry by 30s as recommended by PagerDuty
-			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		}
 		return nil

--- a/pagerduty/resource_pagerduty_business_service.go
+++ b/pagerduty/resource_pagerduty_business_service.go
@@ -107,9 +107,6 @@ func resourcePagerDutyBusinessServiceCreate(d *schema.ResourceData, meta interfa
 		}
 		log.Printf("[INFO] Creating PagerDuty business service %s", businessService.Name)
 		if businessService, _, err = client.BusinessServices.Create(businessService); err != nil {
-			// Delaying retry by 30s as recommended by PagerDuty
-			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		} else if businessService != nil {
 			d.SetId(businessService.ID)
@@ -138,9 +135,6 @@ func resourcePagerDutyBusinessServiceRead(d *schema.ResourceData, meta interface
 				return resource.NonRetryableError(err)
 			}
 
-			// Delaying retry by 30s as recommended by PagerDuty
-			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		} else if businessService != nil {
 			d.Set("name", businessService.Name)

--- a/pagerduty/resource_pagerduty_business_service_subscriber.go
+++ b/pagerduty/resource_pagerduty_business_service_subscriber.go
@@ -70,9 +70,6 @@ func resourcePagerDutyBusinessServiceSubscriberCreate(d *schema.ResourceData, me
 
 		log.Printf("[INFO] Creating PagerDuty business service %s subscriber %s type %s", businessServiceId, businessServiceSubscriber.ID, businessServiceSubscriber.Type)
 		if _, err = client.BusinessServiceSubscribers.Create(businessServiceId, businessServiceSubscriber); err != nil {
-			// Delaying retry by 30s as recommended by PagerDuty
-			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		} else if businessServiceSubscriber != nil {
 			// create subscriber assignment it as PagerDuty API does not return one

--- a/pagerduty/resource_pagerduty_escalation_policy.go
+++ b/pagerduty/resource_pagerduty_escalation_policy.go
@@ -198,9 +198,6 @@ func resourcePagerDutyEscalationPolicyUpdate(d *schema.ResourceData, meta interf
 
 	retryErr := resource.Retry(5*time.Minute, func() *resource.RetryError {
 		if _, _, err := client.EscalationPolicies.Update(d.Id(), escalationPolicy); err != nil {
-			// Delaying retry by 30s as recommended by PagerDuty
-			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		}
 		return nil
@@ -225,7 +222,6 @@ func resourcePagerDutyEscalationPolicyDelete(d *schema.ResourceData, meta interf
 	retryErr := resource.Retry(30*time.Second, func() *resource.RetryError {
 		if _, err := client.EscalationPolicies.Delete(d.Id()); err != nil {
 			if isErrCode(err, 400) {
-				time.Sleep(10 * time.Second)
 				return resource.RetryableError(err)
 			}
 

--- a/pagerduty/resource_pagerduty_event_orchestration.go
+++ b/pagerduty/resource_pagerduty_event_orchestration.go
@@ -110,7 +110,6 @@ func resourcePagerDutyEventOrchestrationCreate(d *schema.ResourceData, meta inte
 	retryErr := resource.Retry(10*time.Second, func() *resource.RetryError {
 		if orch, _, err := client.EventOrchestrations.Create(payload); err != nil {
 			if isErrCode(err, 400) || isErrCode(err, 429) {
-				time.Sleep(2 * time.Second)
 				return resource.RetryableError(err)
 			}
 
@@ -172,7 +171,6 @@ func resourcePagerDutyEventOrchestrationUpdate(d *schema.ResourceData, meta inte
 	retryErr := resource.Retry(10*time.Second, func() *resource.RetryError {
 		if _, _, err := client.EventOrchestrations.Update(d.Id(), orchestration); err != nil {
 			if isErrCode(err, 400) || isErrCode(err, 429) {
-				time.Sleep(2 * time.Second)
 				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)

--- a/pagerduty/resource_pagerduty_event_orchestration_integration.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_integration.go
@@ -120,14 +120,10 @@ func resourcePagerDutyEventOrchestrationIntegrationCreate(ctx context.Context, d
 			if isErrCode(err, 400) {
 				return resource.NonRetryableError(err)
 			}
-			// Delaying retry by 30s as recommended by PagerDuty
-			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		} else if integration != nil {
 			// Try reading an integration after creation, retry if not found:
 			if _, readErr := fetchPagerDutyEventOrchestrationIntegration(ctx, d, meta, oid, integration.ID, true); readErr != nil {
-				time.Sleep(30 * time.Second)
 				log.Printf("[WARN] Cannot locate Integration '%s' on PagerDuty Event Orchestration '%s'. Retrying creation...", integration.ID, oid)
 				return resource.RetryableError(readErr)
 			}
@@ -155,9 +151,6 @@ func resourcePagerDutyEventOrchestrationIntegrationRead(ctx context.Context, d *
 				return resource.NonRetryableError(err)
 			}
 
-			// Delaying retry by 30s as recommended by PagerDuty
-			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		}
 
@@ -192,9 +185,6 @@ func resourcePagerDutyEventOrchestrationIntegrationUpdate(ctx context.Context, d
 				if isErrCode(err, 400) {
 					return resource.NonRetryableError(err)
 				}
-				// Delaying retry by 30s as recommended by PagerDuty
-				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			} else {
 				// try reading the migrated integration from destination and source:
@@ -203,14 +193,12 @@ func resourcePagerDutyEventOrchestrationIntegrationUpdate(ctx context.Context, d
 
 				// retry migration if the read request returned an error:
 				if readDestErr != nil {
-					time.Sleep(30 * time.Second)
 					log.Printf("[WARN] Integration '%s' cannot be found on the destination PagerDuty Event Orchestration '%s'. Retrying migration....", id, destinationOrchId)
 					return resource.RetryableError(readDestErr)
 				}
 
 				// retry migration if the integration still exists on the source:
 				if readSrcErr == nil && srcInt != nil {
-					time.Sleep(30 * time.Second)
 					log.Printf("[WARN] Integration '%s' still exists on the source PagerDuty Event Orchestration '%s'. Retrying migration....", id, sourceOrchId)
 					return resource.RetryableError(fmt.Errorf("Integration '%s' still exists on the source PagerDuty Event Orchestration '%s'.", id, sourceOrchId))
 				}
@@ -239,9 +227,6 @@ func resourcePagerDutyEventOrchestrationIntegrationUpdate(ctx context.Context, d
 			} else if integration != nil {
 				// Try reading an integration after updating the label, retry if the label is not updated:
 				if updInt, readErr := fetchPagerDutyEventOrchestrationIntegration(ctx, d, meta, oid, id, true); readErr != nil && updInt != nil {
-					// Delaying retry by 30s as recommended by PagerDuty
-					// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-					time.Sleep(30 * time.Second)
 					log.Printf("[WARN] Label for Integration '%s' on PagerDuty Event Orchestration '%s' was not updated. Expected: '%s', actual: '%s'. Retrying update...", id, oid, payload.Label, updInt.Label)
 					return resource.RetryableError(readErr)
 				}
@@ -274,14 +259,10 @@ func resourcePagerDutyEventOrchestrationIntegrationDelete(ctx context.Context, d
 				return resource.NonRetryableError(err)
 			}
 
-			// Delaying retry by 30s as recommended by PagerDuty
-			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		} else {
 			// Try reading an integration after deletion, retry if still found:
 			if integr, _, readErr := client.EventOrchestrationIntegrations.GetContext(ctx, oid, id); readErr == nil && integr != nil {
-				time.Sleep(30 * time.Second)
 				log.Printf("[WARN] Integration '%s' still exists on PagerDuty Event Orchestration '%s'. Retrying deletion...", id, oid)
 				return resource.RetryableError(fmt.Errorf("Integration '%s' still exists on PagerDuty Event Orchestration '%s'.", id, oid))
 			}
@@ -314,9 +295,6 @@ func resourcePagerDutyEventOrchestrationIntegrationImport(ctx context.Context, d
 				return resource.NonRetryableError(err)
 			}
 
-			// Delaying retry by 30s as recommended by PagerDuty
-			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		}
 		return nil

--- a/pagerduty/resource_pagerduty_event_orchestration_path_global.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_global.go
@@ -220,7 +220,6 @@ func resourcePagerDutyEventOrchestrationPathGlobalUpdate(ctx context.Context, d 
 				return resource.NonRetryableError(err)
 			}
 
-			time.Sleep(10 * time.Second)
 			return resource.RetryableError(err)
 		} else if response != nil {
 			d.SetId(response.OrchestrationPath.Parent.ID)
@@ -258,7 +257,6 @@ func resourcePagerDutyEventOrchestrationPathGlobalDelete(ctx context.Context, d 
 				return resource.NonRetryableError(err)
 			}
 
-			time.Sleep(10 * time.Second)
 			return resource.RetryableError(err)
 		}
 		return nil

--- a/pagerduty/resource_pagerduty_event_orchestration_path_router.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_router.go
@@ -176,7 +176,6 @@ func resourcePagerDutyEventOrchestrationPathRouterDelete(ctx context.Context, d 
 				return resource.NonRetryableError(err)
 			}
 
-			time.Sleep(10 * time.Second)
 			return resource.RetryableError(err)
 		}
 		return nil
@@ -210,7 +209,6 @@ func resourcePagerDutyEventOrchestrationPathRouterUpdate(ctx context.Context, d 
 				return resource.NonRetryableError(err)
 			}
 
-			time.Sleep(10 * time.Second)
 			return resource.RetryableError(err)
 		}
 		if response == nil {

--- a/pagerduty/resource_pagerduty_event_orchestration_path_service.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_service.go
@@ -267,7 +267,6 @@ func resourcePagerDutyEventOrchestrationPathServiceUpdate(ctx context.Context, d
 				return resource.NonRetryableError(err)
 			}
 
-			time.Sleep(10 * time.Second)
 			return resource.RetryableError(err)
 		} else if response != nil {
 			d.SetId(response.OrchestrationPath.Parent.ID)
@@ -359,7 +358,6 @@ func resourcePagerDutyEventOrchestrationPathServiceDelete(ctx context.Context, d
 				return resource.NonRetryableError(err)
 			}
 
-			time.Sleep(10 * time.Second)
 			return resource.RetryableError(err)
 		}
 		return nil

--- a/pagerduty/resource_pagerduty_event_orchestration_path_unrouted.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_unrouted.go
@@ -226,7 +226,6 @@ func resourcePagerDutyEventOrchestrationPathUnroutedDelete(ctx context.Context, 
 				return resource.NonRetryableError(err)
 			}
 
-			time.Sleep(10 * time.Second)
 			return resource.RetryableError(err)
 		}
 		return nil
@@ -260,7 +259,6 @@ func resourcePagerDutyEventOrchestrationPathUnroutedUpdate(ctx context.Context, 
 				return resource.NonRetryableError(err)
 			}
 
-			time.Sleep(10 * time.Second)
 			return resource.RetryableError(err)
 		}
 

--- a/pagerduty/resource_pagerduty_schedule.go
+++ b/pagerduty/resource_pagerduty_schedule.go
@@ -377,9 +377,6 @@ func resourcePagerDutyScheduleUpdate(d *schema.ResourceData, meta interface{}) e
 
 	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if _, _, err := client.Schedules.Update(d.Id(), schedule, opts); err != nil {
-			// Delaying retry by 30s as recommended by PagerDuty
-			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		}
 		return nil
@@ -430,9 +427,6 @@ func resourcePagerDutyScheduleDelete(d *schema.ResourceData, meta interface{}) e
 	retryErr = resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if _, err := client.Schedules.Delete(scheduleId); err != nil {
 			if !isErrCode(err, 400) {
-				// Delaying retry by 30s as recommended by PagerDuty
-				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 			isErrorScheduleUsedByEP := func(e *pagerduty.Error) bool {
@@ -475,9 +469,6 @@ func resourcePagerDutyScheduleDelete(d *schema.ResourceData, meta interface{}) e
 			epsDataUsingThisSchedule, errFetchingFullEPs := fetchEPsDataUsingASchedule(epsUsingThisSchedule, client)
 			if errFetchingFullEPs != nil {
 				err = fmt.Errorf("%v; %w", err, errFetchingFullEPs)
-				// Delaying retry by 30s as recommended by PagerDuty
-				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 
@@ -492,9 +483,6 @@ func resourcePagerDutyScheduleDelete(d *schema.ResourceData, meta interface{}) e
 			if workaroundErr != nil {
 				err = fmt.Errorf("%v; %w", err, workaroundErr)
 			}
-			// Delaying retry by 30s as recommended by PagerDuty
-			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		}
 		return nil
@@ -781,7 +769,6 @@ func removeScheduleFromEP(c *pagerduty.Client, scheduleID string, ep *pagerduty.
 		_, _, err := c.EscalationPolicies.Update(ep.ID, ep)
 		if err != nil {
 			if !isErrCode(err, 404) {
-				time.Sleep(2 * time.Second)
 				return resource.RetryableError(err)
 			}
 		}
@@ -876,7 +863,6 @@ func fetchEPsDataUsingASchedule(eps []string, c *pagerduty.Client) ([]*pagerduty
 					return resource.NonRetryableError(err)
 				}
 
-				time.Sleep(2 * time.Second)
 				return resource.RetryableError(err)
 			}
 			fullEPs = append(fullEPs, ep)

--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -480,9 +480,7 @@ func fetchService(d *schema.ResourceData, meta interface{}, errCallback func(err
 
 			errResp := errCallback(err, d)
 			if errResp != nil {
-				// Delaying retry by 30s as recommended by PagerDuty
-				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-				time.Sleep(30 * time.Second)
+				time.Sleep(2 * time.Second)
 				return resource.RetryableError(errResp)
 			}
 

--- a/pagerduty/resource_pagerduty_service_dependency.go
+++ b/pagerduty/resource_pagerduty_service_dependency.go
@@ -157,9 +157,6 @@ func resourcePagerDutyServiceDependencyAssociate(ctx context.Context, d *schema.
 
 		if err != nil {
 			if isErrCode(err, 404) {
-				// Delaying retry by 30s as recommended by PagerDuty
-				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)
@@ -205,6 +202,7 @@ func resourcePagerDutyServiceDependencyDisassociate(ctx context.Context, d *sche
 			// Delaying retry by 30s as recommended by PagerDuty
 			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
 			time.Sleep(30 * time.Second)
+
 			return resource.RetryableError(err)
 		} else if dependencies != nil {
 			for _, rel := range dependencies.Relationships {
@@ -249,6 +247,7 @@ func resourcePagerDutyServiceDependencyDisassociate(ctx context.Context, d *sche
 			// Delaying retry by 30s as recommended by PagerDuty
 			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
 			time.Sleep(30 * time.Second)
+
 			return resource.RetryableError(err)
 		}
 		return nil
@@ -327,6 +326,7 @@ func findDependencySetState(ctx context.Context, depID, serviceID, serviceType s
 			// Delaying retry by 30s as recommended by PagerDuty
 			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
 			time.Sleep(30 * time.Second)
+
 			return resource.RetryableError(err)
 		} else if dependencies != nil {
 			depFound := false

--- a/pagerduty/resource_pagerduty_service_event_rule.go
+++ b/pagerduty/resource_pagerduty_service_event_rule.go
@@ -346,9 +346,6 @@ func resourcePagerDutyServiceEventRuleCreate(d *schema.ResourceData, meta interf
 				return resource.NonRetryableError(err)
 			}
 
-			// Delaying retry by 30s as recommended by PagerDuty
-			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		} else if rule != nil {
 			d.SetId(rule.ID)
@@ -424,10 +421,8 @@ func resourcePagerDutyServiceEventRuleUpdate(d *schema.ResourceData, meta interf
 				return resource.NonRetryableError(err)
 			}
 
-			time.Sleep(5 * time.Second)
 			return resource.RetryableError(err)
 		} else if rule.Position != nil && *updatedRule.Position != *rule.Position {
-			time.Sleep(5 * time.Second)
 			log.Printf("[INFO] Service Event Rule %s position %v needs to be %v", updatedRule.ID, *updatedRule.Position, *rule.Position)
 			return resource.RetryableError(fmt.Errorf("Error updating service event rule %s position %d needs to be %d", updatedRule.ID, *updatedRule.Position, *rule.Position))
 		}
@@ -456,7 +451,6 @@ func resourcePagerDutyServiceEventRuleDelete(d *schema.ResourceData, meta interf
 				return resource.NonRetryableError(err)
 			}
 
-			time.Sleep(5 * time.Second)
 			return resource.RetryableError(err)
 		}
 		return nil

--- a/pagerduty/resource_pagerduty_service_integration.go
+++ b/pagerduty/resource_pagerduty_service_integration.go
@@ -635,115 +635,77 @@ func fetchPagerDutyServiceIntegration(d *schema.ResourceData, meta interface{}, 
 
 			errResp := errCallback(err, d)
 			if errResp != nil {
-				// Delaying retry by 30s as recommended by PagerDuty
-				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-				time.Sleep(30 * time.Second)
-				return resource.RetryableError(err)
+				time.Sleep(2 * time.Second)
+				return resource.RetryableError(errResp)
 			}
 
 			return nil
 		}
 
 		if err := d.Set("name", serviceIntegration.Name); err != nil {
-			// Delaying retry by 30s as recommended by PagerDuty
-			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		}
 
 		if err := d.Set("type", serviceIntegration.Type); err != nil {
-			// Delaying retry by 30s as recommended by PagerDuty
-			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		}
 
 		if serviceIntegration.Service != nil {
 			if err := d.Set("service", serviceIntegration.Service.ID); err != nil {
-				// Delaying retry by 30s as recommended by PagerDuty
-				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 		}
 
 		if serviceIntegration.Vendor != nil {
 			if err := d.Set("vendor", serviceIntegration.Vendor.ID); err != nil {
-				// Delaying retry by 30s as recommended by PagerDuty
-				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 		}
 
 		if serviceIntegration.IntegrationKey != "" {
 			if err := d.Set("integration_key", serviceIntegration.IntegrationKey); err != nil {
-				// Delaying retry by 30s as recommended by PagerDuty
-				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 		}
 
 		if serviceIntegration.IntegrationEmail != "" {
 			if err := d.Set("integration_email", serviceIntegration.IntegrationEmail); err != nil {
-				// Delaying retry by 30s as recommended by PagerDuty
-				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 		}
 
 		if serviceIntegration.EmailIncidentCreation != "" {
 			if err := d.Set("email_incident_creation", serviceIntegration.EmailIncidentCreation); err != nil {
-				// Delaying retry by 30s as recommended by PagerDuty
-				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 		}
 
 		if serviceIntegration.EmailFilterMode != "" {
 			if err := d.Set("email_filter_mode", serviceIntegration.EmailFilterMode); err != nil {
-				// Delaying retry by 30s as recommended by PagerDuty
-				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 		}
 
 		if serviceIntegration.EmailParsingFallback != "" {
 			if err := d.Set("email_parsing_fallback", serviceIntegration.EmailParsingFallback); err != nil {
-				// Delaying retry by 30s as recommended by PagerDuty
-				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 		}
 
 		if serviceIntegration.HTMLURL != "" {
 			if err := d.Set("html_url", serviceIntegration.HTMLURL); err != nil {
-				// Delaying retry by 30s as recommended by PagerDuty
-				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 		}
 
 		if serviceIntegration.EmailFilters != nil {
 			if err := d.Set("email_filter", flattenEmailFilters(serviceIntegration.EmailFilters)); err != nil {
-				// Delaying retry by 30s as recommended by PagerDuty
-				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 		}
 
 		if serviceIntegration.EmailParsers != nil {
 			if err := d.Set("email_parser", flattenEmailParsers(serviceIntegration.EmailParsers)); err != nil {
-				// Delaying retry by 30s as recommended by PagerDuty
-				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 		}

--- a/pagerduty/resource_pagerduty_slack_connection.go
+++ b/pagerduty/resource_pagerduty_slack_connection.go
@@ -125,9 +125,6 @@ func resourcePagerDutySlackConnectionCreate(d *schema.ResourceData, meta interfa
 		log.Printf("[INFO] Creating PagerDuty slack connection for source %s and slack channel %s", slackConn.SourceID, slackConn.ChannelID)
 
 		if slackConn, _, err = client.SlackConnections.Create(slackConn.WorkspaceID, slackConn); err != nil {
-			// Delaying retry by 30s as recommended by PagerDuty
-			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		} else if slackConn != nil {
 			d.SetId(slackConn.ID)
@@ -159,9 +156,6 @@ func resourcePagerDutySlackConnectionRead(d *schema.ResourceData, meta interface
 				return resource.NonRetryableError(err)
 			}
 
-			// Delaying retry by 30s as recommended by PagerDuty
-			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		} else if slackConn != nil {
 			d.Set("source_id", slackConn.SourceID)

--- a/pagerduty/resource_pagerduty_tag.go
+++ b/pagerduty/resource_pagerduty_tag.go
@@ -62,7 +62,6 @@ func resourcePagerDutyTagCreate(d *schema.ResourceData, meta interface{}) error 
 	retryErr := resource.Retry(10*time.Second, func() *resource.RetryError {
 		if tag, _, err := client.Tags.Create(tag); err != nil {
 			if isErrCode(err, 400) || isErrCode(err, 429) {
-				time.Sleep(2 * time.Second)
 				return resource.RetryableError(err)
 			}
 
@@ -128,9 +127,6 @@ func resourcePagerDutyTagDelete(d *schema.ResourceData, meta interface{}) error 
 				return resource.NonRetryableError(err)
 			}
 
-			// Delaying retry by 30s as recommended by PagerDuty
-			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		}
 		return nil

--- a/pagerduty/resource_pagerduty_tag_assignment.go
+++ b/pagerduty/resource_pagerduty_tag_assignment.go
@@ -76,9 +76,6 @@ func resourcePagerDutyTagAssignmentCreate(d *schema.ResourceData, meta interface
 	retryErr := resource.Retry(5*time.Minute, func() *resource.RetryError {
 		if _, err := client.Tags.Assign(assignment.EntityType, assignment.EntityID, assignments); err != nil {
 			if isErrCode(err, 400) || isErrCode(err, 429) {
-				// Delaying retry by 30s as recommended by PagerDuty
-				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 
@@ -161,7 +158,6 @@ func resourcePagerDutyTagAssignmentDelete(d *schema.ResourceData, meta interface
 	retryErr := resource.Retry(10*time.Second, func() *resource.RetryError {
 		if _, err := client.Tags.Assign(assignment.EntityType, assignment.EntityID, assignments); err != nil {
 			if isErrCode(err, 400) || isErrCode(err, 429) {
-				time.Sleep(2 * time.Second)
 				return resource.RetryableError(err)
 			}
 
@@ -252,7 +248,6 @@ func isFoundTagAssignmentEntity(entityID, entityType string, meta interface{}) (
 			return nil
 		}
 		if err != nil {
-			time.Sleep(10 * time.Second)
 			return resource.RetryableError(err)
 		}
 		if isErrCode(err, http.StatusBadRequest) {

--- a/pagerduty/resource_pagerduty_team.go
+++ b/pagerduty/resource_pagerduty_team.go
@@ -82,9 +82,6 @@ func resourcePagerDutyTeamCreate(d *schema.ResourceData, meta interface{}) error
 				return resource.NonRetryableError(err)
 			}
 
-			// Delaying retry by 30s as recommended by PagerDuty
-			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		} else if team != nil {
 			d.SetId(team.ID)
@@ -141,7 +138,6 @@ func resourcePagerDutyTeamUpdate(d *schema.ResourceData, meta interface{}) error
 
 	retryErr := resource.Retry(30*time.Second, func() *resource.RetryError {
 		if _, _, err := client.Teams.Update(d.Id(), team); err != nil {
-			time.Sleep(5 * time.Second)
 			return resource.RetryableError(err)
 		}
 		return nil
@@ -167,9 +163,6 @@ func resourcePagerDutyTeamDelete(d *schema.ResourceData, meta interface{}) error
 				return resource.NonRetryableError(err)
 			}
 
-			// Delaying retry by 30s as recommended by PagerDuty
-			// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-			time.Sleep(30 * time.Second)
 			return resource.RetryableError(err)
 		}
 		return nil

--- a/pagerduty/resource_pagerduty_team_membership.go
+++ b/pagerduty/resource_pagerduty_team_membership.go
@@ -131,9 +131,6 @@ func resourcePagerDutyTeamMembershipCreate(d *schema.ResourceData, meta interfac
 	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if _, err := client.Teams.AddUserWithRole(teamID, userID, role); err != nil {
 			if isErrCode(err, 500) {
-				// Delaying retry by 30s as recommended by PagerDuty
-				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 
@@ -171,9 +168,6 @@ func resourcePagerDutyTeamMembershipUpdate(d *schema.ResourceData, meta interfac
 	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if _, err := client.Teams.AddUserWithRole(teamID, userID, role); err != nil {
 			if isErrCode(err, 500) {
-				// Delaying retry by 30s as recommended by PagerDuty
-				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 
@@ -216,9 +210,6 @@ func resourcePagerDutyTeamMembershipDelete(d *schema.ResourceData, meta interfac
 	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if _, err := client.Teams.RemoveUser(teamID, userID); err != nil {
 			if isErrCode(err, 400) {
-				// Delaying retry by 30s as recommended by PagerDuty
-				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 

--- a/pagerduty/resource_pagerduty_user.go
+++ b/pagerduty/resource_pagerduty_user.go
@@ -241,9 +241,6 @@ func resourcePagerDutyUserUpdate(d *schema.ResourceData, meta interface{}) error
 	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if _, _, err := client.Users.Update(d.Id(), user); err != nil {
 			if isErrCode(err, 400) {
-				// Delaying retry by 30s as recommended by PagerDuty
-				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 
@@ -311,9 +308,6 @@ func resourcePagerDutyUserDelete(d *schema.ResourceData, meta interface{}) error
 	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if _, err := client.Users.Delete(d.Id()); err != nil {
 			if isErrCode(err, 400) {
-				// Delaying retry by 30s as recommended by PagerDuty
-				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 

--- a/pagerduty/resource_pagerduty_webhook_subscription.go
+++ b/pagerduty/resource_pagerduty_webhook_subscription.go
@@ -144,9 +144,6 @@ func resourcePagerDutyWebhookSubscriptionCreate(d *schema.ResourceData, meta int
 	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if webhook, _, err := client.WebhookSubscriptions.Create(webhook); err != nil {
 			if isErrCode(err, 400) || isErrCode(err, 429) {
-				// Delaying retry by 30s as recommended by PagerDuty
-				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
-				time.Sleep(30 * time.Second)
 				return resource.RetryableError(err)
 			}
 


### PR DESCRIPTION
Reverts https://github.com/PagerDuty/terraform-provider-pagerduty/pull/758 and https://github.com/PagerDuty/terraform-provider-pagerduty/pull/763

The issue these PR were meant to addressed will now be solved more gracefully by adopting [New REST API rate limiting logic](https://developer.pagerduty.com/docs/72d3b724589e3-rest-api-rate-limits#reaching-the-limit).