### PR TITLE
[CSGI-2263] Support rate limiting throttling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-exec v0.16.0
 	github.com/hashicorp/terraform-json v0.13.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.11.0
-	github.com/heimweh/go-pagerduty v0.0.0-20231201163338-a11b2f79dfcf
+	github.com/heimweh/go-pagerduty v0.0.0-20231201203054-09be11e40bea
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/heimweh/go-pagerduty v0.0.0-20231201163338-a11b2f79dfcf h1:LyQb5eb/+R5VSA7aP5bBjDW4nHndclJQ2bG5N4lGmik=
-github.com/heimweh/go-pagerduty v0.0.0-20231201163338-a11b2f79dfcf/go.mod h1:r59w5iyN01Qvi734yA5hZldbSeJJmsJzee/1kQ/MK7s=
+github.com/heimweh/go-pagerduty v0.0.0-20231201203054-09be11e40bea h1:JJnJ9l1XBIFepPShm8XNvbILSMVQW8sjeAKctexHots=
+github.com/heimweh/go-pagerduty v0.0.0-20231201203054-09be11e40bea/go.mod h1:r59w5iyN01Qvi734yA5hZldbSeJJmsJzee/1kQ/MK7s=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -480,7 +480,6 @@ func fetchService(d *schema.ResourceData, meta interface{}, errCallback func(err
 
 			errResp := errCallback(err, d)
 			if errResp != nil {
-				time.Sleep(2 * time.Second)
 				return resource.RetryableError(errResp)
 			}
 

--- a/pagerduty/resource_pagerduty_service_integration.go
+++ b/pagerduty/resource_pagerduty_service_integration.go
@@ -635,7 +635,6 @@ func fetchPagerDutyServiceIntegration(d *schema.ResourceData, meta interface{}, 
 
 			errResp := errCallback(err, d)
 			if errResp != nil {
-				time.Sleep(2 * time.Second)
 				return resource.RetryableError(errResp)
 			}
 
@@ -732,7 +731,6 @@ func resourcePagerDutyServiceIntegrationCreate(d *schema.ResourceData, meta inte
 	retryErr := resource.Retry(1*time.Minute, func() *resource.RetryError {
 		if serviceIntegration, _, err := client.Services.CreateIntegration(service, serviceIntegration); err != nil {
 			if isErrCode(err, 400) {
-				time.Sleep(2 * time.Second)
 				return resource.RetryableError(err)
 			}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -182,7 +182,7 @@ github.com/hashicorp/terraform-svchost
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 ## explicit
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20231201163338-a11b2f79dfcf
+# github.com/heimweh/go-pagerduty v0.0.0-20231201203054-09be11e40bea
 ## explicit; go 1.17
 github.com/heimweh/go-pagerduty/pagerduty
 github.com/heimweh/go-pagerduty/persistentconfig


### PR DESCRIPTION
Closes #765, #760, #772

Points `heimweh/go-pagerduty` to updated version supporting graceful handling of new REST API rate limiting headers, throttling API calls blocked by http 429 errors, as [recommended by PagerDuty](https://developer.pagerduty.com/docs/72d3b724589e3-rest-api-rate-limits#reaching-the-limit) during the amount of seconds noted in ratelimit-reset headers to retry the call afterwards.

Additionally, removes delays on retries for `pagerduty_service` and `pagerduty_service_integration` which are not longer needed with new version of `heimweh/go-pagerduty`.