### PR TITLE
pagerduty_incident_workflow_trigger remove value check on conditional and update tests

### DIFF
--- a/pagerduty/resource_pagerduty_incident_workflow_trigger.go
+++ b/pagerduty/resource_pagerduty_incident_workflow_trigger.go
@@ -180,9 +180,6 @@ func validateIncidentWorkflowTrigger(_ context.Context, d *schema.ResourceDiff, 
 	if triggerType == "manual" && hadCondition {
 		return fmt.Errorf("when trigger type manual is used, condition must not be specified")
 	}
-	if triggerType == "conditional" && !hadCondition {
-		return fmt.Errorf("when trigger type conditional is used, condition must be specified")
-	}
 
 	// pagerduty_incident_workflow_trigger.permissions input validation
 	permissionRestricted := d.Get("permissions.0.restricted").(bool)

--- a/pagerduty/resource_pagerduty_incident_workflow_trigger_test.go
+++ b/pagerduty/resource_pagerduty_incident_workflow_trigger_test.go
@@ -102,29 +102,6 @@ resource "pagerduty_incident_workflow_trigger" "my_first_workflow_trigger" {
 	})
 }
 
-func TestAccPagerDutyIncidentWorkflowTrigger_ConditionalTypeWithoutCondition(t *testing.T) {
-	config := `
-resource "pagerduty_incident_workflow_trigger" "my_first_workflow_trigger" {
-  type             = "conditional"
-  workflow         = "ignored"
-  subscribed_to_all_services = true
-}
-`
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-			testAccPreCheckIncidentWorkflows(t)
-		},
-		ProviderFactories: testAccProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config:      config,
-				ExpectError: regexp.MustCompile("when trigger type conditional is used, condition must be specified"),
-			},
-		},
-	})
-}
-
 func TestAccPagerDutyIncidentWorkflowTrigger_SubscribedToAllWithInvalidServices(t *testing.T) {
 	config := `
 resource "pagerduty_incident_workflow_trigger" "my_first_workflow_trigger" {
@@ -203,6 +180,17 @@ func TestAccPagerDutyIncidentWorkflowTrigger_BasicConditionalAllServices(t *test
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckPagerDutyIncidentWorkflowTriggerDestroy,
 		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyIncidentWorkflowTriggerConfigConditionalAllServices(workflow, ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyIncidentWorkflowTriggerExists("pagerduty_incident_workflow_trigger.test"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_incident_workflow_trigger.test", "type", "conditional"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_incident_workflow_trigger.test", "condition", ""),
+					resource.TestCheckResourceAttr("pagerduty_incident_workflow_trigger.test", "subscribed_to_all_services", "true"),
+				),
+			},
 			{
 				Config: testAccCheckPagerDutyIncidentWorkflowTriggerConfigConditionalAllServices(workflow, "incident.priority matches 'P1'"),
 				Check: resource.ComposeTestCheckFunc(
@@ -384,6 +372,17 @@ func TestAccPagerDutyIncidentWorkflowTrigger_ChangeTypeCausesReplace(t *testing.
 		CheckDestroy:      testAccCheckPagerDutyIncidentWorkflowTriggerDestroy,
 		Steps: []resource.TestStep{
 			{
+				Config: testAccCheckPagerDutyIncidentWorkflowTriggerConfigConditionalAllServices(workflow, ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyIncidentWorkflowTriggerExists("pagerduty_incident_workflow_trigger.test"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_incident_workflow_trigger.test", "type", "conditional"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_incident_workflow_trigger.test", "condition", ""),
+					resource.TestCheckResourceAttr("pagerduty_incident_workflow_trigger.test", "subscribed_to_all_services", "true"),
+				),
+			},
+			{
 				Config: testAccCheckPagerDutyIncidentWorkflowTriggerConfigConditionalAllServices(workflow, "incident.priority matches 'P1'"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyIncidentWorkflowTriggerExists("pagerduty_incident_workflow_trigger.test"),
@@ -445,6 +444,17 @@ func TestAccPagerDutyIncidentWorkflowTrigger_CannotChangeType(t *testing.T) {
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckPagerDutyIncidentWorkflowTriggerDestroy,
 		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyIncidentWorkflowTriggerConfigConditionalAllServices(workflow, ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyIncidentWorkflowTriggerExists("pagerduty_incident_workflow_trigger.test"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_incident_workflow_trigger.test", "type", "conditional"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_incident_workflow_trigger.test", "condition", ""),
+					resource.TestCheckResourceAttr("pagerduty_incident_workflow_trigger.test", "subscribed_to_all_services", "true"),
+				),
+			},
 			{
 				Config: testAccCheckPagerDutyIncidentWorkflowTriggerConfigConditionalAllServices(workflow, "incident.priority matches 'P1'"),
 				Check: resource.ComposeTestCheckFunc(


### PR DESCRIPTION
Fixes https://github.com/PagerDuty/terraform-provider-pagerduty/issues/961 and https://github.com/PagerDuty/terraform-provider-pagerduty/issues/924

Tested the following resources with a terraform plan and apply
condition key's value set to ""
```
resource "pagerduty_incident_workflow_trigger" "stakeholders_conditional" {
  type                       = "conditional"
  workflow                   = pagerduty_incident_workflow.notify_stakeholders.id
  services                   = [pagerduty_service.high_urgency.id]
  subscribed_to_all_services = false
  condition                  = ""
}
```
condition key missing
```
resource "pagerduty_incident_workflow_trigger" "stakeholders_conditional" {
  type                       = "conditional"
  workflow                   = pagerduty_incident_workflow.notify_stakeholders.id
  services                   = [pagerduty_service.high_urgency.id]
  subscribed_to_all_services = false
}
```

Test run:
Failures are my user's lack of permissions
Important tests:
* TestAccPagerDutyIncidentWorkflowTrigger_BasicConditionalAllServices
* TestAccPagerDutyIncidentWorkflowTrigger_ChangeTypeCausesReplace
* TestAccPagerDutyIncidentWorkflowTrigger_CannotChangeType

`PAGERDUTY_ACC_INCIDENT_WORKFLOWS=1 make testacc TESTARGS="-run PagerDutyIncidentWorkflow"`
```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run PagerDutyIncidentWorkflow -timeout 120m
?       github.com/PagerDuty/terraform-provider-pagerduty       [no test files]
?       github.com/PagerDuty/terraform-provider-pagerduty/util/apiutil  [no test files]
=== RUN   TestAccDataSourcePagerDutyIncidentWorkflow
--- PASS: TestAccDataSourcePagerDutyIncidentWorkflow (5.66s)
=== RUN   TestAccDataSourcePagerDutyIncidentWorkflow_Missing
--- PASS: TestAccDataSourcePagerDutyIncidentWorkflow_Missing (2.40s)
=== RUN   TestAccPagerDutyIncidentWorkflow_import
--- PASS: TestAccPagerDutyIncidentWorkflow_import (5.18s)
=== RUN   TestAccPagerDutyIncidentWorkflowTrigger_import
    import_pagerduty_incident_workflow_trigger_test.go:18: Step 1/2 error: Error running apply: exit status 1

        Error: POST API call to https://api.pagerduty.com/users failed 403 Forbidden. Code: 2010, Errors: <nil>, Message: Access Denied

          with pagerduty_user.foo,
          on terraform_plugin_test.tf line 13, in resource "pagerduty_user" "foo":
          13: resource "pagerduty_user" "foo" {

--- FAIL: TestAccPagerDutyIncidentWorkflowTrigger_import (3.40s)
=== RUN   TestAccPagerDutyIncidentWorkflow_Basic
--- PASS: TestAccPagerDutyIncidentWorkflow_Basic (7.56s)
=== RUN   TestAccPagerDutyIncidentWorkflow_Team
--- PASS: TestAccPagerDutyIncidentWorkflow_Team (9.41s)
=== RUN   TestAccPagerDutyIncidentWorkflow_InlineInputs
    resource_pagerduty_incident_workflow_test.go:123: Step 1/2 error: Error running apply: exit status 1

        Error: POST API call to https://api.pagerduty.com/incident_workflows failed 404 Not Found. Code: 0, Errors: <nil>, Message:

          with pagerduty_incident_workflow.test,
          on terraform_plugin_test.tf line 12, in resource "pagerduty_incident_workflow" "test":
          12: resource "pagerduty_incident_workflow" "test" {

--- FAIL: TestAccPagerDutyIncidentWorkflow_InlineInputs (2.43s)
=== RUN   TestAccPagerDutyIncidentWorkflowTrigger_BadType
--- PASS: TestAccPagerDutyIncidentWorkflowTrigger_BadType (1.64s)
=== RUN   TestAccPagerDutyIncidentWorkflowTrigger_ConditionWithManualType
--- PASS: TestAccPagerDutyIncidentWorkflowTrigger_ConditionWithManualType (1.71s)
=== RUN   TestAccPagerDutyIncidentWorkflowTrigger_SubscribedToAllWithInvalidServices
--- PASS: TestAccPagerDutyIncidentWorkflowTrigger_SubscribedToAllWithInvalidServices (1.72s)
=== RUN   TestAccPagerDutyIncidentWorkflowTrigger_BasicManual
    resource_pagerduty_incident_workflow_trigger_test.go:137: Step 1/1 error: Error running apply: exit status 1

        Error: POST API call to https://api.pagerduty.com/users failed 403 Forbidden. Code: 2010, Errors: <nil>, Message: Access Denied

          with pagerduty_user.foo,
          on terraform_plugin_test.tf line 13, in resource "pagerduty_user" "foo":
          13: resource "pagerduty_user" "foo" {

--- FAIL: TestAccPagerDutyIncidentWorkflowTrigger_BasicManual (3.25s)
=== RUN   TestAccPagerDutyIncidentWorkflowTrigger_BasicConditionalAllServices
--- PASS: TestAccPagerDutyIncidentWorkflowTrigger_BasicConditionalAllServices (11.84s)
=== RUN   TestAccPagerDutyIncidentWorkflowTrigger_ManualWithTeamPermissions
    resource_pagerduty_incident_workflow_trigger_test.go:230: Step 1/5 error: Error running apply: exit status 1

        Error: POST API call to https://api.pagerduty.com/users failed 403 Forbidden. Code: 2010, Errors: <nil>, Message: Access Denied

          with pagerduty_user.foo,
          on terraform_plugin_test.tf line 13, in resource "pagerduty_user" "foo":
          13: resource "pagerduty_user" "foo" {

--- FAIL: TestAccPagerDutyIncidentWorkflowTrigger_ManualWithTeamPermissions (6.14s)
=== RUN   TestAccPagerDutyIncidentWorkflowTrigger_ChangeTypeCausesReplace
--- PASS: TestAccPagerDutyIncidentWorkflowTrigger_ChangeTypeCausesReplace (9.04s)
=== RUN   TestAccPagerDutyIncidentWorkflowTrigger_CannotChangeType
--- PASS: TestAccPagerDutyIncidentWorkflowTrigger_CannotChangeType (8.34s)
FAIL
FAIL    github.com/PagerDuty/terraform-provider-pagerduty/pagerduty     79.726s
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerdutyplugin       (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/util  (cached) [no tests to run]
FAIL
make: *** [GNUmakefile:16: testacc] Error 1
```