### PR TITLE
Address: API calls cancelled by client because of Timeout

### DIFF
--- a/pagerduty/config.go
+++ b/pagerduty/config.go
@@ -79,6 +79,14 @@ func (c *Config) Client() (*pagerduty.Client, error) {
 	httpClient.Timeout = 2 * time.Minute
 
 	transport := http.DefaultTransport.(*http.Transport).Clone()
+	// Set the maximum number of idle (keep-alive) connections across all hosts
+	// Experimenting with these values to see if it helps with the connection pool
+	// and hence to solve the issue
+	// https://github.com/PagerDuty/terraform-provider-pagerduty/issues/904
+	transport.MaxIdleConns = 0
+	transport.MaxIdleConnsPerHost = 500
+	transport.MaxConnsPerHost = 0
+
 	if c.InsecureTls {
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
@@ -142,8 +150,17 @@ func (c *Config) SlackClient() (*pagerduty.Client, error) {
 
 	var httpClient *http.Client
 	httpClient = http.DefaultClient
+	httpClient.Timeout = 2 * time.Minute
 
 	transport := http.DefaultTransport.(*http.Transport).Clone()
+	// Set the maximum number of idle (keep-alive) connections across all hosts
+	// Experimenting with these values to see if it helps with the connection pool
+	// and hence to solve the issue
+	// https://github.com/PagerDuty/terraform-provider-pagerduty/issues/904
+	transport.MaxIdleConns = 0
+	transport.MaxIdleConnsPerHost = 500
+	transport.MaxConnsPerHost = 0
+
 	if c.InsecureTls {
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}

--- a/pagerdutyplugin/config.go
+++ b/pagerdutyplugin/config.go
@@ -79,6 +79,14 @@ func (c *Config) Client(ctx context.Context) (*pagerduty.Client, error) {
 	httpClient.Timeout = 2 * time.Minute
 
 	transport := http.DefaultTransport.(*http.Transport).Clone()
+	// Set the maximum number of idle (keep-alive) connections across all hosts
+	// Experimenting with these values to see if it helps with the connection pool
+	// and hence to solve the issue
+	// https://github.com/PagerDuty/terraform-provider-pagerduty/issues/904
+	transport.MaxIdleConns = 0
+	transport.MaxIdleConnsPerHost = 500
+	transport.MaxConnsPerHost = 0
+
 	if c.InsecureTls {
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}


### PR DESCRIPTION
Closes #904

## Acceptance tests results...

```sh
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -count=1 -run TestAccPagerDutyService_Basic -timeout 120m
?       github.com/PagerDuty/terraform-provider-pagerduty       [no test files]
?       github.com/PagerDuty/terraform-provider-pagerduty/util/apiutil  [no test files]
=== RUN   TestAccPagerDutyService_Basic
--- PASS: TestAccPagerDutyService_Basic (28.90s)
=== RUN   TestAccPagerDutyService_BasicWithIncidentUrgencyRules
--- PASS: TestAccPagerDutyService_BasicWithIncidentUrgencyRules (31.43s)
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerduty     60.845s
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerdutyplugin       1.013s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/util  0.658s [no tests to run]
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -count=1 -run TestAccPagerDutyUser_Basic -timeout 120m
?       github.com/PagerDuty/terraform-provider-pagerduty       [no test files]
?       github.com/PagerDuty/terraform-provider-pagerduty/util/apiutil  [no test files]
=== RUN   TestAccPagerDutyUser_Basic
--- PASS: TestAccPagerDutyUser_Basic (29.33s)
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerduty     29.890s
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerdutyplugin       0.899s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/util  1.168s [no tests to run]
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -count=1 -run TestAccPagerDutyEscalationPolicyWithRoundRobinAssignmentStrategy -timeout 120m
?       github.com/PagerDuty/terraform-provider-pagerduty       [no test files]
?       github.com/PagerDuty/terraform-provider-pagerduty/util/apiutil  [no test files]
=== RUN   TestAccPagerDutyEscalationPolicyWithRoundRobinAssignmentStrategy
--- PASS: TestAccPagerDutyEscalationPolicyWithRoundRobinAssignmentStrategy (25.63s)
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerduty     26.802s
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerdutyplugin       0.521s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/util  0.755s [no tests to run]
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -count=1 -run TestAccPagerDutyTeam_Basic -timeout 120m
?       github.com/PagerDuty/terraform-provider-pagerduty       [no test files]
?       github.com/PagerDuty/terraform-provider-pagerduty/util/apiutil  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerduty     1.295s [no tests to run]
=== RUN   TestAccPagerDutyTeam_Basic
--- PASS: TestAccPagerDutyTeam_Basic (25.21s)
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerdutyplugin       26.167s
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/util  0.565s [no tests to run]
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -count=1 -run TestAccPagerDutyEventOrchestrationPathRouter_Basic -timeout 120m
?       github.com/PagerDuty/terraform-provider-pagerduty       [no test files]
?       github.com/PagerDuty/terraform-provider-pagerduty/util/apiutil  [no test files]
=== RUN   TestAccPagerDutyEventOrchestrationPathRouter_Basic
--- PASS: TestAccPagerDutyEventOrchestrationPathRouter_Basic (93.48s)
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerduty     93.998s
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerdutyplugin       1.144s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/util  0.717s [no tests to run]
```