### PR TITLE
Orca 4805 - adds escalation policy support in rule actions

### DIFF
--- a/pagerduty/resource_pagerduty_event_orchestration_path_global.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_global.go
@@ -83,6 +83,11 @@ func buildEventOrchestrationPathGlobalRuleActionsSchema() map[string]*schema.Sch
 		Optional: true,
 	}
 
+	a["escalation_policy"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+	}
+
 	return a
 }
 

--- a/pagerduty/resource_pagerduty_event_orchestration_path_global_test.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_global_test.go
@@ -41,6 +41,7 @@ func TestAccPagerDutyEventOrchestrationPathGlobal_Basic(t *testing.T) {
 				Config: testAccCheckPagerDutyEventOrchestrationGlobalDefaultConfig(team, escalationPolicy, service, orch),
 				Check:  resource.ComposeTestCheckFunc(baseChecks...),
 			},
+
 			// Adding/updating/deleting automation_action properties
 			{
 				Config: testAccCheckPagerDutyEventOrchestrationPathGlobalAutomationActionsConfig(team, escalationPolicy, service, orch),
@@ -276,7 +277,7 @@ func createBaseGlobalOrchConfig(t, ep, s, o string) string {
 	`, t, ep, s, o)
 }
 
-func testAccCheckPagerDutyEventOrchestrationGlobalDefaultConfig(t, ep, s, o string) string {
+func testAccCheckPagerDutyEventOrchestrationGlobalDefaultConfigDefaultConfig(t, ep, s, o string) string {
 	return fmt.Sprintf("%s%s", createBaseGlobalOrchConfig(t, ep, s, o),
 		`resource "pagerduty_event_orchestration_global" "my_global_orch" {
 			event_orchestration = pagerduty_event_orchestration.orch.id
@@ -286,6 +287,27 @@ func testAccCheckPagerDutyEventOrchestrationGlobalDefaultConfig(t, ep, s, o stri
 			}
 			set {
 				id = "start"
+			}
+		}
+	`)
+}
+
+func testAccCheckPagerDutyEventOrchestrationGlobalDefaultWithEscalationPolicy(t, ep, s, o string) string {
+	return fmt.Sprintf("%s%s", createBaseGlobalOrchConfig(t, ep, s, o),
+		`resource "pagerduty_event_orchestration_global" "my_global_orch" {
+			event_orchestration = pagerduty_event_orchestration.orch.id
+
+			catch_all {
+				actions {}
+			}
+			set {
+				id = "start"
+				rule {
+						label = "rule 1"
+						actions {
+							 "escalation_policy": "POLICY"
+						}
+				}
 			}
 		}
 	`)

--- a/pagerduty/resource_pagerduty_event_orchestration_path_global_test.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_global_test.go
@@ -41,6 +41,10 @@ func TestAccPagerDutyEventOrchestrationPathGlobal_Basic(t *testing.T) {
 				Config: testAccCheckPagerDutyEventOrchestrationGlobalDefaultConfig(team, escalationPolicy, service, orch),
 				Check:  resource.ComposeTestCheckFunc(baseChecks...),
 			},
+			{
+				Config: testAccCheckPagerDutyEventOrchestrationGlobalDefaultWithEscalationPolicy(team, escalationPolicy, service, orch),
+				Check:  resource.ComposeTestCheckFunc(baseChecks...),
+			},
 
 			// Adding/updating/deleting automation_action properties
 			{
@@ -277,7 +281,7 @@ func createBaseGlobalOrchConfig(t, ep, s, o string) string {
 	`, t, ep, s, o)
 }
 
-func testAccCheckPagerDutyEventOrchestrationGlobalDefaultConfigDefaultConfig(t, ep, s, o string) string {
+func testAccCheckPagerDutyEventOrchestrationGlobalDefaultConfig(t, ep, s, o string) string {
 	return fmt.Sprintf("%s%s", createBaseGlobalOrchConfig(t, ep, s, o),
 		`resource "pagerduty_event_orchestration_global" "my_global_orch" {
 			event_orchestration = pagerduty_event_orchestration.orch.id

--- a/pagerduty/resource_pagerduty_event_orchestration_path_service.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_service.go
@@ -93,6 +93,11 @@ func buildEventOrchestrationPathServiceRuleActionsSchema() map[string]*schema.Sc
 		Optional: true,
 	}
 
+	a["escalation_policy"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+	}
+
 	return a
 }
 

--- a/pagerduty/resource_pagerduty_event_orchestration_path_service_test.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_service_test.go
@@ -43,6 +43,10 @@ func TestAccPagerDutyEventOrchestrationPathService_Basic(t *testing.T) {
 				Config: testAccCheckPagerDutyEventOrchestrationPathServiceDefaultConfig(escalationPolicy, service),
 				Check:  resource.ComposeTestCheckFunc(baseChecks...),
 			},
+			{
+				Config: testAccCheckPagerDutyEventOrchestrationServiceEscalationPolicy(escalationPolicy, service),
+				Check:  resource.ComposeTestCheckFunc(baseChecks...),
+			},
 			// Adding/updating/deleting automation_action properties
 			{
 				Config: testAccCheckPagerDutyEventOrchestrationPathServiceAutomationActionsConfig(escalationPolicy, service),
@@ -339,6 +343,31 @@ func createBaseServicePathConfig(ep, s string) string {
 		}
 	}
 	`, ep, s)
+}
+
+func testAccCheckPagerDutyEventOrchestrationServiceEscalationPolicy(ep, s string) string {
+	return fmt.Sprintf("%s%s", createBaseServicePathConfig(ep, s),
+		`resource "pagerduty_event_orchestration_service" "serviceA" {
+			service = pagerduty_service.bar.id
+
+			set {
+				id = "start"
+			}
+
+			catch_all {
+				actions { }
+			}
+			set {
+				id = "start"
+				rule {
+						label = "rule 1"
+						actions {
+							 "escalation_policy": "POLICY"
+						}
+				}
+			}
+		}
+	`)
 }
 
 func testAccCheckPagerDutyEventOrchestrationPathServiceDefaultConfig(ep, s string) string {

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/event_orchestration_path.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/event_orchestration_path.go
@@ -64,6 +64,7 @@ type EventOrchestrationPathRuleActions struct {
 	EventAction                string                                             `json:"event_action"`
 	Variables                  []*EventOrchestrationPathActionVariables           `json:"variables"`
 	Extractions                []*EventOrchestrationPathActionExtractions         `json:"extractions"`
+	EscalationPolicy           string                                             `json:"escalation_policy"`
 }
 
 type EventOrchestrationPathIncidentCustomFieldUpdate struct {


### PR DESCRIPTION
In support of go-pagerduty changes, accepts escalation_policy