### PR TITLE
Add the option to ignore TLS certificate errors when calling the PD API.

### DIFF
--- a/pagerduty/config_test.go
+++ b/pagerduty/config_test.go
@@ -65,3 +65,16 @@ func TestConfigCustomAppUrl(t *testing.T) {
 		t.Fatalf("error: expected the client to not fail: %v", err)
 	}
 }
+
+// Test config with InsecureTls setting
+func TestConfigInsecureTls(t *testing.T) {
+	config := Config{
+		Token:               "foo",
+		InsecureTls:         true,
+		SkipCredsValidation: true,
+	}
+
+	if _, err := config.Client(); err != nil {
+		t.Fatalf("error: expected the client to not fail: %v", err)
+	}
+}

--- a/pagerduty/provider.go
+++ b/pagerduty/provider.go
@@ -77,6 +77,12 @@ func Provider(isMux bool) *schema.Provider {
 				Optional: true,
 				Default:  "",
 			},
+
+			"insecure_tls": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
@@ -228,6 +234,7 @@ func providerConfigureContextFunc(_ context.Context, data *schema.ResourceData, 
 		UserAgent:           fmt.Sprintf("(%s %s) Terraform/%s", runtime.GOOS, runtime.GOARCH, terraformVersion),
 		ApiUrlOverride:      data.Get("api_url_override").(string),
 		ServiceRegion:       serviceRegion,
+		InsecureTls:         data.Get("insecure_tls").(bool),
 	}
 
 	useAuthTokenType := pagerduty.AuthTokenTypeAPIToken

--- a/pagerdutyplugin/config_test.go
+++ b/pagerdutyplugin/config_test.go
@@ -66,3 +66,16 @@ func TestConfigCustomAppUrl(t *testing.T) {
 		t.Fatalf("error: expected the client to not fail: %v", err)
 	}
 }
+
+// Test config with InsecureTls
+func TestConfigInsecureTls(t *testing.T) {
+	config := Config{
+		Token:               "foo",
+		InsecureTls:         true,
+		SkipCredsValidation: true,
+	}
+
+	if _, err := config.Client(context.Background()); err != nil {
+		t.Fatalf("error: expected the client to not fail: %v", err)
+	}
+}

--- a/pagerdutyplugin/provider.go
+++ b/pagerdutyplugin/provider.go
@@ -42,6 +42,7 @@ func (p *Provider) Schema(ctx context.Context, req provider.SchemaRequest, resp 
 			"skip_credentials_validation": schema.BoolAttribute{Optional: true},
 			"token":                       schema.StringAttribute{Optional: true},
 			"user_token":                  schema.StringAttribute{Optional: true},
+			"insecure_tls":                schema.BoolAttribute{Optional: true},
 		},
 		Blocks: map[string]schema.Block{
 			"use_app_oauth_scoped_token": useAppOauthScopedTokenBlock,
@@ -99,6 +100,7 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 	}
 
 	skipCredentialsValidation := args.SkipCredentialsValidation.Equal(types.BoolValue(true))
+	insecureTls := args.InsecureTls.Equal(types.BoolValue(true))
 
 	config := Config{
 		ApiUrl:              "https://api." + regionApiUrl + "pagerduty.com",
@@ -109,6 +111,7 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 		TerraformVersion:    req.TerraformVersion,
 		ApiUrlOverride:      args.ApiUrlOverride.ValueString(),
 		ServiceRegion:       serviceRegion,
+		InsecureTls:         insecureTls,
 	}
 
 	if !args.UseAppOauthScopedToken.IsNull() {
@@ -192,6 +195,7 @@ type providerArguments struct {
 	ServiceRegion             types.String `tfsdk:"service_region"`
 	ApiUrlOverride            types.String `tfsdk:"api_url_override"`
 	UseAppOauthScopedToken    types.List   `tfsdk:"use_app_oauth_scoped_token"`
+	InsecureTls               types.Bool   `tfsdk:"insecure_tls"`
 }
 
 type SchemaGetter interface {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -58,6 +58,7 @@ The following arguments are supported:
 * `skip_credentials_validation` - (Optional) Skip validation of the token against the PagerDuty API.
 * `service_region` - (Optional) The PagerDuty service region to use. Default to empty (uses US region). Supported value: `eu`. This setting also affects configuration of `use_app_oauth_scoped_token` for setting Region of *App Oauth token credentials*. It can also be sourced from the `PAGERDUTY_SERVICE_REGION` environment variable.
 * `api_url_override` - (Optional) It can be used to set a custom proxy endpoint as PagerDuty client api url overriding `service_region` setup.
+* `insecure_tls` - (Optional) Can be used to disable TLS certificate checking when calling the PagerDuty API. This can be useful if you're behind a corporate proxy.
 
 The `use_app_oauth_scoped_token` block contains the following arguments:
 


### PR DESCRIPTION
Hi folks,

Thanks for the awesome module.

This is my first attempt at writing terraform provider code (and I'm pretty green to golang) so please be gentle. :smile: 

This update makes it possible to ignore TLS certs if you really really need to, i.e. when you're behind a corporate proxy that messes with with the certificates...

Is this something you'd accept as a change? I've tested it on our CI server and it applies nicely.

I wasn't sure if I should update the changelog or not, please let me know and I can remove that edit if needed.

Thanks!