### PR TITLE
Address: Errors when trying to apply a business service that was manually deleted from PD

### DIFF
--- a/pagerdutyplugin/resource_pagerduty_business_service.go
+++ b/pagerdutyplugin/resource_pagerduty_business_service.go
@@ -107,10 +107,11 @@ func (r *resourceBusinessService) Read(ctx context.Context, req resource.ReadReq
 	log.Printf("[INFO] Reading PagerDuty business service %s", state.ID)
 
 	state, found := requestGetBusinessService(ctx, r.client, state.ID.ValueString(), false, &resp.Diagnostics)
+	if !found {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 	if resp.Diagnostics.HasError() {
-		if !found {
-			resp.State.RemoveResource(ctx)
-		}
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)


### PR DESCRIPTION
Closes #895 

## Acceptance tests extended to protect from regressions...

```sh
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -count=1 -run TestAccPagerDutyBusinessService -timeout 120m
?       github.com/PagerDuty/terraform-provider-pagerduty       [no test files]
?       github.com/PagerDuty/terraform-provider-pagerduty/util/apiutil  [no test files]
=== RUN   TestAccPagerDutyBusinessServiceSubscriber_import
--- PASS: TestAccPagerDutyBusinessServiceSubscriber_import (11.80s)
=== RUN   TestAccPagerDutyBusinessServiceSubscriber_User
--- PASS: TestAccPagerDutyBusinessServiceSubscriber_User (11.02s)
=== RUN   TestAccPagerDutyBusinessServiceSubscriber_Team
--- PASS: TestAccPagerDutyBusinessServiceSubscriber_Team (9.29s)
=== RUN   TestAccPagerDutyBusinessServiceSubscriber_TeamUser
--- PASS: TestAccPagerDutyBusinessServiceSubscriber_TeamUser (11.76s)
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerduty     44.932s
=== RUN   TestAccPagerDutyBusinessService_import
--- PASS: TestAccPagerDutyBusinessService_import (11.61s)
=== RUN   TestAccPagerDutyBusinessService_Basic # 👈 Acceptance extended
--- PASS: TestAccPagerDutyBusinessService_Basic (20.25s)
=== RUN   TestAccPagerDutyBusinessService_WithTeam
--- PASS: TestAccPagerDutyBusinessService_WithTeam (11.78s)
=== RUN   TestAccPagerDutyBusinessService_SDKv2Compatibility
--- PASS: TestAccPagerDutyBusinessService_SDKv2Compatibility (18.76s)
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerdutyplugin       63.097s
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/util  1.297s [no tests to run]
```