### PR TITLE
Adding an escape for an empty specifiedSteps slice when calling flattenIncidentWorkflowSteps

### DIFF
--- a/pagerduty/resource_pagerduty_incident_workflow.go
+++ b/pagerduty/resource_pagerduty_incident_workflow.go
@@ -488,6 +488,9 @@ func flattenIncidentWorkflowSteps(iw *pagerduty.IncidentWorkflow, specifiedSteps
 	newSteps := make([]map[string]interface{}, len(iw.Steps))
 	for i, s := range iw.Steps {
 		m := make(map[string]interface{})
+		if len(specifiedSteps) == 0 {
+			continue
+		}
 		specifiedStep := *specifiedSteps[i]
 		m["id"] = s.ID
 		m["name"] = s.Name


### PR DESCRIPTION
I had encountered the same issue as reported here when importing an incident workflow:
* https://github.com/PagerDuty/terraform-provider-pagerduty/issues/786
* https://github.com/PagerDuty/terraform-provider-pagerduty/issues/809

I'm not 100% sure if this handles the resource attributes appropriately, would love a sanity check :)
Testing this locally worked for me, as far as I can tell - Or at least let me finish importing my resources.

I've run the local acceptance tests, but it looks like one test fails before I've added my changes, so I can't be too sure 🤔 
![image](https://github.com/PagerDuty/terraform-provider-pagerduty/assets/1776706/3c43fa7d-396f-4775-8cd2-fabbda9d680e)