### PR TITLE
Address: Using pagerduty_alert_grouping_setting causes error HTTP response failed with status code 404 and no JSON error object was present

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/PagerDuty/terraform-provider-pagerduty
 go 1.20
 
 require (
-	github.com/PagerDuty/go-pagerduty v1.8.1-0.20241104145658-2a0050d437ac
+	github.com/PagerDuty/go-pagerduty v1.8.1-0.20241111225923-0ef8f340dd3c
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hc-install v0.6.2
@@ -76,5 +76,3 @@ require (
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 )
-
-replace github.com/PagerDuty/go-pagerduty => github.com/alxndr13/go-pagerduty v0.0.0-20241111083444-60a4c9be7359

--- a/go.mod
+++ b/go.mod
@@ -76,3 +76,5 @@ require (
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 )
+
+replace github.com/PagerDuty/go-pagerduty => github.com/alxndr13/go-pagerduty v0.0.0-20241111083444-60a4c9be7359

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,11 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
+github.com/PagerDuty/go-pagerduty v1.8.1-0.20241111225923-0ef8f340dd3c h1:Bnw38sqsVdQVOiuTealk57GnuRb86zyd5v/XW3BcPl8=
+github.com/PagerDuty/go-pagerduty v1.8.1-0.20241111225923-0ef8f340dd3c/go.mod h1:ilimTqwHSBjmvKeYA/yayDBZvzf/CX4Pwa9Qbhekzok=
 github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c h1:kMFnB0vCcX7IL/m9Y5LO+KQYv+t1CQOiFe6+SV2J7bE=
 github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
-github.com/alxndr13/go-pagerduty v0.0.0-20241111083444-60a4c9be7359 h1:3xXdKIuWfwMzEBTbmSW3fUcVcW+0cJiYbUmAXYPxh8w=
-github.com/alxndr13/go-pagerduty v0.0.0-20241111083444-60a4c9be7359/go.mod h1:ilimTqwHSBjmvKeYA/yayDBZvzf/CX4Pwa9Qbhekzok=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=

--- a/go.sum
+++ b/go.sum
@@ -1,15 +1,11 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
-github.com/PagerDuty/go-pagerduty v1.8.1-0.20241002154647-8ceedfd04d88 h1:y/icahuphX4xGMW4nLN+Bl4MbFUU4rEA9spwgcPIDJk=
-github.com/PagerDuty/go-pagerduty v1.8.1-0.20241002154647-8ceedfd04d88/go.mod h1:ilimTqwHSBjmvKeYA/yayDBZvzf/CX4Pwa9Qbhekzok=
-github.com/PagerDuty/go-pagerduty v1.8.1-0.20241025123418-0c3fc7303be4 h1:egkL94FTYFe3GfnJMpY2aAj6tA2wXXYRfGPJPfC90BQ=
-github.com/PagerDuty/go-pagerduty v1.8.1-0.20241025123418-0c3fc7303be4/go.mod h1:ilimTqwHSBjmvKeYA/yayDBZvzf/CX4Pwa9Qbhekzok=
-github.com/PagerDuty/go-pagerduty v1.8.1-0.20241104145658-2a0050d437ac h1:GtkaaoQH3DSWt9hxC71pAp31pyhKFxU1nBfa5iZWecE=
-github.com/PagerDuty/go-pagerduty v1.8.1-0.20241104145658-2a0050d437ac/go.mod h1:ilimTqwHSBjmvKeYA/yayDBZvzf/CX4Pwa9Qbhekzok=
 github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c h1:kMFnB0vCcX7IL/m9Y5LO+KQYv+t1CQOiFe6+SV2J7bE=
 github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
+github.com/alxndr13/go-pagerduty v0.0.0-20241111083444-60a4c9be7359 h1:3xXdKIuWfwMzEBTbmSW3fUcVcW+0cJiYbUmAXYPxh8w=
+github.com/alxndr13/go-pagerduty v0.0.0-20241111083444-60a4c9be7359/go.mod h1:ilimTqwHSBjmvKeYA/yayDBZvzf/CX4Pwa9Qbhekzok=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=

--- a/vendor/github.com/PagerDuty/go-pagerduty/alert_grouping_setting.go
+++ b/vendor/github.com/PagerDuty/go-pagerduty/alert_grouping_setting.go
@@ -107,6 +107,12 @@ func (c *Client) ListAlertGroupingSettings(ctx context.Context, o ListAlertGroup
 	}
 
 	resp, err := c.get(ctx, "/alert_grouping_settings?"+v.Encode(), nil)
+
+	// If there are no alert grouping settings, return an empty response.
+	if resp.StatusCode == 404 {
+		return &ListAlertGroupingSettingsResponse{}, nil
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/PagerDuty/go-pagerduty v1.8.1-0.20241104145658-2a0050d437ac => github.com/alxndr13/go-pagerduty v0.0.0-20241111083444-60a4c9be7359
+# github.com/PagerDuty/go-pagerduty v1.8.1-0.20241111225923-0ef8f340dd3c
 ## explicit; go 1.19
 github.com/PagerDuty/go-pagerduty
 # github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c
@@ -561,4 +561,3 @@ google.golang.org/protobuf/types/known/timestamppb
 # gopkg.in/ini.v1 v1.67.0
 ## explicit
 gopkg.in/ini.v1
-# github.com/PagerDuty/go-pagerduty => github.com/alxndr13/go-pagerduty v0.0.0-20241111083444-60a4c9be7359

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/PagerDuty/go-pagerduty v1.8.1-0.20241104145658-2a0050d437ac
+# github.com/PagerDuty/go-pagerduty v1.8.1-0.20241104145658-2a0050d437ac => github.com/alxndr13/go-pagerduty v0.0.0-20241111083444-60a4c9be7359
 ## explicit; go 1.19
 github.com/PagerDuty/go-pagerduty
 # github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c
@@ -561,3 +561,4 @@ google.golang.org/protobuf/types/known/timestamppb
 # gopkg.in/ini.v1 v1.67.0
 ## explicit
 gopkg.in/ini.v1
+# github.com/PagerDuty/go-pagerduty => github.com/alxndr13/go-pagerduty v0.0.0-20241111083444-60a4c9be7359


### PR DESCRIPTION
Close #944 

## New test case introduce to protect from regressions...

```bash
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -count=1 -run TestAccPagerDutyAlertGroupingSetting_serviceNotExist -timeout 120m
?       github.com/PagerDuty/terraform-provider-pagerduty       [no test files]
?       github.com/PagerDuty/terraform-provider-pagerduty/util/apiutil  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerduty     0.569s [no tests to run]
=== RUN   TestAccPagerDutyAlertGroupingSetting_serviceNotExist
--- PASS: TestAccPagerDutyAlertGroupingSetting_serviceNotExist (16.57s)
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerdutyplugin       17.731s
```