### PR TITLE
Install a fresh terraform binary if we're unable to locate a matching version in PATH.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Requirements
 
--	[Terraform](https://www.terraform.io/downloads.html) 0.12.x
+-	[Terraform](https://www.terraform.io/downloads.html) >= 1.1.0
 -	[Go](https://golang.org/doc/install) 1.20 (to build the provider plugin)
 
 ## Building the Provider


### PR DESCRIPTION
So full disclosure... I don't know go. I stumbled my way through this and managed to run a simple test w/ vscode.

I'm not sure if this is the best approach to fix the problem that I'm seeing, but I want to try to move along the fix as much as I can.

This is meant to address an issue that we're seeing atm in Terraform Cloud. We get this message when trying to apply our plan:
> terraform binary version >= 1.0.6 not found in $PATH

I looked through the commit history and spotted that this was changed in March to not download a fresh binary. I tried reverting our usage to the version that pulls a fresh binary, but then hit this message:
![image](https://github.com/user-attachments/assets/3627de11-c77e-41d4-9ff4-237003f68c84)

According to this [SO post](https://stackoverflow.com/questions/70763407/blocks-of-type-cloud-are-not-expected-here-for-integrating-with-terraform-clou) it seems to be a requirement of 1.1 in Terraform Cloud while the older version of this provider installs 1.0.6.

I took a screenshot of my poorly written test output (since deleted as I don't know go and couldn't write the mocks):
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/b19da725-c35d-45f1-aed5-9314ae4fec69">

