### PR TITLE
Event Orchestration: add support for Dynamic Routing and Dynamic Escalation Policy Assignment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,3 +76,5 @@ require (
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 )
+
+replace github.com/heimweh/go-pagerduty => github.com/alexzakabluk/go-pagerduty v0.0.0-20240607142119-ac9a64bba6da

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/hashicorp/terraform-plugin-mux v0.13.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.31.0
 	github.com/hashicorp/terraform-plugin-testing v1.6.0
-	github.com/heimweh/go-pagerduty v0.0.0-20240503143637-3459408ac715
+	github.com/heimweh/go-pagerduty v0.0.0-20240722154207-95f2261a009a
 )
 
 require (
@@ -76,5 +76,3 @@ require (
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 )
-
-replace github.com/heimweh/go-pagerduty => github.com/alexzakabluk/go-pagerduty v0.0.0-20240712180401-2eb91c030980

--- a/go.mod
+++ b/go.mod
@@ -77,4 +77,4 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 )
 
-replace github.com/heimweh/go-pagerduty => github.com/alexzakabluk/go-pagerduty v0.0.0-20240607142119-ac9a64bba6da
+replace github.com/heimweh/go-pagerduty => github.com/alexzakabluk/go-pagerduty v0.0.0-20240712180401-2eb91c030980

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c h1:kMFnB0vCcX
 github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
-github.com/alexzakabluk/go-pagerduty v0.0.0-20240607142119-ac9a64bba6da h1:O2mVKSglj/gEz+Z7GX+L4Y1zGRIiDxPHdfp6Ri7klww=
-github.com/alexzakabluk/go-pagerduty v0.0.0-20240607142119-ac9a64bba6da/go.mod h1:r59w5iyN01Qvi734yA5hZldbSeJJmsJzee/1kQ/MK7s=
+github.com/alexzakabluk/go-pagerduty v0.0.0-20240712180401-2eb91c030980 h1:ovY3d2mRCubr/5uuk0xcAZq2zJIR7t0kqGc/n/OWOYc=
+github.com/alexzakabluk/go-pagerduty v0.0.0-20240712180401-2eb91c030980/go.mod h1:r59w5iyN01Qvi734yA5hZldbSeJJmsJzee/1kQ/MK7s=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c h1:kMFnB0vCcX
 github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
+github.com/alexzakabluk/go-pagerduty v0.0.0-20240607142119-ac9a64bba6da h1:O2mVKSglj/gEz+Z7GX+L4Y1zGRIiDxPHdfp6Ri7klww=
+github.com/alexzakabluk/go-pagerduty v0.0.0-20240607142119-ac9a64bba6da/go.mod h1:r59w5iyN01Qvi734yA5hZldbSeJJmsJzee/1kQ/MK7s=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
@@ -95,8 +97,6 @@ github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
-github.com/heimweh/go-pagerduty v0.0.0-20240503143637-3459408ac715 h1:DbdS2LIPkhsqgRcQzOAux0RpTJSH8VYOrN4rZZgznak=
-github.com/heimweh/go-pagerduty v0.0.0-20240503143637-3459408ac715/go.mod h1:r59w5iyN01Qvi734yA5hZldbSeJJmsJzee/1kQ/MK7s=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c h1:kMFnB0vCcX
 github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
-github.com/alexzakabluk/go-pagerduty v0.0.0-20240712180401-2eb91c030980 h1:ovY3d2mRCubr/5uuk0xcAZq2zJIR7t0kqGc/n/OWOYc=
-github.com/alexzakabluk/go-pagerduty v0.0.0-20240712180401-2eb91c030980/go.mod h1:r59w5iyN01Qvi734yA5hZldbSeJJmsJzee/1kQ/MK7s=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
@@ -97,6 +95,8 @@ github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
+github.com/heimweh/go-pagerduty v0.0.0-20240722154207-95f2261a009a h1:s7Z3DLwXMmfoeLEpgF8tfIxXGs8o734zcEVICTvAkAQ=
+github.com/heimweh/go-pagerduty v0.0.0-20240722154207-95f2261a009a/go.mod h1:r59w5iyN01Qvi734yA5hZldbSeJJmsJzee/1kQ/MK7s=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=

