### PR TITLE
[CSGI-2314] Add Round Robin support to `pagerduty_escalation_policy`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-exec v0.16.0
 	github.com/hashicorp/terraform-json v0.13.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.11.0
-	github.com/heimweh/go-pagerduty v0.0.0-20231201203054-09be11e40bea
+	github.com/heimweh/go-pagerduty v0.0.0-20231207205722-b4c4cc9f249e
 )
 
 require (
@@ -71,5 +71,3 @@ require (
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 )
-
-replace github.com/heimweh/go-pagerduty => github.com/imjaroiswebdev/go-pagerduty v0.0.0-20231207172309-e1bb5c16dc17

--- a/go.mod
+++ b/go.mod
@@ -71,3 +71,5 @@ require (
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 )
+
+replace github.com/heimweh/go-pagerduty => github.com/imjaroiswebdev/go-pagerduty v0.0.0-20231207172309-e1bb5c16dc17

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,6 @@ github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/heimweh/go-pagerduty v0.0.0-20231201203054-09be11e40bea h1:JJnJ9l1XBIFepPShm8XNvbILSMVQW8sjeAKctexHots=
-github.com/heimweh/go-pagerduty v0.0.0-20231201203054-09be11e40bea/go.mod h1:r59w5iyN01Qvi734yA5hZldbSeJJmsJzee/1kQ/MK7s=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -260,6 +258,8 @@ github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=
 github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK2O4oXg=
+github.com/imjaroiswebdev/go-pagerduty v0.0.0-20231207172309-e1bb5c16dc17 h1:ASnfR/ZWh+3hkNNxx2U8z/Bwet35QPI/fjxIFFvOELs=
+github.com/imjaroiswebdev/go-pagerduty v0.0.0-20231207172309-e1bb5c16dc17/go.mod h1:r59w5iyN01Qvi734yA5hZldbSeJJmsJzee/1kQ/MK7s=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=

--- a/go.sum
+++ b/go.sum
@@ -250,6 +250,8 @@ github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
+github.com/heimweh/go-pagerduty v0.0.0-20231207205722-b4c4cc9f249e h1:u8v+2ZZOb9QFGiE676aDj08N9kFTNHcMtY6+9g57+ko=
+github.com/heimweh/go-pagerduty v0.0.0-20231207205722-b4c4cc9f249e/go.mod h1:r59w5iyN01Qvi734yA5hZldbSeJJmsJzee/1kQ/MK7s=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -258,8 +260,6 @@ github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=
 github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK2O4oXg=
-github.com/imjaroiswebdev/go-pagerduty v0.0.0-20231207172309-e1bb5c16dc17 h1:ASnfR/ZWh+3hkNNxx2U8z/Bwet35QPI/fjxIFFvOELs=
-github.com/imjaroiswebdev/go-pagerduty v0.0.0-20231207172309-e1bb5c16dc17/go.mod h1:r59w5iyN01Qvi734yA5hZldbSeJJmsJzee/1kQ/MK7s=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/escalation_policy.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/escalation_policy.go
@@ -6,11 +6,18 @@ import "fmt"
 // related methods of the PagerDuty API.
 type EscalationPolicyService service
 
+// EscalationRuleAssignmentStrategy represents an Escalation rule assignment
+// strategy
+type EscalationRuleAssignmentStrategy struct {
+	Type string `json:"type,omitempty"`
+}
+
 // EscalationRule represents an escalation rule.
 type EscalationRule struct {
-	EscalationDelayInMinutes int                          `json:"escalation_delay_in_minutes,omitempty"`
-	ID                       string                       `json:"id,omitempty"`
-	Targets                  []*EscalationTargetReference `json:"targets,omitempty"`
+	EscalationDelayInMinutes         int                               `json:"escalation_delay_in_minutes,omitempty"`
+	EscalationRuleAssignmentStrategy *EscalationRuleAssignmentStrategy `json:"escalation_rule_assignment_strategy,omitempty"`
+	ID                               string                            `json:"id,omitempty"`
+	Targets                          []*EscalationTargetReference      `json:"targets,omitempty"`
 }
 
 // EscalationPolicy represents an escalation policy.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -182,7 +182,7 @@ github.com/hashicorp/terraform-svchost
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 ## explicit
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20231201203054-09be11e40bea => github.com/imjaroiswebdev/go-pagerduty v0.0.0-20231207172309-e1bb5c16dc17
+# github.com/heimweh/go-pagerduty v0.0.0-20231207205722-b4c4cc9f249e
 ## explicit; go 1.17
 github.com/heimweh/go-pagerduty/pagerduty
 github.com/heimweh/go-pagerduty/persistentconfig
@@ -450,4 +450,3 @@ google.golang.org/protobuf/types/known/timestamppb
 # gopkg.in/ini.v1 v1.67.0
 ## explicit
 gopkg.in/ini.v1
-# github.com/heimweh/go-pagerduty => github.com/imjaroiswebdev/go-pagerduty v0.0.0-20231207172309-e1bb5c16dc17

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -182,7 +182,7 @@ github.com/hashicorp/terraform-svchost
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 ## explicit
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20231201203054-09be11e40bea
+# github.com/heimweh/go-pagerduty v0.0.0-20231201203054-09be11e40bea => github.com/imjaroiswebdev/go-pagerduty v0.0.0-20231207172309-e1bb5c16dc17
 ## explicit; go 1.17
 github.com/heimweh/go-pagerduty/pagerduty
 github.com/heimweh/go-pagerduty/persistentconfig
@@ -450,3 +450,4 @@ google.golang.org/protobuf/types/known/timestamppb
 # gopkg.in/ini.v1 v1.67.0
 ## explicit
 gopkg.in/ini.v1
+# github.com/heimweh/go-pagerduty => github.com/imjaroiswebdev/go-pagerduty v0.0.0-20231207172309-e1bb5c16dc17

--- a/website/docs/r/escalation_policy.html.markdown
+++ b/website/docs/r/escalation_policy.html.markdown
@@ -58,7 +58,12 @@ The following arguments are supported:
 Escalation rules (`rule`) supports the following:
 
   * `escalation_delay_in_minutes` - (Required) The number of minutes before an unacknowledged incident escalates away from this rule.
+  * `escalation_rule_assignment_strategy` - (Optional) The strategy used to assign the escalation rule to an incident. Documented below.
   * `targets` - (Required) A target block. Target blocks documented below.
+
+Incident assignment strategy for Escalation Rule (`escalation_rule_assignment_strategy`) supports the following:
+
+* `type` - (Optional) Can be `round_robin` or `assign_to_everyone`.
 
 Targets (`target`) supports the following:
 


### PR DESCRIPTION
Add support for [escalation_rule_assignment_strategy](https://developer.pagerduty.com/api-reference/77515ca391014-create-an-escalation-policy#request-body) `/escalation_policies` API field, which brings support Round Robin escalation rule assignment strategy for incidents.

![image](https://github.com/PagerDuty/terraform-provider-pagerduty/assets/24704624/38d3cb94-bef8-4c6c-8ad4-0dc7638586f0)

### Terraform resource `pagerduty_escalation_policy` update...

![image](https://github.com/PagerDuty/terraform-provider-pagerduty/assets/24704624/14bb1bc1-f6e3-485b-bdfd-f0374249c5d5)


## Test cases introduced...

```sh
$ make testacc TESTARGS="-run TestAccPagerDutyEscalationPolicyWithRoundRobinAssignmentStrategy"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccPagerDutyEscalationPolicyWithRoundRobinAssignmentStrategy -timeout 120m
?       github.com/terraform-providers/terraform-provider-pagerduty     [no test files]
=== RUN   TestAccPagerDutyEscalationPolicyWithRoundRobinAssignmentStrategy
--- PASS: TestAccPagerDutyEscalationPolicyWithRoundRobinAssignmentStrategy (23.75s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   24.506s

```

## Depends on https://github.com/heimweh/go-pagerduty/pull/144