### PR TITLE
fix: return an empty list if there's no alertgrouping list

### DIFF
--- a/vendor/github.com/PagerDuty/go-pagerduty/alert_grouping_setting.go
+++ b/vendor/github.com/PagerDuty/go-pagerduty/alert_grouping_setting.go
@@ -107,6 +107,12 @@ func (c *Client) ListAlertGroupingSettings(ctx context.Context, o ListAlertGroup
 	}
 
 	resp, err := c.get(ctx, "/alert_grouping_settings?"+v.Encode(), nil)
+
+	// If there's no alert grouping settings, return an empty list.
+	if resp.StatusCode == 404 {
+		return &ListAlertGroupingSettingsResponse{}, nil
+	}
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
fixes #944 

test went through, i'm not sure if the change is valid though. Was just a quick fix so i could get my stuff working 😅