### PR TITLE
Allow time_window to be set for content-based grouping (issue 788)

### DIFF
--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -116,7 +116,7 @@ func resourcePagerDutyService() *schema.Resource {
 										Type:             schema.TypeInt,
 										Optional:         true,
 										Computed:         true,
-										ValidateDiagFunc: validateIntelligentTimeWindow,
+										ValidateDiagFunc: validateTimeWindow,
 									},
 								},
 							},
@@ -352,15 +352,15 @@ func customizePagerDutyServiceDiff(context context.Context, diff *schema.Resourc
 		if timeoutVal > 0 && (agpType != "" && hasChangeAgpType && agpType != "time") {
 			return fmt.Errorf("Alert grouping parameters configuration attribute \"timeout\" is only supported by \"time\" type Alert Grouping")
 		}
-		if (timeWindowVal > 300) && (agpType != "" && hasChangeAgpType && agpType != "intelligent") {
-			return fmt.Errorf("Alert grouping parameters configuration attribute \"time_window\" is only supported by \"intelligent\" type Alert Grouping")
+		if (timeWindowVal > 300) && (agpType != "" && hasChangeAgpType && (agpType != "intelligent" && agpType != "content_based")) {
+			return fmt.Errorf("Alert grouping parameters configuration attribute \"time_window\" is only supported by \"intelligent\" and \"content-based\" type Alert Grouping")
 		}
 	}
 
 	return nil
 }
 
-func validateIntelligentTimeWindow(v interface{}, p cty.Path) diag.Diagnostics {
+func validateTimeWindow(v interface{}, p cty.Path) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	tw := v.(int)

--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -367,7 +367,7 @@ func validateTimeWindow(v interface{}, p cty.Path) diag.Diagnostics {
 	if tw < 300 || tw > 3600 {
 		diags = append(diags, diag.Diagnostic{
 			Severity:      diag.Error,
-			Summary:       fmt.Sprintf("Intelligent alert grouping time window value must be between 300 and 3600, current setting is %d", tw),
+			Summary:       fmt.Sprintf("Alert grouping time window value must be between 300 and 3600, current setting is %d", tw),
 			AttributePath: p,
 		})
 	}

--- a/pagerduty/resource_pagerduty_service_test.go
+++ b/pagerduty/resource_pagerduty_service_test.go
@@ -253,7 +253,7 @@ func TestAccPagerDutyService_FormatValidation(t *testing.T) {
           `,
 				),
 				PlanOnly:    true,
-				ExpectError: regexp.MustCompile("Alert grouping parameters configuration attribute \"time_window\" is only supported by \"intelligent\" type Alert Grouping"),
+				ExpectError: regexp.MustCompile("Alert grouping parameters configuration attribute \"time_window\" is only supported by \"intelligent\" and \"content_based\" type Alert Grouping"),
 			},
 			{
 				Config: testAccCheckPagerDutyServiceAlertGroupingInputValidationConfig(username, email, escalationPolicy, service,
@@ -277,13 +277,39 @@ func TestAccPagerDutyService_FormatValidation(t *testing.T) {
           `,
 				),
 				PlanOnly:    true,
-				ExpectError: regexp.MustCompile("Intelligent alert grouping time window value must be between 300 and 3600"),
+				ExpectError: regexp.MustCompile("Content-based alert grouping time window value must be between 300 and 3600"),
 			},
 			{
 				Config: testAccCheckPagerDutyServiceAlertGroupingInputValidationConfig(username, email, escalationPolicy, service,
 					`
           alert_grouping_parameters {
             type = "intelligent"
+            config {
+              time_window = 300
+            }
+          }
+          `,
+				),
+				PlanOnly: true,
+			},
+		},
+	},
+          alert_grouping_parameters {
+            type = "content_based"
+            config {
+              time_window = 3605
+            }
+          }
+          `,
+				),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("Content-based alert grouping time window value must be between 300 and 3600"),
+			},
+			{
+				Config: testAccCheckPagerDutyServiceAlertGroupingInputValidationConfig(username, email, escalationPolicy, service,
+					`
+          alert_grouping_parameters {
+            type = "content_based"
             config {
               time_window = 300
             }

--- a/pagerduty/resource_pagerduty_service_test.go
+++ b/pagerduty/resource_pagerduty_service_test.go
@@ -253,7 +253,7 @@ func TestAccPagerDutyService_FormatValidation(t *testing.T) {
           `,
 				),
 				PlanOnly:    true,
-				ExpectError: regexp.MustCompile("Alert grouping parameters configuration attribute \"time_window\" is only supported by \"intelligent\" and \"content_based\" type Alert Grouping"),
+				ExpectError: regexp.MustCompile("Alert grouping parameters configuration attribute \"time_window\" is only supported by \"intelligent\" and \"content-based\" type Alert Grouping"),
 			},
 			{
 				Config: testAccCheckPagerDutyServiceAlertGroupingInputValidationConfig(username, email, escalationPolicy, service,
@@ -312,12 +312,13 @@ func TestAccPagerDutyService_FormatValidation(t *testing.T) {
           alert_grouping_parameters {
             type = "content_based"
             config {
+              aggregate = "all"
+              fields    = ["custom_details.source_id"]
               time_window = 300
             }
           }
           `,
 				),
-				PlanOnly: true,
 			},
 		},
 	})

