### PR TITLE
Fix cursor for datasource alert grouping setting

### DIFF
--- a/pagerdutyplugin/data_source_pagerduty_alert_grouping_setting.go
+++ b/pagerdutyplugin/data_source_pagerduty_alert_grouping_setting.go
@@ -68,13 +68,12 @@ func (d *dataSourceAlertGroupingSetting) Read(ctx context.Context, req datasourc
 		return
 	}
 
-	var cursorAfter, cursorBefore string
+	var cursorAfter string
 	var found *pagerduty.AlertGroupingSetting
 	err := apiutil.All(ctx, func(offset int) (bool, error) {
 		resp, err := d.client.ListAlertGroupingSettings(ctx, pagerduty.ListAlertGroupingSettingsOptions{
-			After:  cursorAfter,
-			Before: cursorBefore,
-			Limit:  100,
+			After: cursorAfter,
+			Limit: 100,
 		})
 		if err != nil {
 			return false, err
@@ -87,6 +86,7 @@ func (d *dataSourceAlertGroupingSetting) Read(ctx context.Context, req datasourc
 			}
 		}
 
+		cursorAfter = resp.After
 		return resp.After != "", nil
 	})
 	if err != nil {

--- a/pagerdutyplugin/resource_pagerduty_alert_grouping_setting.go
+++ b/pagerdutyplugin/resource_pagerduty_alert_grouping_setting.go
@@ -147,6 +147,9 @@ func (r *resourceAlertGroupingSetting) Create(ctx context.Context, req resource.
 	err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
 		response, err := r.client.CreateAlertGroupingSetting(ctx, plan)
 		if err != nil {
+			if util.IsBadRequestError(err) {
+				return retry.NonRetryableError(err)
+			}
 			return retry.RetryableError(err)
 		}
 		plan.ID = response.ID


### PR DESCRIPTION
```
=== RUN   TestAccDataSourcePagerDutyAlertGroupingSetting_Time
--- PASS: TestAccDataSourcePagerDutyAlertGroupingSetting_Time (19.44s)
=== RUN   TestAccDataSourcePagerDutyAlertGroupingSetting_ContentBased
--- PASS: TestAccDataSourcePagerDutyAlertGroupingSetting_ContentBased (19.07s)
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerdutyplugin       39.088s
```