### PR TITLE
Ignore import state verification for EO routing rules ids

### DIFF
--- a/pagerduty/import_pagerduty_event_orchestration_path_router_test.go
+++ b/pagerduty/import_pagerduty_event_orchestration_path_router_test.go
@@ -28,6 +28,10 @@ func TestAccPagerDutyEventOrchestrationPathRouter_import(t *testing.T) {
 				ImportStateIdFunc: testAccCheckPagerDutyEventOrchestrationPathRouterID,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"set.0.rule.0.id",
+					"set.0.rule.1.id",
+				},
 			},
 		},
 	})

--- a/pagerduty/import_pagerduty_event_orchestration_path_service_test.go
+++ b/pagerduty/import_pagerduty_event_orchestration_path_service_test.go
@@ -22,10 +22,11 @@ func TestAccPagerDutyEventOrchestrationPathService_import(t *testing.T) {
 				Config: testAccCheckPagerDutyEventOrchestrationPathServiceAllActionsConfig(escalationPolicy, service),
 			},
 			{
-				ResourceName:      "pagerduty_event_orchestration_service.serviceA",
-				ImportStateIdFunc: testAccCheckPagerDutyEventOrchestrationPathServiceID,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "pagerduty_event_orchestration_service.serviceA",
+				ImportStateIdFunc:       testAccCheckPagerDutyEventOrchestrationPathServiceID,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"enable_event_orchestration_for_service"},
 			},
 		},
 	})

--- a/pagerduty/import_pagerduty_event_orchestration_path_unrouted_test.go
+++ b/pagerduty/import_pagerduty_event_orchestration_path_unrouted_test.go
@@ -28,6 +28,11 @@ func TestAccPagerDutyEventOrchestrationPathUnrouted_import(t *testing.T) {
 				ImportStateIdFunc: testAccCheckPagerDutyEventOrchestrationPathUnroutedID,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"set.0.rule.0.id",
+					"set.1.rule.0.id",
+					"set.1.rule.1.id",
+				},
 			},
 		},
 	})


### PR DESCRIPTION
## Acceptance test results after patching...

```sh
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -count=1 -run TestAccPagerDutyEventOrchestrationPathRouter_import -timeout 120m
?       github.com/PagerDuty/terraform-provider-pagerduty       [no test files]
?       github.com/PagerDuty/terraform-provider-pagerduty/util/apiutil  [no test files]
=== RUN   TestAccPagerDutyEventOrchestrationPathRouter_import
--- PASS: TestAccPagerDutyEventOrchestrationPathRouter_import (15.98s)
PASS
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -count=1 -run TestAccPagerDutyEventOrchestrationPathUnrouted_import -timeout 120m
?       github.com/PagerDuty/terraform-provider-pagerduty       [no test files]
?       github.com/PagerDuty/terraform-provider-pagerduty/util/apiutil  [no test files]
=== RUN   TestAccPagerDutyEventOrchestrationPathUnrouted_import
--- PASS: TestAccPagerDutyEventOrchestrationPathUnrouted_import (12.95s)
PASS
```