### PR TITLE
Remove invalid alert_grouping_parameters fields after strict check

### DIFF
--- a/pagerduty/resource_pagerduty_service_test.go
+++ b/pagerduty/resource_pagerduty_service_test.go
@@ -479,7 +479,7 @@ func TestAccPagerDutyService_AlertContentGrouping(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyServiceDestroy,
 		Steps: []resource.TestStep{
-			{
+			{ // 1
 				Config: testAccCheckPagerDutyServiceConfigWithAlertContentGrouping(username, email, escalationPolicy, service),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyServiceExists("pagerduty_service.foo"),
@@ -509,11 +509,11 @@ func TestAccPagerDutyService_AlertContentGrouping(t *testing.T) {
 						"pagerduty_service.foo", "incident_urgency_rule.0.type", "constant"),
 				),
 			},
-			{
+			{ // 2
 				Config:   testAccCheckPagerDutyServiceConfigWithAlertContentGrouping(username, email, escalationPolicy, service),
 				PlanOnly: true,
 			},
-			{
+			{ // 3
 				Config: testAccCheckPagerDutyServiceConfigWithAlertIntelligentGroupingUpdated(username, email, escalationPolicy, service),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyServiceExists("pagerduty_service.foo"),
@@ -529,8 +529,8 @@ func TestAccPagerDutyService_AlertContentGrouping(t *testing.T) {
 						"pagerduty_service.foo", "alert_creation", "create_alerts_and_incidents"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "alert_grouping_parameters.0.type", "intelligent"),
-					resource.TestCheckNoResourceAttr(
-						"pagerduty_service.foo", "alert_grouping_parameters.0.config.0"),
+					// resource.TestCheckNoResourceAttr(
+					// 	"pagerduty_service.foo", "alert_grouping_parameters.0.config.0"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "incident_urgency_rule.#", "1"),
 					resource.TestCheckResourceAttr(
@@ -539,7 +539,7 @@ func TestAccPagerDutyService_AlertContentGrouping(t *testing.T) {
 						"pagerduty_service.foo", "incident_urgency_rule.0.type", "constant"),
 				),
 			},
-			{
+			{ // 4
 				Config: testAccCheckPagerDutyServiceConfigWithAlertContentGroupingUpdated(username, email, escalationPolicy, service),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyServiceExists("pagerduty_service.foo"),
@@ -553,10 +553,10 @@ func TestAccPagerDutyService_AlertContentGrouping(t *testing.T) {
 						"pagerduty_service.foo", "acknowledgement_timeout", "1800"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "alert_creation", "create_alerts_and_incidents"),
-					resource.TestCheckNoResourceAttr(
-						"pagerduty_service.foo", "alert_grouping_parameters.0.config"),
-					resource.TestCheckNoResourceAttr(
-						"pagerduty_service.foo", "alert_grouping_parameters.0.type"),
+					// resource.TestCheckNoResourceAttr(
+					// 	"pagerduty_service.foo", "alert_grouping_parameters.0.config"),
+					// resource.TestCheckNoResourceAttr(
+					// 	"pagerduty_service.foo", "alert_grouping_parameters.0.type"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "incident_urgency_rule.#", "1"),
 					resource.TestCheckResourceAttr(
@@ -565,7 +565,7 @@ func TestAccPagerDutyService_AlertContentGrouping(t *testing.T) {
 						"pagerduty_service.foo", "incident_urgency_rule.0.type", "constant"),
 				),
 			},
-			{
+			{ // 5
 				Config: testAccCheckPagerDutyServiceConfigWithAlertTimeGroupingUpdated(username, email, escalationPolicy, service),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyServiceExists("pagerduty_service.foo"),
@@ -583,8 +583,8 @@ func TestAccPagerDutyService_AlertContentGrouping(t *testing.T) {
 						"pagerduty_service.foo", "alert_grouping_parameters.0.type", "time"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "alert_grouping_parameters.0.config.0.timeout", "5"),
-					resource.TestCheckNoResourceAttr(
-						"pagerduty_service.foo", "alert_grouping_parameters.0.config.0"),
+					// resource.TestCheckNoResourceAttr(
+					// 	"pagerduty_service.foo", "alert_grouping_parameters.0.config.0"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "incident_urgency_rule.#", "1"),
 					resource.TestCheckResourceAttr(
@@ -593,7 +593,7 @@ func TestAccPagerDutyService_AlertContentGrouping(t *testing.T) {
 						"pagerduty_service.foo", "incident_urgency_rule.0.type", "constant"),
 				),
 			},
-			{
+			{ // 6
 				Config: testAccCheckPagerDutyServiceConfigWithAlertTimeGroupingTimeoutZeroUpdated(username, email, escalationPolicy, service),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyServiceExists("pagerduty_service.foo"),
@@ -611,8 +611,8 @@ func TestAccPagerDutyService_AlertContentGrouping(t *testing.T) {
 						"pagerduty_service.foo", "alert_grouping_parameters.0.type", "time"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "alert_grouping_parameters.0.config.0.timeout", "0"),
-					resource.TestCheckNoResourceAttr(
-						"pagerduty_service.foo", "alert_grouping_parameters.0.config.0"),
+					// resource.TestCheckNoResourceAttr(
+					// 	"pagerduty_service.foo", "alert_grouping_parameters.0.config.0"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "incident_urgency_rule.#", "1"),
 					resource.TestCheckResourceAttr(
@@ -621,7 +621,7 @@ func TestAccPagerDutyService_AlertContentGrouping(t *testing.T) {
 						"pagerduty_service.foo", "incident_urgency_rule.0.type", "constant"),
 				),
 			},
-			{
+			{ // 7
 				Config: testAccCheckPagerDutyServiceConfigWithAlertIntelligentGroupingUpdated(username, email, escalationPolicy, service),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyServiceExists("pagerduty_service.foo"),
@@ -637,8 +637,8 @@ func TestAccPagerDutyService_AlertContentGrouping(t *testing.T) {
 						"pagerduty_service.foo", "alert_creation", "create_alerts_and_incidents"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "alert_grouping_parameters.0.type", "intelligent"),
-					resource.TestCheckNoResourceAttr(
-						"pagerduty_service.foo", "alert_grouping_parameters.0.config.0"),
+					// resource.TestCheckNoResourceAttr(
+					// 	"pagerduty_service.foo", "alert_grouping_parameters.0.config.0"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "incident_urgency_rule.#", "1"),
 					resource.TestCheckResourceAttr(
@@ -647,7 +647,7 @@ func TestAccPagerDutyService_AlertContentGrouping(t *testing.T) {
 						"pagerduty_service.foo", "incident_urgency_rule.0.type", "constant"),
 				),
 			},
-			{
+			{ // 8
 				Config: testAccCheckPagerDutyServiceConfigWithAlertIntelligentGroupingDescriptionUpdated(username, email, escalationPolicy, service),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyServiceExists("pagerduty_service.foo"),
@@ -663,8 +663,8 @@ func TestAccPagerDutyService_AlertContentGrouping(t *testing.T) {
 						"pagerduty_service.foo", "alert_creation", "create_alerts_and_incidents"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "alert_grouping_parameters.0.type", "intelligent"),
-					resource.TestCheckNoResourceAttr(
-						"pagerduty_service.foo", "alert_grouping_parameters.0.config.0"),
+					// resource.TestCheckNoResourceAttr(
+					// 	"pagerduty_service.foo", "alert_grouping_parameters.0.config.0"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "incident_urgency_rule.#", "1"),
 					resource.TestCheckResourceAttr(
@@ -673,7 +673,7 @@ func TestAccPagerDutyService_AlertContentGrouping(t *testing.T) {
 						"pagerduty_service.foo", "incident_urgency_rule.0.type", "constant"),
 				),
 			},
-			{
+			{ // 9
 				Config: testAccCheckPagerDutyServiceConfigWithAlertIntelligentGroupingOmittingConfig(username, email, escalationPolicy, service),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyServiceExists("pagerduty_service.foo"),
@@ -681,20 +681,20 @@ func TestAccPagerDutyService_AlertContentGrouping(t *testing.T) {
 						"pagerduty_service.foo", "name", service),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "alert_grouping_parameters.0.type", "intelligent"),
-					resource.TestCheckNoResourceAttr(
-						"pagerduty_service.foo", "alert_grouping_parameters.0.config.0"),
+					// resource.TestCheckNoResourceAttr(
+					// 	"pagerduty_service.foo", "alert_grouping_parameters.0.config.0"),
 				),
 			},
-			{
+			{ // 10
 				Config: testAccCheckPagerDutyServiceConfigWithAlertIntelligentGroupingTypeNullEmptyConfigConfig(username, email, escalationPolicy, service),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyServiceExists("pagerduty_service.foo"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "name", service),
-					resource.TestCheckNoResourceAttr(
-						"pagerduty_service.foo", "alert_grouping_parameters.0.type"),
-					resource.TestCheckNoResourceAttr(
-						"pagerduty_service.foo", "alert_grouping_parameters.0.config.0"),
+					// resource.TestCheckNoResourceAttr(
+					// 	"pagerduty_service.foo", "alert_grouping_parameters.0.type"),
+					// resource.TestCheckNoResourceAttr(
+					// 	"pagerduty_service.foo", "alert_grouping_parameters.0.config.0"),
 				),
 			},
 		},


### PR DESCRIPTION
Fixes #887
```
$ go test ./pagerduty -v -run TestAccPagerDutyService_
=== RUN   TestAccPagerDutyService_import
--- PASS: TestAccPagerDutyService_import (15.39s)
=== RUN   TestAccPagerDutyService_Basic
--- PASS: TestAccPagerDutyService_Basic (27.50s)
=== RUN   TestAccPagerDutyService_FormatValidation
--- PASS: TestAccPagerDutyService_FormatValidation (46.18s)
=== RUN   TestAccPagerDutyService_AlertGrouping
--- PASS: TestAccPagerDutyService_AlertGrouping (23.35s)
=== RUN   TestAccPagerDutyService_AlertContentGrouping
--- PASS: TestAccPagerDutyService_AlertContentGrouping (70.74s)
=== RUN   TestAccPagerDutyService_AlertContentGroupingIntelligentTimeWindow
--- PASS: TestAccPagerDutyService_AlertContentGroupingIntelligentTimeWindow (21.59s)
=== RUN   TestAccPagerDutyService_AutoPauseNotificationsParameters
--- PASS: TestAccPagerDutyService_AutoPauseNotificationsParameters (27.41s)
=== RUN   TestAccPagerDutyService_BasicWithIncidentUrgencyRules
--- PASS: TestAccPagerDutyService_BasicWithIncidentUrgencyRules (32.74s)
=== RUN   TestAccPagerDutyService_FromBasicToCustomIncidentUrgencyRules
--- PASS: TestAccPagerDutyService_FromBasicToCustomIncidentUrgencyRules (20.89s)
=== RUN   TestAccPagerDutyService_SupportHoursChange
--- PASS: TestAccPagerDutyService_SupportHoursChange (21.23s)
=== RUN   TestAccPagerDutyService_ResponsePlay
--- PASS: TestAccPagerDutyService_ResponsePlay (31.76s)
=== RUN   TestAccPagerDutyService_AlertGroupingParametersAddConfigField
--- PASS: TestAccPagerDutyService_AlertGroupingParametersAddConfigField (21.51s)
PASS
ok  	github.com/PagerDuty/terraform-provider-pagerduty/pagerduty	360.697s
```