### PR TITLE
Allow resource extension's endpoint_url to be imported as null

### DIFF
--- a/pagerdutyplugin/import_pagerduty_extension_test.go
+++ b/pagerdutyplugin/import_pagerduty_extension_test.go
@@ -30,3 +30,29 @@ func TestAccPagerDutyExtension_import(t *testing.T) {
 		},
 	})
 }
+
+func TestAccPagerDutyExtension_import_WithoutEndpointURL(t *testing.T) {
+	extension_name := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	name := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	url := "https://example.com/receive_a_pagerduty_webhook"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(),
+		CheckDestroy:             testAccCheckPagerDutyExtensionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyExtensionConfig(name, extension_name, url, "false", "any"),
+			},
+			{
+				Config: testAccCheckPagerDutyExtensionConfig_NoEndpointURL(name, extension_name, "false", "any"),
+			},
+			{
+				ResourceName:            "pagerduty_extension.foo",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"config"},
+			},
+		},
+	})
+}

--- a/pagerdutyplugin/resource_pagerduty_extension.go
+++ b/pagerdutyplugin/resource_pagerduty_extension.go
@@ -37,12 +37,36 @@ func (r *resourceExtension) Metadata(_ context.Context, _ resource.MetadataReque
 func (r *resourceExtension) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			"name":         schema.StringAttribute{Optional: true, Computed: true},
-			"id":           schema.StringAttribute{Computed: true},
-			"html_url":     schema.StringAttribute{Computed: true},
-			"type":         schema.StringAttribute{Optional: true, Computed: true},
-			"endpoint_url": schema.StringAttribute{Optional: true, Sensitive: true},
-			"summary":      schema.StringAttribute{Computed: true},
+			"name": schema.StringAttribute{Optional: true, Computed: true},
+			"id": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"html_url": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"type": schema.StringAttribute{
+				Optional: true, Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"endpoint_url": schema.StringAttribute{
+				Optional:  true,
+				Computed:  true,
+				Sensitive: true,
+			},
+			"summary": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 			"extension_objects": schema.SetAttribute{
 				Required:    true,
 				ElementType: types.StringType,
@@ -317,6 +341,7 @@ func flattenExtension(response *pagerduty.Extension, accessToken *string, diags 
 		ID:               types.StringValue(response.ID),
 		Name:             types.StringValue(response.Name),
 		HTMLURL:          types.StringValue(response.HTMLURL),
+		Type:             types.StringValue(response.Type),
 		Summary:          types.StringValue(response.Summary),
 		EndpointURL:      types.StringValue(response.EndpointURL),
 		Config:           flattenExtensionConfig(response.Config, accessToken, diags),


### PR DESCRIPTION
Closes #869 

## Acceptance tests introduced...

```sh
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -count=1 -run TestAccPagerDutyExtension_import -timeout 120m
?       github.com/PagerDuty/terraform-provider-pagerduty       [no test files]
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerduty     0.541s [no tests to run]
=== RUN   TestAccPagerDutyExtension_import
--- PASS: TestAccPagerDutyExtension_import (19.72s)
=== RUN   TestAccPagerDutyExtension_import_WithoutEndpointURL # 👈 New acceptance introduce to protect from a regression
--- PASS: TestAccPagerDutyExtension_import_WithoutEndpointURL (24.18s)
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerdutyplugin       44.780s
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/util  0.625s [no tests to run]
```