### PR TITLE
Add api_limit field to provider configuration

### DIFF
--- a/pagerduty/config.go
+++ b/pagerduty/config.go
@@ -31,6 +31,9 @@ type Config struct {
 	// The PagerDuty User level token for Slack
 	UserToken string
 
+	// API Pagination Limit
+	ApiLimit int
+
 	// Skip validation of the token against the PagerDuty API
 	SkipCredsValidation bool
 

--- a/pagerduty/data_source_pagerduty_service.go
+++ b/pagerduty/data_source_pagerduty_service.go
@@ -77,7 +77,7 @@ func dataSourcePagerDutyServiceRead(d *schema.ResourceData, meta interface{}) er
 
 	o := &pagerduty.ListServicesOptions{
 		Query: searchName,
-		Limit: d.Get("api_limit").(int),
+		Limit: meta.(*Config).ApiLimit,
 	}
 
 	return retry.Retry(5*time.Minute, func() *retry.RetryError {

--- a/pagerduty/provider.go
+++ b/pagerduty/provider.go
@@ -233,6 +233,7 @@ func providerConfigureContextFunc(_ context.Context, data *schema.ResourceData, 
 		UserToken:           data.Get("user_token").(string),
 		UserAgent:           fmt.Sprintf("(%s %s) Terraform/%s", runtime.GOOS, runtime.GOARCH, terraformVersion),
 		ApiUrlOverride:      data.Get("api_url_override").(string),
+		ApiLimit:            data.Get("api_limit").(int),
 		ServiceRegion:       serviceRegion,
 	}
 

--- a/pagerdutyplugin/provider.go
+++ b/pagerdutyplugin/provider.go
@@ -38,6 +38,7 @@ func (p *Provider) Schema(ctx context.Context, req provider.SchemaRequest, resp 
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"api_url_override":            schema.StringAttribute{Optional: true},
+			"api_limit":                   schema.Int64Attribute{Optional: true},
 			"service_region":              schema.StringAttribute{Optional: true},
 			"skip_credentials_validation": schema.BoolAttribute{Optional: true},
 			"token":                       schema.StringAttribute{Optional: true},
@@ -190,6 +191,7 @@ type providerArguments struct {
 	SkipCredentialsValidation types.Bool   `tfsdk:"skip_credentials_validation"`
 	ServiceRegion             types.String `tfsdk:"service_region"`
 	ApiUrlOverride            types.String `tfsdk:"api_url_override"`
+	ApiLimit                  types.Int64  `tfsdk:"api_limit"`
 	UseAppOauthScopedToken    types.List   `tfsdk:"use_app_oauth_scoped_token"`
 }
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -58,6 +58,7 @@ The following arguments are supported:
 * `skip_credentials_validation` - (Optional) Skip validation of the token against the PagerDuty API.
 * `service_region` - (Optional) The PagerDuty service region to use. Default to empty (uses US region). Supported value: `eu`. This setting also affects configuration of `use_app_oauth_scoped_token` for setting Region of *App Oauth token credentials*. It can also be sourced from the `PAGERDUTY_SERVICE_REGION` environment variable.
 * `api_url_override` - (Optional) It can be used to set a custom proxy endpoint as PagerDuty client api url overriding `service_region` setup.
+* `api_limit` - (Optional) It can be used to set the limit pagination property when calling the provider calls the API.
 
 The `use_app_oauth_scoped_token` block contains the following arguments:
 


### PR DESCRIPTION
Assuming a service named _hello_, and 25 other services in the pattern _*hello_, when using the following data block:

```
data "pagerduty_service" "hello" {
    name = "hello"
}
``` 

It will fail with the message: 

> Error: Unable to locate any service with the name: hello

This is because the API call to locate the service, by default, has a pagination limit of 25, thus the service is excluded since it appears on the 2nd page.

This PR adds an api_limit field to the provider to allow a pagination limit to be set.

It can be used as such:
```
provider "pagerduty" {
  token = "your_token"
  api_limit = 50 // default 25
}
```