### PR TITLE
[CSGI-2739 ] Address permadiff when user name has repeated whitespaces

### DIFF
--- a/pagerduty/resource_pagerduty_user_test.go
+++ b/pagerduty/resource_pagerduty_user_test.go
@@ -53,10 +53,10 @@ func testSweepUser(region string) error {
 }
 
 func TestAccPagerDutyUser_Basic(t *testing.T) {
-	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	usernameSpaces := " " + username + " "
+	username := fmt.Sprintf("tf %s", acctest.RandString(5))
+	usernameSpaces := " " + strings.ReplaceAll(username, " ", "  ") + " "
 	usernameUpdated := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.test", username)
+	email := fmt.Sprintf("%s@foo.test", strings.ReplaceAll(username, " ", ""))
 	emailUpdated := fmt.Sprintf("%s@foo.test", usernameUpdated)
 
 	resource.Test(t, resource.TestCase{

--- a/pagerduty/util.go
+++ b/pagerduty/util.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"math"
 	"reflect"
+	"regexp"
 	"strings"
 	"time"
 	"unicode"
@@ -82,7 +83,9 @@ func parseRFC3339Time(k, oldTime, newTime string) (time.Time, time.Time, error) 
 }
 
 func suppressLeadTrailSpaceDiff(k, old, new string, d *schema.ResourceData) bool {
-	return old == strings.TrimSpace(new)
+	trimmedInput := strings.TrimSpace(new)
+	repeatedSpaceMatcher := regexp.MustCompile(`\s+`)
+	return old == repeatedSpaceMatcher.ReplaceAllLiteralString(trimmedInput, " ")
 }
 
 func suppressCaseDiff(k, old, new string, d *schema.ResourceData) bool {


### PR DESCRIPTION
Since diff produced by leading and trailing white spaces for user names was being suppressed, then diff produced by repeated white spaces in the middle of user names will be suppressed too for consistency of behaviour regarding `pagerduty_user`'s name attribute.