--- a/pagerduty/event_orchestration_path_util.go
+++ b/pagerduty/event_orchestration_path_util.go
@@ -427,3 +427,7 @@ func emptyOrchestrationPathStructBuilder(pathType string) *pagerduty.EventOrches
 
 	return commonEmptyOrchestrationPath()
 }
+
+func isNonEmptyList(arg interface{}) bool {
+	return !isNilFunc(arg) && len(arg.([]interface{})) > 0
+}

--- a/pagerduty/import_pagerduty_event_orchestration_path_router_test.go
+++ b/pagerduty/import_pagerduty_event_orchestration_path_router_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/heimweh/go-pagerduty/pagerduty"
 )
 
 func TestAccPagerDutyEventOrchestrationPathRouter_import(t *testing.T) {
@@ -22,6 +23,39 @@ func TestAccPagerDutyEventOrchestrationPathRouter_import(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckPagerDutyEventOrchestrationRouterConfigWithMultipleRules(team, escalationPolicy, service, orchestration),
+			},
+			{
+				ResourceName:      "pagerduty_event_orchestration_router.router",
+				ImportStateIdFunc: testAccCheckPagerDutyEventOrchestrationPathRouterID,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"set.0.rule.0.id",
+					"set.0.rule.1.id",
+				},
+			},
+		},
+	})
+}
+
+func TestAccPagerDutyEventOrchestrationPathRouterDynamicRouteTo_import(t *testing.T) {
+	team := fmt.Sprintf("tf-name-%s", acctest.RandString(5))
+	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	orchestration := fmt.Sprintf("tf-orchestration-%s", acctest.RandString(5))
+	dynamicRouteToByNameInput := &pagerduty.EventOrchestrationPathDynamicRouteTo{
+		LookupBy: "service_name",
+		Regex:    ".*",
+		Source:   "event.custom_details.pd_service_name",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyEventOrchestrationRouterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyEventOrchestrationRouterDynamicRouteToConfig(team, escalationPolicy, service, orchestration, dynamicRouteToByNameInput),
 			},
 			{
 				ResourceName:      "pagerduty_event_orchestration_router.router",

--- a/pagerduty/resource_pagerduty_event_orchestration_path_global.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_global.go
@@ -72,6 +72,10 @@ var eventOrchestrationPathGlobalCatchAllActionsSchema = map[string]*schema.Schem
 			Schema: eventOrchestrationIncidentCustomFieldsObjectSchema,
 		},
 	},
+	"escalation_policy": {
+		Type:     schema.TypeString,
+		Optional: true,
+	},
 }
 
 var eventOrchestrationPathGlobalRuleActionsSchema = buildEventOrchestrationPathGlobalRuleActionsSchema()
@@ -374,6 +378,7 @@ func expandGlobalPathActions(v interface{}) *pagerduty.EventOrchestrationPathRul
 		actions.Suppress = a["suppress"].(bool)
 		actions.Suspend = intTypeToIntPtr(a["suspend"].(int))
 		actions.Priority = a["priority"].(string)
+		actions.EscalationPolicy = stringTypeToStringPtr(a["escalation_policy"].(string))
 		actions.Annotate = a["annotate"].(string)
 		actions.Severity = a["severity"].(string)
 		actions.EventAction = a["event_action"].(string)
