### PR TITLE
Delete a non-actionable warning on the `pagerduty_event_orchestration_integration` resource

### DIFF
--- a/pagerduty/resource_pagerduty_event_orchestration_integration.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_integration.go
@@ -28,7 +28,6 @@ func resourcePagerDutyEventOrchestrationIntegration() *schema.Resource {
 			"event_orchestration": {
 				Type:             schema.TypeString,
 				Required:         true,
-				ValidateDiagFunc: addIntegrationMigrationWarning(),
 			},
 			"id": {
 				Type:     schema.TypeString,
@@ -55,20 +54,6 @@ func resourcePagerDutyEventOrchestrationIntegration() *schema.Resource {
 				},
 			},
 		},
-	}
-}
-
-func addIntegrationMigrationWarning() schema.SchemaValidateDiagFunc {
-	return func(v interface{}, p cty.Path) diag.Diagnostics {
-		var diags diag.Diagnostics
-
-		diags = append(diags, diag.Diagnostic{
-			Severity:      diag.Warning,
-			Summary:       "Modifying the event_orchestration property of the 'pagerduty_event_orchestration_integration' resource will cause all future events sent with this integration's routing key to be evaluated against the new Event Orchestration.",
-			AttributePath: p,
-		})
-
-		return diags
 	}
 }
 

--- a/pagerduty/resource_pagerduty_event_orchestration_integration.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_integration.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pagerduty/resource_pagerduty_event_orchestration_integration.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_integration.go
@@ -26,8 +26,8 @@ func resourcePagerDutyEventOrchestrationIntegration() *schema.Resource {
 		},
 		Schema: map[string]*schema.Schema{
 			"event_orchestration": {
-				Type:             schema.TypeString,
-				Required:         true,
+				Type:     schema.TypeString,
+				Required: true,
 			},
 			"id": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
### Context
When we just launched multiple EO Integrations we wanted to emphasize that modifying the `event_orchestration` attribute will result in an ingestion-level change where all future events sent to this integration will now be evaluated against a new orchestration. But since this warning is non-actionable and we also have this information in the Provider docs, we decided that the warning is rather an annoyance than a helpful message. This PR deletes the warning and as a result fixes the following issues:
- Closes #704 
- Closes #839

