### PR TITLE
[ORCA-5142] Add deprecation warning for the route_to action within a Service Orchestration catch-all rule

### DIFF
--- a/pagerduty/resource_pagerduty_event_orchestration_path_service.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_service.go
@@ -13,90 +13,94 @@ import (
 	"github.com/heimweh/go-pagerduty/pagerduty"
 )
 
-var eventOrchestrationPathServiceCatchAllActionsSchema = map[string]*schema.Schema{
-	"suppress": {
-		Type:     schema.TypeBool,
-		Optional: true,
-	},
-	"suspend": {
-		Type:     schema.TypeInt,
-		Optional: true,
-	},
-	"priority": {
-		Type:     schema.TypeString,
-		Optional: true,
-	},
-	"annotate": {
-		Type:     schema.TypeString,
-		Optional: true,
-	},
-	"pagerduty_automation_action": {
-		Type:     schema.TypeList,
-		Optional: true,
-		MaxItems: 1,
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"action_id": {
-					Type:     schema.TypeString,
-					Required: true,
+func buildEventOrchestrationPathServiceCatchAllActionsSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"suppress": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
+		"suspend": {
+			Type:     schema.TypeInt,
+			Optional: true,
+		},
+		"priority": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"annotate": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"pagerduty_automation_action": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"action_id": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
 				},
 			},
 		},
-	},
-	"automation_action": {
-		Type:     schema.TypeList,
-		Optional: true,
-		MaxItems: 1,
-		Elem: &schema.Resource{
-			Schema: eventOrchestrationAutomationActionSchema,
+		"automation_action": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: eventOrchestrationAutomationActionSchema,
+			},
 		},
-	},
-	"severity": {
-		Type:             schema.TypeString,
-		Optional:         true,
-		ValidateDiagFunc: validateEventOrchestrationPathSeverity(),
-	},
-	"event_action": {
-		Type:             schema.TypeString,
-		Optional:         true,
-		ValidateDiagFunc: validateEventOrchestrationPathEventAction(),
-	},
-	"variable": {
-		Type:     schema.TypeList,
-		Optional: true,
-		Elem: &schema.Resource{
-			Schema: eventOrchestrationPathVariablesSchema,
+		"severity": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			ValidateDiagFunc: validateEventOrchestrationPathSeverity(),
 		},
-	},
-	"extraction": {
-		Type:     schema.TypeList,
-		Optional: true,
-		Elem: &schema.Resource{
-			Schema: eventOrchestrationPathExtractionsSchema,
+		"event_action": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			ValidateDiagFunc: validateEventOrchestrationPathEventAction(),
 		},
-	},
-	"incident_custom_field_update": {
-		Type:     schema.TypeList,
-		Optional: true,
-		Elem: &schema.Resource{
-			Schema: eventOrchestrationIncidentCustomFieldsObjectSchema,
+		"variable": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: eventOrchestrationPathVariablesSchema,
+			},
 		},
-	},
-	"escalation_policy": {
-		Type:     schema.TypeString,
-		Optional: true,
-	},
+		"extraction": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: eventOrchestrationPathExtractionsSchema,
+			},
+		},
+		"incident_custom_field_update": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: eventOrchestrationIncidentCustomFieldsObjectSchema,
+			},
+		},
+		"escalation_policy": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"route_to": {
+			Type:       schema.TypeString,
+			Deprecated: "The 'route_to' attribute is no longer supported for catch-all rules.",
+			Optional:   true,
+		},
+	}
 }
 
 var eventOrchestrationPathServiceRuleActionsSchema = buildEventOrchestrationPathServiceRuleActionsSchema()
+var eventOrchestrationPathServiceCatchAllActionsSchema = buildEventOrchestrationPathServiceCatchAllActionsSchema()
 
 func buildEventOrchestrationPathServiceRuleActionsSchema() map[string]*schema.Schema {
-	a := eventOrchestrationPathServiceCatchAllActionsSchema
-	a["route_to"] = &schema.Schema{
-		Type:     schema.TypeString,
-		Optional: true,
-	}
-
+	a := buildEventOrchestrationPathServiceCatchAllActionsSchema()
+	a["route_to"].Deprecated = ""
 	return a
 }
 
@@ -178,7 +182,7 @@ func resourcePagerDutyEventOrchestrationPathService() *schema.Resource {
 							Required: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
-								Schema: eventOrchestrationPathServiceRuleActionsSchema,
+								Schema: eventOrchestrationPathServiceCatchAllActionsSchema,
 							},
 						},
 					},


### PR DESCRIPTION
Passing in a `route_to` action for the catch-all rule within a Service Orchestration is not supported. In this PR, we are adding a deprecation warning indicating this.

# Testing

For some given TF config:
```
resource "pagerduty_event_orchestration_service" "event_orchestration" {
  service = pagerduty_service.svc.id
  enable_event_orchestration_for_service = true

  set {
    id = "start"
    rule {
      label = "Set severity to critical if we see at least 5 triggers on the DB within the last 1 minute"
      condition {
        expression = "cache_var.num_db_triggers >= 5"
      }
      actions {
        severity = "critical"
        route_to = "foobar"
      }
    }
  }

  set {
    id = "foobar"
    rule {
      label = "nothing"
      actions {}
    }
  }

  catch_all {
    actions {
      route_to = "start"
      annotate = "hello"
    }
  }
}
```

The following warning was returned
```
╷
│ Warning: Argument is deprecated
│
│   with pagerduty_event_orchestration_service.event_orchestration,
│   on main.tf line 847, in resource "pagerduty_event_orchestration_service" "event_orchestration":
│  847:       route_to = "start"
│
│ The 'route_to' attribute is no longer supported for catch-all rules.
╵
```