### PR TITLE
Address: Unable to import service dependencies

### DIFF
--- a/pagerdutyplugin/import_pagerduty_service_dependency_test.go
+++ b/pagerdutyplugin/import_pagerduty_service_dependency_test.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -30,6 +31,13 @@ func TestAccPagerDutyServiceDependency_import(t *testing.T) {
 				ImportStateIdFunc: testAccCheckPagerDutyServiceDependencyID,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+
+			{
+				ResourceName:  "pagerduty_service_dependency.foo",
+				ImportStateId: "wrongFormatID",
+				ImportState:   true,
+				ExpectError:   regexp.MustCompile(`Expecting an importation ID formed as`),
 			},
 		},
 	})

--- a/pagerdutyplugin/resource_pagerduty_service_dependency.go
+++ b/pagerdutyplugin/resource_pagerduty_service_dependency.go
@@ -334,6 +334,7 @@ func (r *resourceServiceDependency) ImportState(ctx context.Context, req resourc
 			"Error importing pagerduty_service_dependency",
 			"Expecting an importation ID formed as '<supporting_service_id>.<supporting_service_type>.<service_dependency_id>'",
 		)
+		return
 	}
 	supID, supRt, id := ids[0], ids[1], ids[2]
 	serviceDependency, err := r.requestGetServiceDependency(ctx, id, supID, supRt)


### PR DESCRIPTION
Closes #967 

## Results of Acceptance Tests case added for protecting from regressions

```bash
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -count=1 -run TestAccPagerDutyServiceDependency_import -timeout 120m
?       github.com/PagerDuty/terraform-provider-pagerduty       [no test files]
?       github.com/PagerDuty/terraform-provider-pagerduty/util/apiutil  [no test files]
?       github.com/PagerDuty/terraform-provider-pagerduty/util/validate [no test files]
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerduty     2.149s [no tests to run]
=== RUN   TestAccPagerDutyServiceDependency_import # 👈 Extended test case
--- PASS: TestAccPagerDutyServiceDependency_import (27.72s)
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerdutyplugin       29.380s
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/util  1.282s [no tests to run]
```