--- a/pagerduty/resource_pagerduty_service_test.go
+++ b/pagerduty/resource_pagerduty_service_test.go
@@ -277,7 +277,7 @@ func TestAccPagerDutyService_FormatValidation(t *testing.T) {
           `,
 				),
 				PlanOnly:    true,
-				ExpectError: regexp.MustCompile("Content-based alert grouping time window value must be between 300 and 3600"),
+				ExpectError: regexp.MustCompile("Alert grouping time window value must be between 300 and 3600"),
 			},
 			{
 				Config: testAccCheckPagerDutyServiceAlertGroupingInputValidationConfig(username, email, escalationPolicy, service,
@@ -292,18 +292,19 @@ func TestAccPagerDutyService_FormatValidation(t *testing.T) {
 				),
 				PlanOnly: true,
 			},
-		},
-	},
+			{
+				Config: testAccCheckPagerDutyServiceAlertGroupingInputValidationConfig(username, email, escalationPolicy, service,
+					`
           alert_grouping_parameters {
             type = "content_based"
             config {
-              time_window = 3605
+              time_window = 5
             }
           }
           `,
 				),
 				PlanOnly:    true,
-				ExpectError: regexp.MustCompile("Content-based alert grouping time window value must be between 300 and 3600"),
+				ExpectError: regexp.MustCompile("Alert grouping time window value must be between 300 and 3600"),
 			},
 			{
 				Config: testAccCheckPagerDutyServiceAlertGroupingInputValidationConfig(username, email, escalationPolicy, service,

--- a/website/docs/r/service.html.markdown
+++ b/website/docs/r/service.html.markdown
@@ -71,7 +71,7 @@ The `alert_grouping_parameters` block contains the following arguments:
     * `timeout` - (Optional) The duration in minutes within which to automatically group incoming alerts. This setting applies only when `type` is set to `time`. To continue grouping alerts until the incident is resolved, set this value to `0`.
     * `aggregate` - (Optional) One of `any` or `all`. This setting applies only when `type` is set to `content_based`. Group alerts based on one or all of `fields` value(s).
     * `fields` - (Optional) Alerts will be grouped together if the content of these fields match. This setting applies only when `type` is set to `content_based`.
-    * `time_window` - (Optional) The maximum amount of time allowed between Alerts. Value must be between `300` and `3600`. Any Alerts arriving greater than `time_window` seconds apart will not be grouped together. This is a rolling time window and is counted from the most recently grouped alert. The window is extended every time a new alert is added to the group, up to 24 hours.
+    * `time_window` - (Optional) The maximum amount of time allowed between Alerts. This setting applies only when `type` is set to `intelligent` or `content_based`. Value must be between `300` and `3600`. Any Alerts arriving greater than `time_window` seconds apart will not be grouped together. This is a rolling time window and is counted from the most recently grouped alert. The window is extended every time a new alert is added to the group, up to 24 hours.
 
 The `auto_pause_notifications_parameters` block contains the following arguments:
 


### PR DESCRIPTION
Closes #788 

Very simple change, little bit of renaming since this is no longer specific to intelligent grouping w/ test coverage updated to reflect changes to error strings and cover new cases.