### PR TITLE
fix invalid target type in docs

### DIFF
--- a/website/docs/d/user.html.markdown
+++ b/website/docs/d/user.html.markdown
@@ -25,7 +25,7 @@ resource "pagerduty_escalation_policy" "foo" {
     escalation_delay_in_minutes = 10
 
     target {
-      type = "user"
+      type = "user_reference"
       id   = data.pagerduty_user.me.id
     }
   }


### PR DESCRIPTION
Fixes invalid target type `user` in https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/data-sources/user where it should be `user_reference` (https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/escalation_policy#type)

Closes #857 