### PR TITLE
[CSGI-2574] Address: Fail to enable rules in pagerduty_event_orchestration_router

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,3 +74,5 @@ require (
 	google.golang.org/protobuf v1.32.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 )
+
+replace github.com/heimweh/go-pagerduty => github.com/imjaroiswebdev/go-pagerduty v0.0.0-20240205220520-6f8c0393b684

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/terraform-plugin-mux v0.13.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.31.0
 	github.com/hashicorp/terraform-plugin-testing v1.6.0
-	github.com/heimweh/go-pagerduty v0.0.0-20231212192829-0de11cddf326
+	github.com/heimweh/go-pagerduty v0.0.0-20240206151700-a2cbd995ef76
 )
 
 require (
@@ -74,5 +74,3 @@ require (
 	google.golang.org/protobuf v1.32.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 )
-
-replace github.com/heimweh/go-pagerduty => github.com/imjaroiswebdev/go-pagerduty v0.0.0-20240205220520-6f8c0393b684

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
-github.com/heimweh/go-pagerduty v0.0.0-20231212192829-0de11cddf326 h1:ZyL8A1yPg0C9rUKc/QCUNM848NJ9DhTE/cRZH54y/5s=
-github.com/heimweh/go-pagerduty v0.0.0-20231212192829-0de11cddf326/go.mod h1:r59w5iyN01Qvi734yA5hZldbSeJJmsJzee/1kQ/MK7s=
+github.com/imjaroiswebdev/go-pagerduty v0.0.0-20240205220520-6f8c0393b684 h1:/RQu11u50ZZED2vVYRlKlFRukv3etj6wTASBmoa+LRU=
+github.com/imjaroiswebdev/go-pagerduty v0.0.0-20240205220520-6f8c0393b684/go.mod h1:r59w5iyN01Qvi734yA5hZldbSeJJmsJzee/1kQ/MK7s=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
-github.com/imjaroiswebdev/go-pagerduty v0.0.0-20240205220520-6f8c0393b684 h1:/RQu11u50ZZED2vVYRlKlFRukv3etj6wTASBmoa+LRU=
-github.com/imjaroiswebdev/go-pagerduty v0.0.0-20240205220520-6f8c0393b684/go.mod h1:r59w5iyN01Qvi734yA5hZldbSeJJmsJzee/1kQ/MK7s=
+github.com/heimweh/go-pagerduty v0.0.0-20240206151700-a2cbd995ef76 h1:+JY7wpGAsTe/r51/nTdo3pQQ2Wj4cTXpsQfij1JK2gc=
+github.com/heimweh/go-pagerduty v0.0.0-20240206151700-a2cbd995ef76/go.mod h1:r59w5iyN01Qvi734yA5hZldbSeJJmsJzee/1kQ/MK7s=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/event_orchestration_path.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/event_orchestration_path.go
@@ -37,7 +37,7 @@ type EventOrchestrationPathRule struct {
 	Label      string                                 `json:"label,omitempty"`
 	Conditions []*EventOrchestrationPathRuleCondition `json:"conditions"`
 	Actions    *EventOrchestrationPathRuleActions     `json:"actions,omitempty"`
-	Disabled   bool                                   `json:"disabled,omitempty"`
+	Disabled   bool                                   `json:"disabled"`
 }
 
 type EventOrchestrationPathRuleCondition struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -247,7 +247,7 @@ github.com/hashicorp/terraform-svchost
 # github.com/hashicorp/yamux v0.1.1
 ## explicit; go 1.15
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20231212192829-0de11cddf326 => github.com/imjaroiswebdev/go-pagerduty v0.0.0-20240205220520-6f8c0393b684
+# github.com/heimweh/go-pagerduty v0.0.0-20240206151700-a2cbd995ef76
 ## explicit; go 1.17
 github.com/heimweh/go-pagerduty/pagerduty
 github.com/heimweh/go-pagerduty/persistentconfig
@@ -546,4 +546,3 @@ google.golang.org/protobuf/types/known/timestamppb
 # gopkg.in/ini.v1 v1.67.0
 ## explicit
 gopkg.in/ini.v1
-# github.com/heimweh/go-pagerduty => github.com/imjaroiswebdev/go-pagerduty v0.0.0-20240205220520-6f8c0393b684

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -247,7 +247,7 @@ github.com/hashicorp/terraform-svchost
 # github.com/hashicorp/yamux v0.1.1
 ## explicit; go 1.15
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20231212192829-0de11cddf326
+# github.com/heimweh/go-pagerduty v0.0.0-20231212192829-0de11cddf326 => github.com/imjaroiswebdev/go-pagerduty v0.0.0-20240205220520-6f8c0393b684
 ## explicit; go 1.17
 github.com/heimweh/go-pagerduty/pagerduty
 github.com/heimweh/go-pagerduty/persistentconfig
@@ -546,3 +546,4 @@ google.golang.org/protobuf/types/known/timestamppb
 # gopkg.in/ini.v1 v1.67.0
 ## explicit
 gopkg.in/ini.v1
+# github.com/heimweh/go-pagerduty => github.com/imjaroiswebdev/go-pagerduty v0.0.0-20240205220520-6f8c0393b684


### PR DESCRIPTION
Closes #652

## Acceptance tests output and new test case introduced...

```sh
$ make testacc TESTARGS="-count=1 -run TestAccPagerDutyEventOrchestration"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -count=1 -run TestAccPagerDutyEventOrchestration -timeout 120m
?       github.com/terraform-providers/terraform-provider-pagerduty     [no test files]
?       github.com/terraform-providers/terraform-provider-pagerduty/util        [no test files]
=== RUN   TestAccPagerDutyEventOrchestrationIntegration_import
--- PASS: TestAccPagerDutyEventOrchestrationIntegration_import (6.78s)
=== RUN   TestAccPagerDutyEventOrchestrationPathGlobal_import
--- PASS: TestAccPagerDutyEventOrchestrationPathGlobal_import (13.93s)
=== RUN   TestAccPagerDutyEventOrchestrationPathRouter_import
--- PASS: TestAccPagerDutyEventOrchestrationPathRouter_import (16.56s)
=== RUN   TestAccPagerDutyEventOrchestrationPathService_import
--- PASS: TestAccPagerDutyEventOrchestrationPathService_import (14.56s)
=== RUN   TestAccPagerDutyEventOrchestrationPathUnrouted_import
--- PASS: TestAccPagerDutyEventOrchestrationPathUnrouted_import (13.49s)
=== RUN   TestAccPagerDutyEventOrchestration_import
--- PASS: TestAccPagerDutyEventOrchestration_import (7.49s)
=== RUN   TestAccPagerDutyEventOrchestrationNameOnly_import
--- PASS: TestAccPagerDutyEventOrchestrationNameOnly_import (4.75s)
=== RUN   TestAccPagerDutyEventOrchestrationIntegration_Basic
--- PASS: TestAccPagerDutyEventOrchestrationIntegration_Basic (21.82s)
=== RUN   TestAccPagerDutyEventOrchestrationPathGlobal_Basic
--- PASS: TestAccPagerDutyEventOrchestrationPathGlobal_Basic (63.05s)
=== RUN   TestAccPagerDutyEventOrchestrationPathRouter_Basic
--- PASS: TestAccPagerDutyEventOrchestrationPathRouter_Basic (54.31s)
=== RUN   TestAccPagerDutyEventOrchestrationPathRouter_EnableRoutingRule # 👈 New test case introduced
--- PASS: TestAccPagerDutyEventOrchestrationPathRouter_EnableRoutingRule (19.79s)
=== RUN   TestAccPagerDutyEventOrchestrationPathService_Basic
--- PASS: TestAccPagerDutyEventOrchestrationPathService_Basic (115.73s)
=== RUN   TestAccPagerDutyEventOrchestrationPathUnrouted_Basic
--- PASS: TestAccPagerDutyEventOrchestrationPathUnrouted_Basic (46.91s)
=== RUN   TestAccPagerDutyEventOrchestration_Basic
--- PASS: TestAccPagerDutyEventOrchestration_Basic (17.06s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   417.516s
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerdutyplugin     0.814s [no tests to run]

$ make testacc TESTARGS="-count=1 -run TestAccDataSourcePagerDutyEventOrchestration"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -count=1 -run TestAccDataSourcePagerDutyEventOrchestration -timeout 120m
?       github.com/terraform-providers/terraform-provider-pagerduty     [no test files]
?       github.com/terraform-providers/terraform-provider-pagerduty/util        [no test files]
=== RUN   TestAccDataSourcePagerDutyEventOrchestrationIntegration_Basic
--- PASS: TestAccDataSourcePagerDutyEventOrchestrationIntegration_Basic (276.76s)
=== RUN   TestAccDataSourcePagerDutyEventOrchestration_Basic
--- PASS: TestAccDataSourcePagerDutyEventOrchestration_Basic (5.99s)
=== RUN   TestAccDataSourcePagerDutyEventOrchestrations_Basic
--- PASS: TestAccDataSourcePagerDutyEventOrchestrations_Basic (22.59s)
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerduty   306.004s
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-pagerduty/pagerdutyplugin     0.981s [no tests to run]

```

## Depends on https://github.com/heimweh/go-pagerduty/pull/148