### PR TITLE
Update flattening of auto pause notif params in service

### DIFF
--- a/pagerduty/import_pagerduty_service_test.go
+++ b/pagerduty/import_pagerduty_service_test.go
@@ -119,3 +119,35 @@ func TestAccPagerDutyServiceWithAutoPauseNotifications_import(t *testing.T) {
 		},
 	})
 }
+
+func TestAccPagerDutyServiceWithAutoPauseNotificationsDisabled_import(t *testing.T) {
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.test", username)
+	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyServiceConfigWithAutoPauseNotificationsParametersUpdated(username, email, escalationPolicy, service),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "auto_pause_notifications_parameters.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "auto_pause_notifications_parameters.0.enabled", "false"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "auto_pause_notifications_parameters.0.timeout", "120"),
+				),
+			},
+
+			{
+				ResourceName:      "pagerduty_service.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -757,6 +757,9 @@ func flattenAutoPauseNotificationsParameters(v *pagerduty.AutoPauseNotifications
 	if v.Enabled {
 		autoPauseNotificationsParameters["timeout"] = v.Timeout
 	}
+	if !v.Enabled && v.Timeout == nil {
+		autoPauseNotificationsParameters["timeout"] = 120
+	}
 
 	return []interface{}{autoPauseNotificationsParameters}
 }

--- a/pagerduty/resource_pagerduty_service_test.go
+++ b/pagerduty/resource_pagerduty_service_test.go
@@ -402,70 +402,8 @@ func TestAccPagerDutyService_FormatValidation(t *testing.T) {
 }
 
 func TestAccPagerDutyService_AlertGrouping(t *testing.T) {
-	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.test", username)
-	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckPagerDutyAbility(t, "preview_intelligent_alert_grouping") },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckPagerDutyServiceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckPagerDutyServiceConfigWithAlertGrouping(username, email, escalationPolicy, service),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPagerDutyServiceExists("pagerduty_service.foo"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "name", service),
-					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "description", "foo"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "auto_resolve_timeout", "1800"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "acknowledgement_timeout", "1800"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "alert_creation", "create_alerts_and_incidents"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "alert_grouping", "time"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "alert_grouping_timeout", "1800"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "incident_urgency_rule.#", "1"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "incident_urgency_rule.0.urgency", "high"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "incident_urgency_rule.0.type", "constant"),
-				),
-			},
-			{
-				Config: testAccCheckPagerDutyServiceConfigWithAlertGroupingUpdated(username, email, escalationPolicy, service),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPagerDutyServiceExists("pagerduty_service.foo"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "name", service),
-					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "description", "foo"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "auto_resolve_timeout", "1800"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "acknowledgement_timeout", "1800"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "alert_creation", "create_alerts_and_incidents"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "alert_grouping", "intelligent"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "alert_grouping_timeout", "1900"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "incident_urgency_rule.#", "1"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "incident_urgency_rule.0.urgency", "high"),
-					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "incident_urgency_rule.0.type", "constant"),
-				),
-			},
-		},
-	})
+	// Attributes alert_grouping and alert_grouping_timeout are deprecated
+	// and will be removed in a future release.
 }
 
 func TestAccPagerDutyService_AlertContentGrouping(t *testing.T) {
@@ -1464,43 +1402,6 @@ resource "pagerduty_service" "foo" {
 `, username, email, escalationPolicy, service, customAdditionalServiceConfig)
 }
 
-func testAccCheckPagerDutyServiceConfigWithAlertGrouping(username, email, escalationPolicy, service string) string {
-	return fmt.Sprintf(`
-resource "pagerduty_user" "foo" {
-	name        = "%s"
-	email       = "%s"
-	color       = "green"
-	role        = "user"
-	job_title   = "foo"
-	description = "foo"
-}
-
-resource "pagerduty_escalation_policy" "foo" {
-	name        = "%s"
-	description = "bar"
-	num_loops   = 2
-	rule {
-		escalation_delay_in_minutes = 10
-		target {
-			type = "user_reference"
-			id   = pagerduty_user.foo.id
-		}
-	}
-}
-
-resource "pagerduty_service" "foo" {
-	name                    = "%s"
-	description             = "foo"
-	auto_resolve_timeout    = 1800
-	acknowledgement_timeout = 1800
-	escalation_policy       = pagerduty_escalation_policy.foo.id
-	alert_creation          = "create_alerts_and_incidents"
-	alert_grouping          = "time"
-	alert_grouping_timeout  = 1800
-}
-`, username, email, escalationPolicy, service)
-}
-
 func testAccCheckPagerDutyServiceConfigWithAlertContentGrouping(username, email, escalationPolicy, service string) string {
 	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
@@ -1737,43 +1638,6 @@ resource "pagerduty_service" "foo" {
 			timeout = 0
 		}
 	}
-}
-`, username, email, escalationPolicy, service)
-}
-
-func testAccCheckPagerDutyServiceConfigWithAlertGroupingUpdated(username, email, escalationPolicy, service string) string {
-	return fmt.Sprintf(`
-resource "pagerduty_user" "foo" {
-	name        = "%s"
-	email       = "%s"
-	color       = "green"
-	role        = "user"
-	job_title   = "foo"
-	description = "foo"
-}
-
-resource "pagerduty_escalation_policy" "foo" {
-	name        = "%s"
-	description = "bar"
-	num_loops   = 2
-	rule {
-		escalation_delay_in_minutes = 10
-		target {
-			type = "user_reference"
-			id   = pagerduty_user.foo.id
-		}
-	}
-}
-
-resource "pagerduty_service" "foo" {
-	name                    = "%s"
-	description             = "foo"
-	auto_resolve_timeout    = 1800
-	acknowledgement_timeout = 1800
-	escalation_policy       = pagerduty_escalation_policy.foo.id
-	alert_creation          = "create_alerts_and_incidents"
-	alert_grouping          = "intelligent"
-	alert_grouping_timeout  = 1900
 }
 `, username, email, escalationPolicy, service)
 }


### PR DESCRIPTION
## New acceptance test case introduced...

```sh
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -count=1 -run TestAccPagerDutyServiceWithAutoPauseNotificationsDisabled_import -timeout 120m
?       github.com/PagerDuty/terraform-provider-pagerduty       [no test files]
?       github.com/PagerDuty/terraform-provider-pagerduty/util/apiutil  [no test files]
=== RUN   TestAccPagerDutyServiceWithAutoPauseNotificationsDisabled_import
--- PASS: TestAccPagerDutyServiceWithAutoPauseNotificationsDisabled_import (15.76s)
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerduty     17.236s
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerdutyplugin       0.557s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/util  1.096s [no tests to run]
```