### PR TITLE
Improvements for escalation policies

### DIFF
--- a/pagerduty/resource_pagerduty_escalation_policy_test.go
+++ b/pagerduty/resource_pagerduty_escalation_policy_test.go
@@ -78,7 +78,6 @@ func TestAccPagerDutyEscalationPolicy_Basic(t *testing.T) {
 						"pagerduty_escalation_policy.foo", "rule.0.escalation_delay_in_minutes", "10"),
 				),
 			},
-
 			{
 				Config: testAccCheckPagerDutyEscalationPolicyConfigUpdated(username, email, escalationPolicyUpdated),
 				Check: resource.ComposeTestCheckFunc(
@@ -306,7 +305,6 @@ func testAccCheckPagerDutyEscalationPolicyDestroy(s *terraform.State) error {
 		if _, _, err := client.EscalationPolicies.Get(r.Primary.ID, &pagerduty.GetEscalationPolicyOptions{}); err == nil {
 			return fmt.Errorf("Escalation Policy still exists")
 		}
-
 	}
 	return nil
 }


### PR DESCRIPTION
* Prevent null-pointer panic at escalation_policy
* Fix broken tests for escalation policies
* Use pagination for data.pagerduty_escalation_policy (Fixes #877 )

```
=== RUN   TestAccPagerDutyEscalationPolicy_import
--- PASS: TestAccPagerDutyEscalationPolicy_import (12.77s)
=== RUN   TestAccPagerDutyEscalationPolicy_Basic
--- PASS: TestAccPagerDutyEscalationPolicy_Basic (25.84s)
=== RUN   TestAccPagerDutyEscalationPolicy_FormatValidation
--- PASS: TestAccPagerDutyEscalationPolicy_FormatValidation (0.57s)
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerduty     40.186s

=== RUN   TestAccDataSourcePagerDutyEscalationPolicy_Basic
--- PASS: TestAccDataSourcePagerDutyEscalationPolicy_Basic (13.98s)
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerduty     14.891s
```