### PR TITLE
[integration key] do not error with deprecation on output-only usage

### DIFF
--- a/pagerduty/resource_pagerduty_service_integration.go
+++ b/pagerduty/resource_pagerduty_service_integration.go
@@ -66,7 +66,6 @@ func resourcePagerDutyServiceIntegration() *schema.Resource {
 			},
 			"integration_key": {
 				Type:       schema.TypeString,
-				Optional:   true,
 				Computed:   true,
 				Deprecated: "Assignments or updates to this attribute are not supported by Service Integrations API, it is a read-only value. Input support will be dropped in upcomming major release",
 			},


### PR DESCRIPTION
Fixes the `integration_key` deprecation warning when only used on `output` and not `input`.

# Detail
* In https://github.com/PagerDuty/terraform-provider-pagerduty/pull/775, the `integration_key` was marked as `deprecated` with the intent for `input` (makes sense).
* Post-shipping, it was found that this when used on `output` would still provide the `deprecation` message which is not expected or desired (example: https://github.com/PagerDuty/terraform-provider-pagerduty/issues/782).
* By removing `Optional: true`, this should make it `output`-only in Terraform, to my knowledge.

# Testing
* Tests pass, happy to do other things if desired.
```
go test -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-pagerduty github.com/terraform-providers/terraform-provider-pagerduty/pagerduty
?   	github.com/terraform-providers/terraform-provider-pagerduty	[no test files]
ok  	github.com/terraform-providers/terraform-provider-pagerduty/pagerduty	4.227s
```