### PR TITLE
[CSGI-2303] Hotfix - Alert grouping parameters input validation broken

### DIFF
--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -341,18 +341,19 @@ func customizePagerDutyServiceDiff(context context.Context, diff *schema.Resourc
 		aggregateVal := diff.Get(agppath + "aggregate").(string)
 		fieldsVal := diff.Get(agppath + "fields").([]interface{})
 		timeWindowVal := diff.Get(agppath + "time_window").(int)
+		hasChangeAgpType := diff.HasChange("alert_grouping_parameters")
 
-		if agpType == "time" && (aggregateVal != "" || len(fieldsVal) > 0 || timeWindowVal > 0) {
-			return fmt.Errorf("Alert grouping parameters configuration of type \"time\" only supports setting \"timeout\" attribute")
-		}
-		if agpType == "content_based" && (timeoutVal > 0 || timeWindowVal > 0) {
-			return fmt.Errorf("Alert grouping parameters configuration of type \"content_based\" only supports setting \"aggregate\" and \"fields\" attributes")
-		}
 		if agpType == "content_based" && (aggregateVal == "" || len(fieldsVal) == 0) {
 			return fmt.Errorf("When using Alert grouping parameters configuration of type \"content_based\" is in use, attributes \"aggregate\" and \"fields\" are required")
 		}
-		if agpType == "intelligent" && (aggregateVal != "" || len(fieldsVal) > 0 || timeoutVal > 0) {
-			return fmt.Errorf("Alert grouping parameters configuration of type \"intelligent\" only supports setting the optional attribute \"time_window\"")
+		if (aggregateVal != "" || len(fieldsVal) > 0) && (agpType != "" && !hasChangeAgpType && agpType != "content_based") {
+			return fmt.Errorf("Alert grouping parameters configuration attributes \"aggregate\" and \"fields\" are only supported by \"content_based\" type Alert Grouping")
+		}
+		if timeoutVal > 0 && (agpType != "" && !hasChangeAgpType && agpType != "time") {
+			return fmt.Errorf("Alert grouping parameters configuration attribute \"timeout\" is only supported by \"time\" type Alert Grouping")
+		}
+		if (timeWindowVal > 300) && (agpType != "" && !hasChangeAgpType && agpType != "intelligent") {
+			return fmt.Errorf("Alert grouping parameters configuration attribute \"time_window\" is only supported by \"intelligent\" type Alert Grouping")
 		}
 	}
 

--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -346,13 +346,13 @@ func customizePagerDutyServiceDiff(context context.Context, diff *schema.Resourc
 		if agpType == "content_based" && (aggregateVal == "" || len(fieldsVal) == 0) {
 			return fmt.Errorf("When using Alert grouping parameters configuration of type \"content_based\" is in use, attributes \"aggregate\" and \"fields\" are required")
 		}
-		if (aggregateVal != "" || len(fieldsVal) > 0) && (agpType != "" && !hasChangeAgpType && agpType != "content_based") {
+		if (aggregateVal != "" || len(fieldsVal) > 0) && (agpType != "" && hasChangeAgpType && agpType != "content_based") {
 			return fmt.Errorf("Alert grouping parameters configuration attributes \"aggregate\" and \"fields\" are only supported by \"content_based\" type Alert Grouping")
 		}
-		if timeoutVal > 0 && (agpType != "" && !hasChangeAgpType && agpType != "time") {
+		if timeoutVal > 0 && (agpType != "" && hasChangeAgpType && agpType != "time") {
 			return fmt.Errorf("Alert grouping parameters configuration attribute \"timeout\" is only supported by \"time\" type Alert Grouping")
 		}
-		if (timeWindowVal > 300) && (agpType != "" && !hasChangeAgpType && agpType != "intelligent") {
+		if (timeWindowVal > 300) && (agpType != "" && hasChangeAgpType && agpType != "intelligent") {
 			return fmt.Errorf("Alert grouping parameters configuration attribute \"time_window\" is only supported by \"intelligent\" type Alert Grouping")
 		}
 	}

--- a/pagerduty/resource_pagerduty_service_test.go
+++ b/pagerduty/resource_pagerduty_service_test.go
@@ -284,7 +284,11 @@ func TestAccPagerDutyService_AlertContentGrouping(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckPagerDutyServiceConfigWithAlertContentGroupingUpdated(username, email, escalationPolicy, service),
+				Config:   testAccCheckPagerDutyServiceConfigWithAlertContentGrouping(username, email, escalationPolicy, service),
+				PlanOnly: true,
+			},
+			{
+				Config: testAccCheckPagerDutyServiceConfigWithAlertIntelligentGroupingUpdated(username, email, escalationPolicy, service),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyServiceExists("pagerduty_service.foo"),
 					resource.TestCheckResourceAttr(
@@ -298,7 +302,31 @@ func TestAccPagerDutyService_AlertContentGrouping(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "alert_creation", "create_alerts_and_incidents"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "alert_grouping", "rules"),
+						"pagerduty_service.foo", "alert_grouping_parameters.0.type", "intelligent"),
+					resource.TestCheckNoResourceAttr(
+						"pagerduty_service.foo", "alert_grouping_parameters.0.config.0"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.0.urgency", "high"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.0.type", "constant"),
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyServiceConfigWithAlertContentGroupingUpdated(username, email, escalationPolicy, service),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyServiceExists("pagerduty_service.foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "name", service),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "description", "foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "auto_resolve_timeout", "1800"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "acknowledgement_timeout", "1800"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "alert_creation", "create_alerts_and_incidents"),
 					resource.TestCheckNoResourceAttr(
 						"pagerduty_service.foo", "alert_grouping_parameters.0.config"),
 					resource.TestCheckNoResourceAttr(

--- a/pagerduty/resource_pagerduty_service_test.go
+++ b/pagerduty/resource_pagerduty_service_test.go
@@ -131,6 +131,7 @@ func TestAccPagerDutyService_Basic(t *testing.T) {
 }
 
 func TestAccPagerDutyService_FormatValidation(t *testing.T) {
+	service := fmt.Sprintf("ts-%s", acctest.RandString(5))
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	email := fmt.Sprintf("%s@foo.test", username)
 	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
@@ -170,6 +171,126 @@ func TestAccPagerDutyService_FormatValidation(t *testing.T) {
 				Config:      testAccCheckPagerDutyServiceConfig(username, email, escalationPolicy, "this name has a non printable\\n character"),
 				PlanOnly:    true,
 				ExpectError: regexp.MustCompile(errMessageMatcher),
+			},
+			// Alert grouping parameters "Content Based" type input validation
+			{
+				Config: testAccCheckPagerDutyServiceAlertGroupingInputValidationConfig(username, email, escalationPolicy, service,
+					`
+          alert_grouping_parameters {
+            type = "content_based"
+            config {}
+          }
+          `,
+				),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("When using Alert grouping parameters configuration of type \"content_based\" is in use, attributes \"aggregate\" and \"fields\" are required"),
+			},
+			{
+				Config: testAccCheckPagerDutyServiceAlertGroupingInputValidationConfig(username, email, escalationPolicy, service,
+					`
+          alert_grouping_parameters {
+            type = "content_based"
+            config {
+              aggregate = "all"
+              fields    = ["custom_details.source_id"]
+            }
+          }
+          `,
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyServiceAlertGroupingInputValidationConfig(username, email, escalationPolicy, service,
+					`
+          alert_grouping_parameters {
+            type = "time"
+            config {
+              aggregate = "all"
+              fields    = ["custom_details.source_id"]
+            }
+          }
+          `,
+				),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("Alert grouping parameters configuration attributes \"aggregate\" and \"fields\" are only supported by \"content_based\" type Alert Grouping"),
+			},
+			// Alert grouping parameters "time" type input validation
+			{
+				Config: testAccCheckPagerDutyServiceAlertGroupingInputValidationConfig(username, email, escalationPolicy, service,
+					`
+          alert_grouping_parameters {
+            type = "time"
+            config {
+              timeout = 5
+            }
+          }
+          `,
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyServiceAlertGroupingInputValidationConfig(username, email, escalationPolicy, service,
+					`
+          alert_grouping_parameters {
+            type = "intelligent"
+            config {
+              timeout = 5
+            }
+          }
+          `,
+				),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("Alert grouping parameters configuration attribute \"timeout\" is only supported by \"time\" type Alert Grouping"),
+			},
+			// Alert grouping parameters "intelligent" type input validation
+			{
+				Config: testAccCheckPagerDutyServiceAlertGroupingInputValidationConfig(username, email, escalationPolicy, service,
+					`
+          alert_grouping_parameters {
+            type = "time"
+            config {
+              time_window = 600
+            }
+          }
+          `,
+				),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("Alert grouping parameters configuration attribute \"time_window\" is only supported by \"intelligent\" type Alert Grouping"),
+			},
+			{
+				Config: testAccCheckPagerDutyServiceAlertGroupingInputValidationConfig(username, email, escalationPolicy, service,
+					`
+          alert_grouping_parameters {
+            type = "intelligent"
+            config {}
+          }
+          `,
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyServiceAlertGroupingInputValidationConfig(username, email, escalationPolicy, service,
+					`
+          alert_grouping_parameters {
+            type = "intelligent"
+            config {
+              time_window = 5
+            }
+          }
+          `,
+				),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("Intelligent alert grouping time window value must be between 300 and 3600"),
+			},
+			{
+				Config: testAccCheckPagerDutyServiceAlertGroupingInputValidationConfig(username, email, escalationPolicy, service,
+					`
+          alert_grouping_parameters {
+            type = "intelligent"
+            config {
+              time_window = 300
+            }
+          }
+          `,
+				),
+				PlanOnly: true,
 			},
 		},
 	})
@@ -1162,6 +1283,42 @@ resource "pagerduty_service" "foo" {
 	alert_creation          = "create_incidents"
 }
 `, username, email, escalationPolicy, service)
+}
+
+func testAccCheckPagerDutyServiceAlertGroupingInputValidationConfig(username, email, escalationPolicy, service, alertGroupingParams string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "foo" {
+  name        = "%s"
+  email       = "%s"
+  color       = "green"
+  role        = "user"
+  job_title   = "foo"
+  description = "foo"
+}
+
+resource "pagerduty_escalation_policy" "foo" {
+  name        = "%s"
+  description = "bar"
+  num_loops   = 2
+  rule {
+    escalation_delay_in_minutes = 10
+    target {
+      type = "user_reference"
+      id   = pagerduty_user.foo.id
+    }
+  }
+}
+
+resource "pagerduty_service" "foo" {
+  name                    = "%s"
+  description             = "foo"
+  auto_resolve_timeout    = 1800
+  acknowledgement_timeout = 1800
+  escalation_policy       = pagerduty_escalation_policy.foo.id
+  alert_creation          = "create_alerts_and_incidents"
+  %s
+}
+`, username, email, escalationPolicy, service, alertGroupingParams)
 }
 
 func testAccCheckPagerDutyServiceConfigWithAlertGrouping(username, email, escalationPolicy, service string) string {


### PR DESCRIPTION
Closes #778 

## Test cases extended...

```sh
$ make testacc TESTARGS="-run TestAccPagerDutyService_AlertContentGrouping"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccPagerDutyService_AlertContentGrouping -timeout 120m
?       github.com/terraform-providers/terraform-provider-pagerduty     [no test files]
=== RUN   TestAccPagerDutyService_AlertContentGrouping # 👈 Test case extended to cover regression
--- PASS: TestAccPagerDutyService_AlertContentGrouping (66.24s)
=== RUN   TestAccPagerDutyService_AlertContentGroupingIntelligentTimeWindow
--- PASS: TestAccPagerDutyService_AlertContentGroupingIntelligentTimeWindow (19.25s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   86.107s
```

```sh
$ make testacc TESTARGS="-run TestAccPagerDutyService_FormatValidation"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccPagerDutyService_FormatValidation -timeout 120m
?       github.com/terraform-providers/terraform-provider-pagerduty     [no test files]
=== RUN   TestAccPagerDutyService_FormatValidation # 👈 Test case extended to cover regression
--- PASS: TestAccPagerDutyService_FormatValidation (34.79s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   35.488s
```