### PR TITLE
Fix service update conflict on alert grouping rules

### DIFF
--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -418,7 +418,9 @@ func buildServiceStruct(d *schema.ResourceData) (*pagerduty.Service, error) {
 
 	if attr, ok := d.GetOk("alert_grouping"); ok {
 		ag := attr.(string)
-		service.AlertGrouping = &ag
+		if ag != "rules" {
+			service.AlertGrouping = &ag
+		}
 	}
 
 	if attr, ok := d.GetOk("alert_grouping_parameters"); ok {
@@ -524,6 +526,10 @@ func resourcePagerDutyServiceCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	d.SetId(service.ID)
+
+	// We wait for internal subsystem to sync. Otherwise fields like
+	// alert_grouping_parameters will return empty.
+	time.Sleep(500 * time.Millisecond)
 
 	return fetchService(d, meta, genError)
 }

--- a/pagerduty/resource_pagerduty_service_test.go
+++ b/pagerduty/resource_pagerduty_service_test.go
@@ -406,7 +406,7 @@ func TestAccPagerDutyService_AlertGrouping(t *testing.T) {
 	// and will be removed in a future release.
 }
 
-func TestAccPagerDutyService_AlertContentGrouping(t *testing.T) {
+func TestAccPagerDutyService_AlertGroupingContentBased(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	email := fmt.Sprintf("%s@foo.test", username)
 	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))


### PR DESCRIPTION
Prevents conflict between the field `alert_grouping` of a service and its associated `alert_grouping_setting`. Fixing #949  #958 