### PR TITLE
[CSGINS-1665] Add support  for `is_enabled` field to `pagerduty_incidenet_workflow`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/hashicorp/terraform-plugin-mux v0.13.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.31.0
 	github.com/hashicorp/terraform-plugin-testing v1.6.0
-	github.com/heimweh/go-pagerduty v0.0.0-20250113182705-ce1f94dc30af
+	github.com/heimweh/go-pagerduty v0.0.0-20250206202923-12b6de611ec0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
-github.com/heimweh/go-pagerduty v0.0.0-20250113182705-ce1f94dc30af h1:41UndNNQiIhLMxleHdJNTxmpHzT06twPUNRaqfJaSpU=
-github.com/heimweh/go-pagerduty v0.0.0-20250113182705-ce1f94dc30af/go.mod h1:r59w5iyN01Qvi734yA5hZldbSeJJmsJzee/1kQ/MK7s=
+github.com/heimweh/go-pagerduty v0.0.0-20250206202923-12b6de611ec0 h1:ixfkJ7Vb93KR9NkmBWjs+tKZi/W3l+CfvYYeYtr4dPM=
+github.com/heimweh/go-pagerduty v0.0.0-20250206202923-12b6de611ec0/go.mod h1:r59w5iyN01Qvi734yA5hZldbSeJJmsJzee/1kQ/MK7s=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=

--- a/pagerduty/resource_pagerduty_incident_workflow.go
+++ b/pagerduty/resource_pagerduty_incident_workflow.go
@@ -67,6 +67,15 @@ func resourcePagerDutyIncidentWorkflow() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"is_enabled": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateDiagFunc: validateValueDiagFunc([]string{
+					"true",
+					"false",
+				}),
+			},
 			"step": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -477,6 +486,9 @@ func flattenIncidentWorkflow(
 	if iw.Team != nil {
 		d.Set("team", iw.Team.ID)
 	}
+	if iw.IsEnabled != nil {
+		d.Set("is_enabled", strconv.FormatBool(*iw.IsEnabled))
+	}
 
 	if includeSteps {
 		steps := flattenIncidentWorkflowSteps(iw, specifiedSteps, isImport)
@@ -617,6 +629,10 @@ func buildIncidentWorkflowStruct(d *schema.ResourceData) (
 		iw.Team = &pagerduty.TeamReference{
 			ID: team.(string),
 		}
+	}
+	if is_enabled, ok := d.GetOk("is_enabled"); ok {
+		b := is_enabled.(string) == "true"
+		iw.IsEnabled = &b
 	}
 
 	specifiedSteps := make([]*SpecifiedStep, 0)

--- a/pagerduty/resource_pagerduty_incident_workflow_test.go
+++ b/pagerduty/resource_pagerduty_incident_workflow_test.go
@@ -67,6 +67,7 @@ func TestAccPagerDutyIncidentWorkflow_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"pagerduty_incident_workflow.test", "name", workflowName),
 					resource.TestCheckResourceAttr("pagerduty_incident_workflow.test", "description", "Managed by Terraform"),
+					resource.TestCheckResourceAttr("pagerduty_incident_workflow.test", "is_enabled", "true"),
 					resource.TestCheckResourceAttr("pagerduty_incident_workflow.test", "step.#", "2"),
 					resource.TestCheckResourceAttr("pagerduty_incident_workflow.test", "step.0.input.#", "1"),
 					resource.TestCheckResourceAttr("pagerduty_incident_workflow.test", "step.0.input.0.generated", "false"),
@@ -81,6 +82,7 @@ func TestAccPagerDutyIncidentWorkflow_Basic(t *testing.T) {
 						"pagerduty_incident_workflow.test", "name", workflowName),
 					resource.TestCheckResourceAttr(
 						"pagerduty_incident_workflow.test", "description", "some description"),
+					resource.TestCheckResourceAttr("pagerduty_incident_workflow.test", "is_enabled", "false"),
 					resource.TestCheckResourceAttr("pagerduty_incident_workflow.test", "step.#", "2"),
 					resource.TestCheckResourceAttr("pagerduty_incident_workflow.test", "step.0.input.#", "1"),
 					resource.TestCheckResourceAttr("pagerduty_incident_workflow.test", "step.0.input.0.generated", "false"),
@@ -327,6 +329,7 @@ func testAccCheckPagerDutyIncidentWorkflowConfigUpdate(name string) string {
 resource "pagerduty_incident_workflow" "test" {
   name = "%s"
   description = "some description"
+  is_enabled = false
   step {
     name           = "Example Step"
     action         = "pagerduty.com:incident-workflows:send-status-update:1"

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/incident_workflow.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/incident_workflow.go
@@ -18,6 +18,7 @@ type IncidentWorkflow struct {
 	Self        string                  `json:"self,omitempty"`
 	Steps       []*IncidentWorkflowStep `json:"steps,omitempty"`
 	Team        *TeamReference          `json:"team,omitempty"`
+	IsEnabled   *bool                   `json:"is_enabled,omitempty"`
 }
 
 // IncidentWorkflowStep represents a step in an incident workflow.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -261,7 +261,7 @@ github.com/hashicorp/terraform-svchost
 # github.com/hashicorp/yamux v0.1.1
 ## explicit; go 1.15
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20250113182705-ce1f94dc30af
+# github.com/heimweh/go-pagerduty v0.0.0-20250206202923-12b6de611ec0
 ## explicit; go 1.17
 github.com/heimweh/go-pagerduty/pagerduty
 github.com/heimweh/go-pagerduty/persistentconfig

--- a/website/docs/r/incident_workflow.html.markdown
+++ b/website/docs/r/incident_workflow.html.markdown
@@ -33,6 +33,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the workflow.
 * `description` - (Optional) The description of the workflow.
+* `is_enabled` - (Optional) Indicates whether the Incident Workflow is enabled or not. Disabled workflows will not be triggered, and will not count toward the account's enabled workflow limit.
 * `team` - (Optional) A team ID. If specified then workflow edit permissions will be scoped to members of this team.
 * `step` - (Optional) The steps in the workflow.
 


### PR DESCRIPTION
## Test cases extended

```sh
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -count=1 -run TestAccPagerDutyIncidentWorkflow_Basic -timeout 120m
?       github.com/PagerDuty/terraform-provider-pagerduty       [no test files]
?       github.com/PagerDuty/terraform-provider-pagerduty/util/apiutil  [no test files]
?       github.com/PagerDuty/terraform-provider-pagerduty/util/validate [no test files]
=== RUN   TestAccPagerDutyIncidentWorkflow_Basic # 👈 Extended test case
--- PASS: TestAccPagerDutyIncidentWorkflow_Basic (12.76s)
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerduty     13.905s
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerdutyplugin       1.673s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/util  0.836s [no tests to run]
```