@@ -439,14 +444,15 @@ func flattenGlobalPathActions(actions *pagerduty.EventOrchestrationPathRuleActio
 	var actionsMap []map[string]interface{}
 
 	flattenedAction := map[string]interface{}{
-		"drop_event":   actions.DropEvent,
-		"route_to":     actions.RouteTo,
-		"severity":     actions.Severity,
-		"event_action": actions.EventAction,
-		"suppress":     actions.Suppress,
-		"suspend":      actions.Suspend,
-		"priority":     actions.Priority,
-		"annotate":     actions.Annotate,
+		"drop_event":        actions.DropEvent,
+		"route_to":          actions.RouteTo,
+		"severity":          actions.Severity,
+		"event_action":      actions.EventAction,
+		"suppress":          actions.Suppress,
+		"suspend":           actions.Suspend,
+		"priority":          actions.Priority,
+		"annotate":          actions.Annotate,
+		"escalation_policy": stringPtrToStringType(actions.EscalationPolicy),
 	}
 
 	if actions.Variables != nil {

--- a/pagerduty/resource_pagerduty_event_orchestration_path_global_test.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_global_test.go
@@ -135,6 +135,9 @@ func TestAccPagerDutyEventOrchestrationPathGlobal_Basic(t *testing.T) {
 							resource.TestCheckResourceAttrSet(res, "set.0.rule.1.id"),
 							resource.TestCheckResourceAttrSet(res, "set.1.rule.0.id"),
 							resource.TestCheckResourceAttrSet(res, "set.1.rule.1.id"),
+							resource.TestCheckResourceAttr(
+								res, "set.0.rule.0.actions.0.escalation_policy", "POLICY3",
+							),
 						}...,
 					)...,
 				),
