### PR TITLE
fix(team membership): Allow 404 to propagate to avoid registering it in disassociated eps list

### DIFF
--- a/pagerduty/resource_pagerduty_team_membership.go
+++ b/pagerduty/resource_pagerduty_team_membership.go
@@ -277,9 +277,12 @@ func dissociateEPsFromTeam(c *pagerduty.Client, teamID string, eps []string) ([]
 	for _, ep := range eps {
 		retryErr := retry.Retry(2*time.Minute, func() *retry.RetryError {
 			_, err := c.Teams.RemoveEscalationPolicy(teamID, ep)
-			if err != nil {
+			if err != nil && !isErrCode(err, 404) {
 				time.Sleep(2 * time.Second)
 				return retry.RetryableError(err)
+			}
+			if isErrCode(err, 404) {
+				return retry.NonRetryableError(err)
 			}
 			return nil
 		})

--- a/pagerduty/resource_pagerduty_team_membership.go
+++ b/pagerduty/resource_pagerduty_team_membership.go
@@ -277,7 +277,7 @@ func dissociateEPsFromTeam(c *pagerduty.Client, teamID string, eps []string) ([]
 	for _, ep := range eps {
 		retryErr := retry.Retry(2*time.Minute, func() *retry.RetryError {
 			_, err := c.Teams.RemoveEscalationPolicy(teamID, ep)
-			if err != nil && !isErrCode(err, 404) {
+			if err != nil {
 				time.Sleep(2 * time.Second)
 				return retry.RetryableError(err)
 			}

--- a/pagerduty/resource_pagerduty_team_membership.go
+++ b/pagerduty/resource_pagerduty_team_membership.go
@@ -281,7 +281,7 @@ func dissociateEPsFromTeam(c *pagerduty.Client, teamID string, eps []string) ([]
 				time.Sleep(2 * time.Second)
 				return retry.RetryableError(err)
 			}
-			if isErrCode(err, 404) {
+			if err != nil && isErrCode(err, 404) {
 				return retry.NonRetryableError(err)
 			}
 			return nil


### PR DESCRIPTION
This is related to a bug where when deleting team membership you can get errors when the same user exists in other teams escalation policies (due to the fact that it will try to reattach all the EP's to the team, even when getting 404 error).
TLDR, Line 289 will never get hit if we keep that logic in place.

## Acceptance test results...

```sh
$ make testacc TESTARGS='-run TestAccPagerDutyTeamMembership'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccPagerDutyTeamMembership -timeout 120m
?       github.com/PagerDuty/terraform-provider-pagerduty       [no test files]
=== RUN   TestAccPagerDutyTeamMembership_import
--- PASS: TestAccPagerDutyTeamMembership_import (20.67s)
=== RUN   TestAccPagerDutyTeamMembership_importWithRole
--- PASS: TestAccPagerDutyTeamMembership_importWithRole (19.72s)
=== RUN   TestAccPagerDutyTeamMembership_Basic
--- PASS: TestAccPagerDutyTeamMembership_Basic (18.80s)
=== RUN   TestAccPagerDutyTeamMembership_WithRole
--- PASS: TestAccPagerDutyTeamMembership_WithRole (16.48s)
=== RUN   TestAccPagerDutyTeamMembership_WithRoleConsistentlyAssigned
--- PASS: TestAccPagerDutyTeamMembership_WithRoleConsistentlyAssigned (27.50s)
=== RUN   TestAccPagerDutyTeamMembership_DestroyWithEscalationPolicyDependant
--- PASS: TestAccPagerDutyTeamMembership_DestroyWithEscalationPolicyDependant (27.87s)
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerduty     132.341s
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerdutyplugin       0.959s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/util  1.196s [no tests to run]
```