### PR TITLE
Handle 403 at EO path service refresh as orphan

### DIFF
--- a/pagerduty/resource_pagerduty_event_orchestration_path_service.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_service.go
@@ -203,6 +203,14 @@ func resourcePagerDutyEventOrchestrationPathServiceRead(ctx context.Context, d *
 				return retry.NonRetryableError(err)
 			}
 
+			// When the service referenced by `id` gets deleted manually, the response
+			// of the API is a 403 instead of the expected 404. We will then handle the
+			// it as the service is gone, deleting this orphan EO path service.
+			if isErrCode(err, http.StatusForbidden) {
+				d.SetId("")
+				return nil
+			}
+
 			time.Sleep(2 * time.Second)
 			return retry.RetryableError(err)
 		}


### PR DESCRIPTION
Hotfix in response of:

> They created services via the TF provider, but those services were removed from the UI unbeknownst to them.
When they tried to sync their configuration, they began receiving the error
Error: GET API call to {service URL} failed 403 Forbidden. Code: 0, Errors: <nil>, Message: Forbidden
The TF provider was still trying to get those services but received a 403 because you cannot update a non-existing object.