### PR TITLE
Address: timeout while waiting for state to become 'success' 

### DIFF
--- a/pagerduty/config.go
+++ b/pagerduty/config.go
@@ -3,9 +3,7 @@ package pagerduty
 import (
 	"fmt"
 	"log"
-	"net"
 	"net/http"
-	"runtime"
 	"sync"
 	"time"
 
@@ -73,18 +71,8 @@ func (c *Config) Client() (*pagerduty.Client, error) {
 
 	var httpClient *http.Client
 	httpClient = http.DefaultClient
-	httpClient.Transport = logging.NewTransport(
-		"PagerDuty",
-		&http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-			DialContext: (&net.Dialer{
-				Timeout:   30 * time.Second,
-				KeepAlive: 30 * time.Second,
-			}).DialContext,
-			IdleConnTimeout:     60 * time.Second,
-			TLSHandshakeTimeout: 10 * time.Second,
-			MaxIdleConnsPerHost: runtime.GOMAXPROCS(0) + 1,
-		})
+	httpClient.Timeout = 1 * time.Minute
+	httpClient.Transport = logging.NewTransport("PagerDuty", http.DefaultTransport)
 
 	var apiUrl = c.ApiUrl
 	if c.ApiUrlOverride != "" {

--- a/pagerduty/data_source_pagerduty_automation_actions_action.go
+++ b/pagerduty/data_source_pagerduty_automation_actions_action.go
@@ -106,7 +106,7 @@ func dataSourcePagerDutyAutomationActionsActionRead(d *schema.ResourceData, meta
 
 	log.Printf("[INFO] Reading PagerDuty AutomationActionsAction")
 
-	return resource.Retry(1*time.Minute, func() *resource.RetryError {
+	return resource.Retry(2*time.Minute, func() *resource.RetryError {
 		automationActionsAction, _, err := client.AutomationActionsAction.Get(d.Get("id").(string))
 		if err != nil {
 			if isErrCode(err, http.StatusBadRequest) {

--- a/pagerduty/data_source_pagerduty_automation_actions_runner.go
+++ b/pagerduty/data_source_pagerduty_automation_actions_runner.go
@@ -61,7 +61,7 @@ func dataSourcePagerDutyAutomationActionsRunnerRead(d *schema.ResourceData, meta
 
 	log.Printf("[INFO] Reading PagerDuty automation actions runner")
 
-	return resource.Retry(1*time.Minute, func() *resource.RetryError {
+	return resource.Retry(2*time.Minute, func() *resource.RetryError {
 		runner, _, err := client.AutomationActionsRunner.Get(d.Get("id").(string))
 		if err != nil {
 			if isErrCode(err, http.StatusBadRequest) {

--- a/pagerduty/data_source_pagerduty_event_orchestrations.go
+++ b/pagerduty/data_source_pagerduty_event_orchestrations.go
@@ -84,7 +84,7 @@ func dataSourcePagerDutyEventOrchestrationsRead(d *schema.ResourceData, meta int
 	nameFilter := d.Get("name_filter").(string)
 
 	var eoList []*pagerduty.EventOrchestration
-	retryErr := resource.Retry(30*time.Second, func() *resource.RetryError {
+	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		resp, _, err := client.EventOrchestrations.List()
 		if err != nil {
 			if isErrCode(err, http.StatusBadRequest) {
@@ -118,7 +118,7 @@ func dataSourcePagerDutyEventOrchestrationsRead(d *schema.ResourceData, meta int
 	for _, orchestration := range eoList {
 		// Get orchestration matched by ID so we can set the integrations property
 		// since the list endpoint does not return it
-		retryErr := resource.Retry(30*time.Second, func() *resource.RetryError {
+		retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 			orch, _, err := client.EventOrchestrations.Get(orchestration.ID)
 			if err != nil {
 				if isErrCode(err, http.StatusBadRequest) {

--- a/pagerduty/resource_pagerduty_automation_actions_action.go
+++ b/pagerduty/resource_pagerduty_automation_actions_action.go
@@ -212,7 +212,7 @@ func resourcePagerDutyAutomationActionsActionCreate(d *schema.ResourceData, meta
 
 	log.Printf("[INFO] Creating PagerDuty AutomationActionsAction %s", automationActionsAction.Name)
 
-	retryErr := resource.Retry(10*time.Second, func() *resource.RetryError {
+	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if automationActionsAction, _, err := client.AutomationActionsAction.Create(automationActionsAction); err != nil {
 			if isErrCode(err, 400) || isErrCode(err, 429) {
 				time.Sleep(2 * time.Second)
@@ -261,7 +261,7 @@ func resourcePagerDutyAutomationActionsActionRead(d *schema.ResourceData, meta i
 
 	log.Printf("[INFO] Reading PagerDuty AutomationActionsAction %s", d.Id())
 
-	return resource.Retry(30*time.Second, func() *resource.RetryError {
+	return resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if automationActionsAction, _, err := client.AutomationActionsAction.Get(d.Id()); err != nil {
 			if isErrCode(err, http.StatusBadRequest) {
 				return resource.NonRetryableError(err)

--- a/pagerduty/resource_pagerduty_automation_actions_action_service_association.go
+++ b/pagerduty/resource_pagerduty_automation_actions_action_service_association.go
@@ -44,7 +44,7 @@ func resourcePagerDutyAutomationActionsActionServiceAssociationCreate(d *schema.
 
 	log.Printf("[INFO] Creating PagerDuty AutomationActionsActionServiceAssociation %s:%s", d.Get("action_id").(string), d.Get("service_id").(string))
 
-	retryErr := resource.Retry(10*time.Second, func() *resource.RetryError {
+	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if serviceRef, _, err := client.AutomationActionsAction.AssociateToService(actionID, serviceID); err != nil {
 			if isErrCode(err, 429) {
 				time.Sleep(2 * time.Second)
@@ -76,7 +76,7 @@ func fetchPagerDutyAutomationActionsActionServiceAssociation(d *schema.ResourceD
 		return err
 	}
 
-	return resource.Retry(30*time.Second, func() *resource.RetryError {
+	return resource.Retry(2*time.Minute, func() *resource.RetryError {
 		resp, _, err := client.AutomationActionsAction.GetAssociationToService(actionID, serviceID)
 		if err != nil {
 			if isErrCode(err, http.StatusBadRequest) {

--- a/pagerduty/resource_pagerduty_automation_actions_action_team_association.go
+++ b/pagerduty/resource_pagerduty_automation_actions_action_team_association.go
@@ -44,7 +44,7 @@ func resourcePagerDutyAutomationActionsActionTeamAssociationCreate(d *schema.Res
 
 	log.Printf("[INFO] Creating PagerDuty AutomationActionsActionTeamAssociation %s:%s", d.Get("action_id").(string), d.Get("team_id").(string))
 
-	retryErr := resource.Retry(10*time.Second, func() *resource.RetryError {
+	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if teamRef, _, err := client.AutomationActionsAction.AssociateToTeam(actionID, teamID); err != nil {
 			if isErrCode(err, http.StatusBadRequest) {
 				return resource.NonRetryableError(err)
@@ -80,7 +80,7 @@ func fetchPagerDutyAutomationActionsActionTeamAssociation(d *schema.ResourceData
 		return err
 	}
 
-	return resource.Retry(30*time.Second, func() *resource.RetryError {
+	return resource.Retry(2*time.Minute, func() *resource.RetryError {
 		resp, _, err := client.AutomationActionsAction.GetAssociationToTeam(actionID, teamID)
 		if err != nil {
 			if isErrCode(err, http.StatusBadRequest) {

--- a/pagerduty/resource_pagerduty_automation_actions_runner.go
+++ b/pagerduty/resource_pagerduty_automation_actions_runner.go
@@ -113,7 +113,7 @@ func resourcePagerDutyAutomationActionsRunnerCreate(d *schema.ResourceData, meta
 
 	log.Printf("[INFO] Creating PagerDuty AutomationActionsRunner %s", automationActionsRunner.Name)
 
-	retryErr := resource.Retry(10*time.Second, func() *resource.RetryError {
+	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if automationActionsRunner, _, err := client.AutomationActionsRunner.Create(automationActionsRunner); err != nil {
 			if isErrCode(err, 400) || isErrCode(err, 429) {
 				time.Sleep(2 * time.Second)
@@ -142,7 +142,7 @@ func resourcePagerDutyAutomationActionsRunnerRead(d *schema.ResourceData, meta i
 
 	log.Printf("[INFO] Reading PagerDuty AutomationActionsRunner %s", d.Id())
 
-	return resource.Retry(30*time.Second, func() *resource.RetryError {
+	return resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if automationActionsRunner, _, err := client.AutomationActionsRunner.Get(d.Id()); err != nil {
 			if isErrCode(err, http.StatusBadRequest) {
 				return resource.NonRetryableError(err)

--- a/pagerduty/resource_pagerduty_automation_actions_runner_team_association.go
+++ b/pagerduty/resource_pagerduty_automation_actions_runner_team_association.go
@@ -44,7 +44,7 @@ func resourcePagerDutyAutomationActionsRunnerTeamAssociationCreate(d *schema.Res
 
 	log.Printf("[INFO] Creating PagerDuty AutomationActionsRunnerTeamAssociation %s:%s", d.Get("runner_id").(string), d.Get("team_id").(string))
 
-	retryErr := resource.Retry(10*time.Second, func() *resource.RetryError {
+	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if teamRef, _, err := client.AutomationActionsRunner.AssociateToTeam(runnerID, teamID); err != nil {
 			if isErrCode(err, 429) {
 				time.Sleep(2 * time.Second)
@@ -76,7 +76,7 @@ func fetchPagerDutyAutomationActionsRunnerTeamAssociation(d *schema.ResourceData
 		return err
 	}
 
-	return resource.Retry(30*time.Second, func() *resource.RetryError {
+	return resource.Retry(2*time.Minute, func() *resource.RetryError {
 		resp, _, err := client.AutomationActionsRunner.GetAssociationToTeam(runnerID, teamID)
 		if err != nil {
 			if isErrCode(err, http.StatusBadRequest) {

--- a/pagerduty/resource_pagerduty_escalation_policy.go
+++ b/pagerduty/resource_pagerduty_escalation_policy.go
@@ -238,7 +238,7 @@ func resourcePagerDutyEscalationPolicyDelete(d *schema.ResourceData, meta interf
 	log.Printf("[INFO] Deleting PagerDuty escalation policy: %s", d.Id())
 
 	// Retrying to give other resources (such as services) to delete
-	retryErr := resource.Retry(30*time.Second, func() *resource.RetryError {
+	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if _, err := client.EscalationPolicies.Delete(d.Id()); err != nil {
 			if isErrCode(err, 400) {
 				return resource.RetryableError(err)

--- a/pagerduty/resource_pagerduty_event_orchestration.go
+++ b/pagerduty/resource_pagerduty_event_orchestration.go
@@ -107,7 +107,7 @@ func resourcePagerDutyEventOrchestrationCreate(d *schema.ResourceData, meta inte
 
 	log.Printf("[INFO] Creating PagerDuty Event Orchestration: %s", payload.Name)
 
-	retryErr := resource.Retry(10*time.Second, func() *resource.RetryError {
+	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if orch, _, err := client.EventOrchestrations.Create(payload); err != nil {
 			if isErrCode(err, 400) || isErrCode(err, 429) {
 				return resource.RetryableError(err)
@@ -168,7 +168,7 @@ func resourcePagerDutyEventOrchestrationUpdate(d *schema.ResourceData, meta inte
 
 	log.Printf("[INFO] Updating PagerDuty Event Orchestration: %s", d.Id())
 
-	retryErr := resource.Retry(10*time.Second, func() *resource.RetryError {
+	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if _, _, err := client.EventOrchestrations.Update(d.Id(), orchestration); err != nil {
 			if isErrCode(err, 400) || isErrCode(err, 429) {
 				return resource.RetryableError(err)

--- a/pagerduty/resource_pagerduty_event_rule.go
+++ b/pagerduty/resource_pagerduty_event_rule.go
@@ -67,7 +67,7 @@ func resourcePagerDutyEventRuleCreate(d *schema.ResourceData, meta interface{}) 
 
 	log.Printf("[INFO] Creating PagerDuty event rule: %s", eventRule.Condition)
 
-	retryErr := resource.Retry(1*time.Minute, func() *resource.RetryError {
+	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if eventRule, _, err := client.EventRules.Create(eventRule); err != nil {
 			if isErrCode(err, http.StatusBadRequest) {
 				return resource.NonRetryableError(err)

--- a/pagerduty/resource_pagerduty_response_play.go
+++ b/pagerduty/resource_pagerduty_response_play.go
@@ -312,7 +312,7 @@ func resourcePagerDutyResponsePlayUpdate(d *schema.ResourceData, meta interface{
 
 	log.Printf("[INFO] Updating PagerDuty response play: %s", d.Id())
 
-	retryErr := resource.Retry(30*time.Second, func() *resource.RetryError {
+	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if _, _, err := client.ResponsePlays.Update(d.Id(), responsePlay); err != nil {
 			if isErrCode(err, http.StatusBadRequest) {
 				return resource.NonRetryableError(err)
@@ -338,7 +338,7 @@ func resourcePagerDutyResponsePlayDelete(d *schema.ResourceData, meta interface{
 	log.Printf("[INFO] Deleting PagerDuty response play: %s", d.Id())
 	from := d.Get("from").(string)
 
-	retryErr := resource.Retry(30*time.Second, func() *resource.RetryError {
+	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if _, err := client.ResponsePlays.Delete(d.Id(), from); err != nil {
 			if isErrCode(err, http.StatusBadRequest) {
 				return resource.NonRetryableError(err)

--- a/pagerduty/resource_pagerduty_ruleset.go
+++ b/pagerduty/resource_pagerduty_ruleset.go
@@ -145,7 +145,7 @@ func resourcePagerDutyRulesetCreate(d *schema.ResourceData, meta interface{}) er
 
 	log.Printf("[INFO] Creating PagerDuty ruleset: %s", ruleset.Name)
 
-	retryErr := resource.Retry(10*time.Second, func() *resource.RetryError {
+	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if ruleset, _, err := client.Rulesets.Create(ruleset); err != nil {
 			if isErrCode(err, 400) || isErrCode(err, 429) {
 				return resource.RetryableError(err)

--- a/pagerduty/resource_pagerduty_ruleset_rule.go
+++ b/pagerduty/resource_pagerduty_ruleset_rule.go
@@ -874,7 +874,7 @@ func resourcePagerDutyRulesetRuleUpdate(d *schema.ResourceData, meta interface{}
 }
 
 func performRulesetRuleUpdate(rulesetID string, id string, rule *pagerduty.RulesetRule, client *pagerduty.Client) error {
-	retryErr := resource.Retry(30*time.Second, func() *resource.RetryError {
+	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if updatedRule, _, err := client.Rulesets.UpdateRule(rulesetID, id, rule); err != nil {
 			if isErrCode(err, http.StatusBadRequest) {
 				return resource.NonRetryableError(err)
@@ -935,7 +935,7 @@ func resourcePagerDutyRulesetRuleDelete(d *schema.ResourceData, meta interface{}
 
 	log.Printf("[INFO] Deleting PagerDuty ruleset rule: %s", d.Id())
 
-	retryErr := resource.Retry(30*time.Second, func() *resource.RetryError {
+	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if _, err := client.Rulesets.DeleteRule(rulesetID, d.Id()); err != nil {
 			if isErrCode(err, http.StatusBadRequest) {
 				return resource.NonRetryableError(err)

--- a/pagerduty/resource_pagerduty_schedule.go
+++ b/pagerduty/resource_pagerduty_schedule.go
@@ -269,7 +269,7 @@ func fetchSchedule(d *schema.ResourceData, meta interface{}, errCallback func(er
 		return err
 	}
 
-	retryErr := resource.Retry(30*time.Second, func() *resource.RetryError {
+	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		schedule, _, err := client.Schedules.Get(d.Id(), &pagerduty.GetScheduleOptions{})
 		if err != nil {
 			log.Printf("[WARN] Schedule read error")
@@ -398,7 +398,7 @@ func resourcePagerDutyScheduleDelete(d *schema.ResourceData, meta interface{}) e
 
 	log.Printf("[INFO] Starting deletion process of Schedule %s", scheduleId)
 	var scheduleData *pagerduty.Schedule
-	retryErr := resource.Retry(10*time.Second, func() *resource.RetryError {
+	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		resp, _, err := client.Schedules.Get(scheduleId, &pagerduty.GetScheduleOptions{})
 		if err != nil {
 			if isErrCode(err, http.StatusBadRequest) {
@@ -658,7 +658,7 @@ func flattenScheFinalSchedule(finalSche *pagerduty.SubSchedule) []map[string]int
 
 func listIncidentsOpenedRelatedToSchedule(c *pagerduty.Client, schedule *pagerduty.Schedule, epIDs []string) ([]string, error) {
 	var incidents []*pagerduty.Incident
-	retryErr := resource.Retry(30*time.Second, func() *resource.RetryError {
+	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		var err error
 		options := &pagerduty.ListIncidentsOptions{
 			DateRange: "all",
@@ -765,7 +765,7 @@ func removeScheduleFromEP(c *pagerduty.Client, scheduleID string, ep *pagerduty.
 	}
 	ep.EscalationRules = epr
 
-	retryErr := resource.Retry(10*time.Second, func() *resource.RetryError {
+	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		_, _, err := c.EscalationPolicies.Update(ep.ID, ep)
 		if err != nil {
 			if !isErrCode(err, 404) {
@@ -856,7 +856,7 @@ func detectUseOfScheduleByEPsWithOneLayer(scheduleId string, eps []*pagerduty.Es
 func fetchEPsDataUsingASchedule(eps []string, c *pagerduty.Client) ([]*pagerduty.EscalationPolicy, error) {
 	fullEPs := []*pagerduty.EscalationPolicy{}
 	for _, epID := range eps {
-		retryErr := resource.Retry(10*time.Second, func() *resource.RetryError {
+		retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 			ep, _, err := c.EscalationPolicies.Get(epID, &pagerduty.GetEscalationPolicyOptions{})
 			if err != nil {
 				if isErrCode(err, http.StatusBadRequest) {

--- a/pagerduty/resource_pagerduty_service_event_rule.go
+++ b/pagerduty/resource_pagerduty_service_event_rule.go
@@ -415,7 +415,7 @@ func resourcePagerDutyServiceEventRuleUpdate(d *schema.ResourceData, meta interf
 	log.Printf("[INFO] Updating PagerDuty service event rule: %s", d.Id())
 	serviceID := d.Get("service").(string)
 
-	retryErr := resource.Retry(30*time.Second, func() *resource.RetryError {
+	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if updatedRule, _, err := client.Services.UpdateEventRule(serviceID, d.Id(), rule); err != nil {
 			if isErrCode(err, http.StatusBadRequest) {
 				return resource.NonRetryableError(err)
@@ -445,7 +445,7 @@ func resourcePagerDutyServiceEventRuleDelete(d *schema.ResourceData, meta interf
 	log.Printf("[INFO] Deleting PagerDuty service event rule: %s", d.Id())
 	serviceID := d.Get("service").(string)
 
-	retryErr := resource.Retry(30*time.Second, func() *resource.RetryError {
+	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if _, err := client.Services.DeleteEventRule(serviceID, d.Id()); err != nil {
 			if isErrCode(err, http.StatusBadRequest) {
 				return resource.NonRetryableError(err)

--- a/pagerduty/resource_pagerduty_service_integration.go
+++ b/pagerduty/resource_pagerduty_service_integration.go
@@ -752,7 +752,7 @@ func resourcePagerDutyServiceIntegrationCreate(d *schema.ResourceData, meta inte
 
 	service := d.Get("service").(string)
 
-	retryErr := resource.Retry(1*time.Minute, func() *resource.RetryError {
+	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if serviceIntegration, _, err := client.Services.CreateIntegration(service, serviceIntegration); err != nil {
 			if isErrCode(err, 400) {
 				return resource.RetryableError(err)

--- a/pagerduty/resource_pagerduty_tag.go
+++ b/pagerduty/resource_pagerduty_tag.go
@@ -59,7 +59,7 @@ func resourcePagerDutyTagCreate(d *schema.ResourceData, meta interface{}) error 
 
 	log.Printf("[INFO] Creating PagerDuty tag %s", tag.Label)
 
-	retryErr := resource.Retry(10*time.Second, func() *resource.RetryError {
+	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if tag, _, err := client.Tags.Create(tag); err != nil {
 			if isErrCode(err, 400) || isErrCode(err, 429) {
 				return resource.RetryableError(err)
@@ -88,7 +88,7 @@ func resourcePagerDutyTagRead(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[INFO] Reading PagerDuty tag %s", d.Id())
 
-	return resource.Retry(30*time.Second, func() *resource.RetryError {
+	return resource.Retry(2*time.Minute, func() *resource.RetryError {
 		tag, _, err := client.Tags.Get(d.Id())
 		if err != nil {
 			if isErrCode(err, http.StatusBadRequest) {

--- a/pagerduty/resource_pagerduty_tag_assignment.go
+++ b/pagerduty/resource_pagerduty_tag_assignment.go
@@ -116,7 +116,7 @@ func resourcePagerDutyTagAssignmentRead(d *schema.ResourceData, meta interface{}
 		return nil
 	}
 
-	return resource.Retry(30*time.Second, func() *resource.RetryError {
+	return resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if tagResponse, _, err := client.Tags.ListTagsForEntity(assignment.EntityType, assignment.EntityID); err != nil {
 			if isErrCode(err, http.StatusBadRequest) {
 				return resource.NonRetryableError(err)
@@ -155,7 +155,7 @@ func resourcePagerDutyTagAssignmentDelete(d *schema.ResourceData, meta interface
 	}
 	log.Printf("[INFO] Deleting PagerDuty tag assignment with tagID %s for entityID %s", assignment.TagID, assignment.EntityID)
 
-	retryErr := resource.Retry(10*time.Second, func() *resource.RetryError {
+	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if _, err := client.Tags.Assign(assignment.EntityType, assignment.EntityID, assignments); err != nil {
 			if isErrCode(err, 400) || isErrCode(err, 429) {
 				return resource.RetryableError(err)
@@ -232,7 +232,7 @@ func isFoundTagAssignmentEntity(entityID, entityType string, meta interface{}) (
 	fetchEscalationPolicy := func(id string) (*pagerduty.EscalationPolicy, *pagerduty.Response, error) {
 		return client.EscalationPolicies.Get(id, &pagerduty.GetEscalationPolicyOptions{})
 	}
-	retryErr := resource.Retry(30*time.Second, func() *resource.RetryError {
+	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		var err error
 		if entityType == "users" {
 			_, _, err = fetchUser(entityID)

--- a/pagerduty/resource_pagerduty_team.go
+++ b/pagerduty/resource_pagerduty_team.go
@@ -105,7 +105,7 @@ func resourcePagerDutyTeamRead(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[INFO] Reading PagerDuty team %s", d.Id())
 
-	return resource.Retry(30*time.Second, func() *resource.RetryError {
+	return resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if team, _, err := client.Teams.Get(d.Id()); err != nil {
 			if isErrCode(err, http.StatusBadRequest) {
 				return resource.NonRetryableError(err)
@@ -136,7 +136,7 @@ func resourcePagerDutyTeamUpdate(d *schema.ResourceData, meta interface{}) error
 
 	log.Printf("[INFO] Updating PagerDuty team %s", d.Id())
 
-	retryErr := resource.Retry(30*time.Second, func() *resource.RetryError {
+	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if _, _, err := client.Teams.Update(d.Id(), team); err != nil {
 			return resource.RetryableError(err)
 		}

--- a/pagerduty/resource_pagerduty_team_membership.go
+++ b/pagerduty/resource_pagerduty_team_membership.go
@@ -251,7 +251,7 @@ func buildEPsIdsList(l []*pagerduty.OnCall) []string {
 
 func extractEPsAssociatedToUser(c *pagerduty.Client, userID string) ([]string, error) {
 	var oncalls []*pagerduty.OnCall
-	retryErr := resource.Retry(10*time.Second, func() *resource.RetryError {
+	retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		resp, _, err := c.OnCall.List(&pagerduty.ListOnCallOptions{UserIds: []string{userID}})
 		if err != nil {
 			if isErrCode(err, http.StatusBadRequest) {
@@ -274,7 +274,7 @@ func extractEPsAssociatedToUser(c *pagerduty.Client, userID string) ([]string, e
 func dissociateEPsFromTeam(c *pagerduty.Client, teamID string, eps []string) ([]string, error) {
 	epsDissociatedFromTeam := []string{}
 	for _, ep := range eps {
-		retryErr := resource.Retry(10*time.Second, func() *resource.RetryError {
+		retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 			_, err := c.Teams.RemoveEscalationPolicy(teamID, ep)
 			if err != nil && !isErrCode(err, 404) {
 				time.Sleep(2 * time.Second)
@@ -299,7 +299,7 @@ func dissociateEPsFromTeam(c *pagerduty.Client, teamID string, eps []string) ([]
 
 func associateEPsBackToTeam(c *pagerduty.Client, teamID string, eps []string) error {
 	for _, ep := range eps {
-		retryErr := resource.Retry(10*time.Second, func() *resource.RetryError {
+		retryErr := resource.Retry(2*time.Minute, func() *resource.RetryError {
 			_, err := c.Teams.AddEscalationPolicy(teamID, ep)
 			if err != nil && !isErrCode(err, 404) {
 				time.Sleep(2 * time.Second)

--- a/pagerduty/resource_pagerduty_webhook_subscription.go
+++ b/pagerduty/resource_pagerduty_webhook_subscription.go
@@ -170,7 +170,7 @@ func resourcePagerDutyWebhookSubscriptionRead(d *schema.ResourceData, meta inter
 
 	log.Printf("[INFO] Reading PagerDuty webhook subscription %s", d.Id())
 
-	return resource.Retry(30*time.Second, func() *resource.RetryError {
+	return resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if webhook, _, err := client.WebhookSubscriptions.Get(d.Id()); err != nil {
 			if isErrCode(err, http.StatusBadRequest) {
 				return resource.NonRetryableError(err)


### PR DESCRIPTION
Add 1 minute timeout limit to api calls lifecycle.

Additionally, set retries timeouts across the provider to minimum 2min.

Second attempt and hopefully definitive to...

Close #780 

The first attempt brought by #802 didn't make it, because the granularity timeout configuration introduced with that update was not actually covering the whole lifecycle of api request hanging, due to multiple reasons in client/server side depending on the scenario the provider was running in. However, this simpler and more straightforward configuration proved to be the solution to make the provider able of gracefully retrying the calls once the new timeout was reached.