### PR TITLE
Second attempt to address: API calls cancelled by client because of Timeout

### DIFF
--- a/pagerduty/config.go
+++ b/pagerduty/config.go
@@ -76,17 +76,9 @@ func (c *Config) Client() (*pagerduty.Client, error) {
 
 	var httpClient *http.Client
 	httpClient = http.DefaultClient
-	httpClient.Timeout = 2 * time.Minute
+	httpClient.Timeout = 30 * time.Second
 
 	transport := http.DefaultTransport.(*http.Transport).Clone()
-	// Set the maximum number of idle (keep-alive) connections across all hosts
-	// Experimenting with these values to see if it helps with the connection pool
-	// and hence to solve the issue
-	// https://github.com/PagerDuty/terraform-provider-pagerduty/issues/904
-	transport.MaxIdleConns = 0
-	transport.MaxIdleConnsPerHost = 500
-	transport.MaxConnsPerHost = 0
-
 	if c.InsecureTls {
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
@@ -150,17 +142,9 @@ func (c *Config) SlackClient() (*pagerduty.Client, error) {
 
 	var httpClient *http.Client
 	httpClient = http.DefaultClient
-	httpClient.Timeout = 2 * time.Minute
+	httpClient.Timeout = 30 * time.Second
 
 	transport := http.DefaultTransport.(*http.Transport).Clone()
-	// Set the maximum number of idle (keep-alive) connections across all hosts
-	// Experimenting with these values to see if it helps with the connection pool
-	// and hence to solve the issue
-	// https://github.com/PagerDuty/terraform-provider-pagerduty/issues/904
-	transport.MaxIdleConns = 0
-	transport.MaxIdleConnsPerHost = 500
-	transport.MaxConnsPerHost = 0
-
 	if c.InsecureTls {
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}

--- a/pagerdutyplugin/config.go
+++ b/pagerdutyplugin/config.go
@@ -76,17 +76,9 @@ func (c *Config) Client(ctx context.Context) (*pagerduty.Client, error) {
 	}
 
 	httpClient := http.DefaultClient
-	httpClient.Timeout = 2 * time.Minute
+	httpClient.Timeout = 30 * time.Second
 
 	transport := http.DefaultTransport.(*http.Transport).Clone()
-	// Set the maximum number of idle (keep-alive) connections across all hosts
-	// Experimenting with these values to see if it helps with the connection pool
-	// and hence to solve the issue
-	// https://github.com/PagerDuty/terraform-provider-pagerduty/issues/904
-	transport.MaxIdleConns = 0
-	transport.MaxIdleConnsPerHost = 500
-	transport.MaxConnsPerHost = 0
-
 	if c.InsecureTls {
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}


### PR DESCRIPTION
Closes #904 

## Acceptance tests results...

```sh
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -count=1 -run TestAccPagerDutyService_Basic -timeout 120m
?       github.com/PagerDuty/terraform-provider-pagerduty       [no test files]
?       github.com/PagerDuty/terraform-provider-pagerduty/util/apiutil  [no test files]
=== RUN   TestAccPagerDutyService_Basic
--- PASS: TestAccPagerDutyService_Basic (29.45s)
=== RUN   TestAccPagerDutyService_BasicWithIncidentUrgencyRules
--- PASS: TestAccPagerDutyService_BasicWithIncidentUrgencyRules (32.61s)
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerduty     63.755s
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerdutyplugin       1.497s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/util  1.026s [no tests to run]
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -count=1 -run TestAccPagerDutyUser_Basic -timeout 120m
?       github.com/PagerDuty/terraform-provider-pagerduty       [no test files]
?       github.com/PagerDuty/terraform-provider-pagerduty/util/apiutil  [no test files]
=== RUN   TestAccPagerDutyUser_Basic
--- PASS: TestAccPagerDutyUser_Basic (28.62s)
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerduty     29.687s
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerdutyplugin       0.489s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/util  0.690s [no tests to run]
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -count=1 -run TestAccPagerDutyEscalationPolicyWithRoundRobinAssignmentStrategy -timeout 120m
?       github.com/PagerDuty/terraform-provider-pagerduty       [no test files]
?       github.com/PagerDuty/terraform-provider-pagerduty/util/apiutil  [no test files]
=== RUN   TestAccPagerDutyEscalationPolicyWithRoundRobinAssignmentStrategy
--- PASS: TestAccPagerDutyEscalationPolicyWithRoundRobinAssignmentStrategy (25.43s)
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerduty     26.639s
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerdutyplugin       0.569s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/util  0.788s [no tests to run]
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -count=1 -run TestAccPagerDutySchedule_Basic -timeout 120m
?       github.com/PagerDuty/terraform-provider-pagerduty       [no test files]
?       github.com/PagerDuty/terraform-provider-pagerduty/util/apiutil  [no test files]
=== RUN   TestAccPagerDutySchedule_Basic
--- PASS: TestAccPagerDutySchedule_Basic (29.77s)
=== RUN   TestAccPagerDutySchedule_BasicWeek
--- PASS: TestAccPagerDutySchedule_BasicWeek (18.62s)
testing: warning: no tests to run
ok    github.com/PagerDuty/terraform-provider-pagerduty/pagerduty     183.229s
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerdutyplugin       0.773s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/util  1.005s [no tests to run]
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -count=1 -run TestAccPagerDutyTeam_Basic -timeout 120m
?       github.com/PagerDuty/terraform-provider-pagerduty       [no test files]
?       github.com/PagerDuty/terraform-provider-pagerduty/util/apiutil  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerduty     0.515s [no tests to run]
=== RUN   TestAccPagerDutyTeam_Basic
--- PASS: TestAccPagerDutyTeam_Basic (24.11s)
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerdutyplugin       25.236s
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/util  0.718s [no tests to run]
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -count=1 -run TestAccPagerDutyEventOrchestrationPathRouter_Basic -timeout 120m
?       github.com/PagerDuty/terraform-provider-pagerduty       [no test files]
?       github.com/PagerDuty/terraform-provider-pagerduty/util/apiutil  [no test files]
=== RUN   TestAccPagerDutyEventOrchestrationPathRouter_Basic
--- PASS: TestAccPagerDutyEventOrchestrationPathRouter_Basic (91.02s)
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerduty     91.484s
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerdutyplugin       1.076s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/util  0.663s [no tests to run]

```