### PR TITLE
Prevent timeout for alert_grouping_parameters to be explicitly set to zero when they are of type "content_based"

### DIFF
--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -647,6 +647,9 @@ func expandAlertGroupingParameters(v interface{}) *pagerduty.AlertGroupingParame
 	}
 
 	alertGroupingParameters.Config = expandAlertGroupingConfig(ragpVal["config"])
+	if groupingType == "content_based" && alertGroupingParameters.Config != nil {
+		alertGroupingParameters.Config.Timeout = nil
+	}
 	return alertGroupingParameters
 }
 


### PR DESCRIPTION
Fixes issue #867

## New acceptance test introduced to prevent regression

```sh
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -count=1 -run TestAccPagerDutyService_AlertGroupingParametersAddConfigField -timeout 120m
?       github.com/PagerDuty/terraform-provider-pagerduty       [no test files]
=== RUN   TestAccPagerDutyService_AlertGroupingParametersAddConfigField
--- PASS: TestAccPagerDutyService_AlertGroupingParametersAddConfigField (21.31s)
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerduty     21.978s
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerdutyplugin       1.147s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/util  0.780s [no tests to run]
```