@@ -481,6 +484,7 @@ func testAccCheckPagerDutyEventOrchestrationPathGlobalAllActionsConfig(t, ep, s,
 					actions {
 						route_to = "set-1"
 						priority = "P0IN2KQ"
+						escalation_policy = pagerduty_escalation_policy.foo.id
 						annotate = "Routed through an event orchestration"
 						severity = "critical"
 						event_action = "trigger"
@@ -544,6 +548,7 @@ func testAccCheckPagerDutyEventOrchestrationPathGlobalAllActionsConfig(t, ep, s,
 				actions {
 					drop_event = true
 					priority = "P0IN2KW"
+					escalation_policy = pagerduty_escalation_policy.foo.id
 					annotate = "Routed through an event orchestration - catch-all rule"
 					severity = "warning"
 					event_action = "trigger"
@@ -589,6 +594,7 @@ func testAccCheckPagerDutyEventOrchestrationPathGlobalAllActionsUpdateConfig(t, 
 					actions {
 						route_to = "set-2"
 						priority = "P0IN2KR"
+						escalation_policy = "POLICY3"
 						annotate = "Routed through a service orchestration!"
 						severity = "warning"
 						event_action = "resolve"
@@ -629,6 +635,7 @@ func testAccCheckPagerDutyEventOrchestrationPathGlobalAllActionsUpdateConfig(t, 
 					label = "set-2 rule 1"
 					actions {
 						suspend = 15
+						escalation_policy = pagerduty_escalation_policy.foo.id
 					}
 				}
 				rule {
@@ -666,6 +673,7 @@ func testAccCheckPagerDutyEventOrchestrationPathGlobalAllActionsUpdateConfig(t, 
 				actions {
 					drop_event = false
 					priority = "P0IN2KX"
+					escalation_policy = "POLICY4"
 					annotate = "[UPD] Routed through an event orchestration - catch-all rule"
 					severity = "info"
 					event_action = "resolve"

--- a/pagerduty/resource_pagerduty_event_orchestration_path_service.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_service.go
@@ -82,6 +82,10 @@ var eventOrchestrationPathServiceCatchAllActionsSchema = map[string]*schema.Sche
 			Schema: eventOrchestrationIncidentCustomFieldsObjectSchema,
 		},
 	},
+	"escalation_policy": {
+		Type:     schema.TypeString,
+		Optional: true,
+	},
 }
 
 var eventOrchestrationPathServiceRuleActionsSchema = buildEventOrchestrationPathServiceRuleActionsSchema()
@@ -484,6 +488,7 @@ func expandServicePathActions(v interface{}) *pagerduty.EventOrchestrationPathRu
 		actions.Suppress = a["suppress"].(bool)
 		actions.Suspend = intTypeToIntPtr(a["suspend"].(int))
 		actions.Priority = a["priority"].(string)
+		actions.EscalationPolicy = stringTypeToStringPtr(a["escalation_policy"].(string))
 		actions.Annotate = a["annotate"].(string)
 		actions.Severity = a["severity"].(string)
 		actions.EventAction = a["event_action"].(string)
@@ -565,13 +570,14 @@ func flattenServicePathActions(actions *pagerduty.EventOrchestrationPathRuleActi
 	var actionsMap []map[string]interface{}
 
 	flattenedAction := map[string]interface{}{
-		"route_to":     actions.RouteTo,
-		"severity":     actions.Severity,
-		"event_action": actions.EventAction,
-		"suppress":     actions.Suppress,
-		"suspend":      actions.Suspend,
-		"priority":     actions.Priority,
-		"annotate":     actions.Annotate,
+		"route_to":          actions.RouteTo,
+		"severity":          actions.Severity,
+		"event_action":      actions.EventAction,
+		"suppress":          actions.Suppress,
+		"suspend":           actions.Suspend,
+		"priority":          actions.Priority,
+		"annotate":          actions.Annotate,
+		"escalation_policy": stringPtrToStringType(actions.EscalationPolicy),
 	}
 
 	if actions.Variables != nil {

--- a/pagerduty/resource_pagerduty_event_orchestration_path_service_test.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_service_test.go
@@ -135,6 +135,9 @@ func TestAccPagerDutyEventOrchestrationPathService_Basic(t *testing.T) {
 							resource.TestCheckResourceAttrSet(resourceName, "set.0.rule.0.id"),
 							resource.TestCheckResourceAttrSet(resourceName, "set.1.rule.0.id"),
 							resource.TestCheckResourceAttrSet(resourceName, "set.1.rule.1.id"),
+							resource.TestCheckResourceAttr(
+								resourceName, "set.0.rule.0.actions.0.escalation_policy", "POLICY3",
+							),
 						}...,
 					)...,
 				),
@@ -547,6 +550,7 @@ func testAccCheckPagerDutyEventOrchestrationPathServiceAllActionsConfig(ep, s st
 					actions {
 						route_to = "set-1"
 						priority = "P0IN2KQ"
+						escalation_policy = pagerduty_escalation_policy.foo.id
 						annotate = "Routed through an event orchestration"
 						pagerduty_automation_action {
 							action_id = "01CSB5SMOKCKVRI5GN0LJG7SMB"
@@ -604,6 +608,7 @@ func testAccCheckPagerDutyEventOrchestrationPathServiceAllActionsConfig(ep, s st
 				actions {
 					suspend = 120
 					priority = "P0IN2KW"
+					escalation_policy = pagerduty_escalation_policy.foo.id
 					annotate = "Routed through an event orchestration - catch-all rule"
 					pagerduty_automation_action {
 						action_id = "01CSB5SMOKCKVRI5GN0LJG7SMC"
@@ -652,6 +657,7 @@ func testAccCheckPagerDutyEventOrchestrationPathServiceAllActionsUpdateConfig(ep
 					actions {
 						route_to = "set-2"
 						priority = "P0IN2KR"
+						escalation_policy = "POLICY3"
 						annotate = "Routed through a service orchestration!"
 						pagerduty_automation_action {
 							action_id = "01CSB5SMOKCKVRI5GN0LJG7SMBUPDATED"
@@ -723,6 +729,7 @@ func testAccCheckPagerDutyEventOrchestrationPathServiceAllActionsUpdateConfig(ep
 				actions {
 					suspend = 360
 					priority = "P0IN2KX"
+					escalation_policy = "POLICY4"
 					annotate = "[UPD] Routed through an event orchestration - catch-all rule"
 					pagerduty_automation_action {
 						action_id = "01CSB5SMOKCKVRI5GN0LJG7SMD"

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/event_orchestration_path.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/event_orchestration_path.go
@@ -65,6 +65,7 @@ type EventOrchestrationPathRuleActions struct {
 	EventAction                string                                             `json:"event_action"`
 	Variables                  []*EventOrchestrationPathActionVariables           `json:"variables"`
 	Extractions                []*EventOrchestrationPathActionExtractions         `json:"extractions"`
+	EscalationPolicy           *string                                            `json:"escalation_policy"`
 }
 
 type EventOrchestrationPathDynamicRouteTo struct {

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/event_orchestration_path.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/event_orchestration_path.go
@@ -53,6 +53,7 @@ type EventOrchestrationPathRuleCondition struct {
 type EventOrchestrationPathRuleActions struct {
 	DropEvent                  bool                                               `json:"drop_event"`
 	RouteTo                    string                                             `json:"route_to"`
+	DynamicRouteTo             *EventOrchestrationPathDynamicRouteTo              `json:"dynamic_route_to"`
 	Suppress                   bool                                               `json:"suppress"`
 	Suspend                    *int                                               `json:"suspend"`
 	Priority                   string                                             `json:"priority"`
@@ -64,6 +65,12 @@ type EventOrchestrationPathRuleActions struct {
 	EventAction                string                                             `json:"event_action"`
 	Variables                  []*EventOrchestrationPathActionVariables           `json:"variables"`
 	Extractions                []*EventOrchestrationPathActionExtractions         `json:"extractions"`
+}
+
+type EventOrchestrationPathDynamicRouteTo struct {
+	Source   string `json:"source,omitempty"`
+	Regex    string `json:"regex,omitempty"`
+	LookupBy string `json:"lookup_by,omitempty"`
 }
 
 type EventOrchestrationPathIncidentCustomFieldUpdate struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -258,7 +258,7 @@ github.com/hashicorp/terraform-svchost
 # github.com/hashicorp/yamux v0.1.1
 ## explicit; go 1.15
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20240503143637-3459408ac715 => github.com/alexzakabluk/go-pagerduty v0.0.0-20240607142119-ac9a64bba6da
+# github.com/heimweh/go-pagerduty v0.0.0-20240503143637-3459408ac715 => github.com/alexzakabluk/go-pagerduty v0.0.0-20240712180401-2eb91c030980
 ## explicit; go 1.17
 github.com/heimweh/go-pagerduty/pagerduty
 github.com/heimweh/go-pagerduty/persistentconfig
@@ -559,4 +559,4 @@ google.golang.org/protobuf/types/known/timestamppb
 # gopkg.in/ini.v1 v1.67.0
 ## explicit
 gopkg.in/ini.v1
-# github.com/heimweh/go-pagerduty => github.com/alexzakabluk/go-pagerduty v0.0.0-20240607142119-ac9a64bba6da
+# github.com/heimweh/go-pagerduty => github.com/alexzakabluk/go-pagerduty v0.0.0-20240712180401-2eb91c030980

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -258,7 +258,7 @@ github.com/hashicorp/terraform-svchost
 # github.com/hashicorp/yamux v0.1.1
 ## explicit; go 1.15
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20240503143637-3459408ac715 => github.com/alexzakabluk/go-pagerduty v0.0.0-20240712180401-2eb91c030980
+# github.com/heimweh/go-pagerduty v0.0.0-20240722154207-95f2261a009a
 ## explicit; go 1.17
 github.com/heimweh/go-pagerduty/pagerduty
 github.com/heimweh/go-pagerduty/persistentconfig
@@ -559,4 +559,3 @@ google.golang.org/protobuf/types/known/timestamppb
 # gopkg.in/ini.v1 v1.67.0
 ## explicit
 gopkg.in/ini.v1
-# github.com/heimweh/go-pagerduty => github.com/alexzakabluk/go-pagerduty v0.0.0-20240712180401-2eb91c030980

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -258,7 +258,7 @@ github.com/hashicorp/terraform-svchost
 # github.com/hashicorp/yamux v0.1.1
 ## explicit; go 1.15
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20240503143637-3459408ac715
+# github.com/heimweh/go-pagerduty v0.0.0-20240503143637-3459408ac715 => github.com/alexzakabluk/go-pagerduty v0.0.0-20240607142119-ac9a64bba6da
 ## explicit; go 1.17
 github.com/heimweh/go-pagerduty/pagerduty
 github.com/heimweh/go-pagerduty/persistentconfig
@@ -559,3 +559,4 @@ google.golang.org/protobuf/types/known/timestamppb
 # gopkg.in/ini.v1 v1.67.0
 ## explicit
 gopkg.in/ini.v1
+# github.com/heimweh/go-pagerduty => github.com/alexzakabluk/go-pagerduty v0.0.0-20240607142119-ac9a64bba6da

--- a/website/docs/r/event_orchestration_router.html.markdown
+++ b/website/docs/r/event_orchestration_router.html.markdown
@@ -12,15 +12,31 @@ An Orchestration Router allows users to create a set of Event Rules. The Router 
 
 ## Example of configuring Router rules for an Orchestration
 
-In this example the user has defined the Router with two rules, each routing to a different service.
-
-This example assumes services used in the `route_to` configuration already exists. So it does not show creation of service resource.
+In this example the user has defined the Router with three rules. The first rule configures a dynamic route: any event containing a value in its `pd_service_id` custom detail will be routed to the Service with the ID specified by that value. The other rules route events matching a condition to specific services.
 
 ```hcl
+data "pagerduty_service" "database" {
+  name = "Primary Data Store"
+}
+
+data "pagerduty_service" "www" {
+  name = "Web Server App"
+}
+
 resource "pagerduty_event_orchestration_router" "router" {
   event_orchestration = pagerduty_event_orchestration.my_monitor.id
   set {
     id = "start"
+    rule {
+      label = "Dynamically route events related to specific PagerDuty services"
+      actions {
+        dynamic_route_to = {
+          lookup_by = "service_id"
+          source = "event.custom_details.pd_service_id"
+          regexp = "(.*)"
+        }
+      }
+    }
     rule {
       label = "Events relating to our relational database"
       condition {
@@ -30,7 +46,7 @@ resource "pagerduty_event_orchestration_router" "router" {
         expression = "event.source matches regex 'db[0-9]+-server'"
       }
       actions {
-        route_to = pagerduty_service.database.id
+        route_to = data.pagerduty_service.database.id
       }
     }
     rule {
@@ -38,7 +54,7 @@ resource "pagerduty_event_orchestration_router" "router" {
         expression = "event.summary matches part 'www'"
       }
       actions {
-        route_to = pagerduty_service.www.id
+        route_to = data.pagerduty_service.www.id
       }
     }
   }
@@ -72,6 +88,22 @@ The following arguments are supported:
 * `expression`- (Required) A [PCL condition](https://developer.pagerduty.com/docs/ZG9jOjM1NTE0MDc0-pcl-overview) string.
 
 ### Actions (`actions`) supports the following:
+
+#### Dynamic Routing
+
+Use the contents of an event payload to dynamically route an event to the target service. Note these setting can only be used once in the Router, and only in the first rule. The dynamic routing rule cannot have `conditions` nor a `route_to` action defined.
+
+* `dynamic_route_to` - (Required) supports the following:
+    * `source` - (Required) The path to a field in an event.
+    * `regex` - (Required) The regular expression, used to extract a value from the source field. Must use valid [RE2 regular expression](https://github.com/google/re2/wiki/Syntax) syntax.
+    * `lookup_by` - (Required) Indicates whether the extracted value from the source is a service's name or ID. Allowed values are: `service_name`, `service_id`
+
+If an event has a value at the specified `source`, and if the `regex` successfully matches the value, and if the matching portion is valid Service ID or Name, then the event will be routed to that service. Otherwise the event will be checked against any subsequent router rules.
+
+#### Service Route
+
+If an event matches this rule's conditions, then route it to the specified Service.
+
 * `route_to` - (Required) The ID of the target Service for the resulting alert.
 
 ### Catch All (`catch_all`) supports the following:

--- a/website/docs/r/event_orchestration_service.html.markdown
+++ b/website/docs/r/event_orchestration_service.html.markdown
@@ -16,7 +16,7 @@ A [Service Orchestration](https://support.pagerduty.com/docs/event-orchestration
 
 This example shows creating `Team`, `User`, `Escalation Policy`, and `Service` resources followed by creating a Service Orchestration to handle Events sent to that Service.
 
-This example also shows using `priority` [data source](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/data-sources/priority) to configure `priority` action for a rule. If the Event matches the first rule in set "step-two" the resulting incident will have the Priority `P1`.
+This example also shows using the [pagerduty_priority](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/data-sources/priority) and [pagerduty_escalation_policy](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/data-sources/escalation_policy) data sources to configure `priority` and `escalation_policy` actions for a rule.
 
 This example shows a Service Orchestration that has nested sets: a rule in the "start" set has a `route_to` action pointing at the "step-two" set.
 
@@ -70,6 +70,10 @@ data "pagerduty_priority" "p1" {
   name = "P1"
 }
 
+data "pagerduty_escalation_policy" "sre_esc_policy" {
+  name = "SRE Escalation Policy"
+}
+
 resource "pagerduty_event_orchestration_service" "www" {
   service = pagerduty_service.example.id
   enable_event_orchestration_for_service = true
@@ -114,6 +118,15 @@ resource "pagerduty_event_orchestration_service" "www" {
           id = pagerduty_incident_custom_field.cs_impact.id
           value = "High Impact"
         }
+      }
+    }
+    rule {
+      label = "If any of the API apps are unavailable, page the SRE team"
+      condition {
+        expression = "event.custom_details.service_name matches part '-api' and event.custom_details.status_code matches '502'"
+      }
+      actions {
+        escalation_policy = data.pagerduty_escalation_policy.sre_esc_policy.id
       }
     }
     rule {
@@ -184,6 +197,7 @@ The following arguments are supported:
 * `suppress` - (Optional) Set whether the resulting alert is suppressed. Suppressed alerts will not trigger an incident.
 * `suspend` - (Optional) The number of seconds to suspend the resulting alert before triggering. This effectively pauses incident notifications. If a `resolve` event arrives before the alert triggers then PagerDuty won't create an incident for this alert.
 * `priority` - (Optional) The ID of the priority you want to set on resulting incident. Consider using the [`pagerduty_priority`](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/data-sources/priority) data source.
+* `escalation_policy` - (Optional) The ID of the Escalation Policy you want to assign incidents to. Event rules with this action will override the Escalation Policy already set on a Service's settings, with what is configured by this action.
 * `annotate` - (Optional) Add this text as a note on the resulting incident.
 * `incident_custom_field_update` - (Optional) Assign a custom field to the resulting incident.
   * `id` - (Required) The custom field id


### PR DESCRIPTION
### Context
This PR adds support for Dynamic Routing and Dynamic Escalation Policy Assignment to the following resources:
- `pagerduty_event_orchestration_global` (Dynamic Escalation Policy Assignment)
- `pagerduty_event_orchestration_router` (Dynamic Routing)
- `pagerduty_event_orchestration_service` (Dynamic Escalation Policy Assignment)

### Testing
Testing conducted in individual PRs:
- https://github.com/alenapan/terraform-provider-pagerduty/pull/1
- https://github.com/alenapan/terraform-provider-pagerduty/pull/2
- https://github.com/alenapan/terraform-provider-pagerduty/pull/3
- https://github.com/alenapan/terraform-provider-pagerduty/pull/4
- https://github.com/alenapan/terraform-provider-pagerduty/pull/5

