### PR TITLE
Various fixes 2025-02-14

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/hashicorp/terraform-plugin-mux v0.13.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.31.0
 	github.com/hashicorp/terraform-plugin-testing v1.6.0
-	github.com/heimweh/go-pagerduty v0.0.0-20250206202923-12b6de611ec0
+	github.com/heimweh/go-pagerduty v0.0.0-20250214190935-c474ec404dae
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
-github.com/heimweh/go-pagerduty v0.0.0-20250206202923-12b6de611ec0 h1:ixfkJ7Vb93KR9NkmBWjs+tKZi/W3l+CfvYYeYtr4dPM=
-github.com/heimweh/go-pagerduty v0.0.0-20250206202923-12b6de611ec0/go.mod h1:r59w5iyN01Qvi734yA5hZldbSeJJmsJzee/1kQ/MK7s=
+github.com/heimweh/go-pagerduty v0.0.0-20250214190935-c474ec404dae h1:le7p/QnSPOQ4tnt+xjrAIu58JOdPyiNauGR8B2hRaoU=
+github.com/heimweh/go-pagerduty v0.0.0-20250214190935-c474ec404dae/go.mod h1:r59w5iyN01Qvi734yA5hZldbSeJJmsJzee/1kQ/MK7s=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=

--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -418,8 +418,11 @@ func buildServiceStruct(d *schema.ResourceData) (*pagerduty.Service, error) {
 
 	if attr, ok := d.GetOk("alert_grouping"); ok {
 		ag := attr.(string)
-		if ag != "rules" {
-			service.AlertGrouping = &ag
+		if ag == "content_based_intelligent" || ag == "rules" {
+			service.AlertGrouping = nil
+		} else {
+			agPtr := &ag
+			service.AlertGrouping = &agPtr
 		}
 	}
 
@@ -599,8 +602,8 @@ func flattenService(d *schema.ResourceData, service *pagerduty.Service) error {
 		d.Set("acknowledgement_timeout", strconv.Itoa(*service.AcknowledgementTimeout))
 	}
 	d.Set("alert_creation", service.AlertCreation)
-	if service.AlertGrouping != nil && *service.AlertGrouping != "" {
-		d.Set("alert_grouping", *service.AlertGrouping)
+	if service.AlertGrouping != nil && *service.AlertGrouping != nil && **service.AlertGrouping != "" {
+		d.Set("alert_grouping", **service.AlertGrouping)
 	}
 	if service.AlertGroupingTimeout == nil {
 		d.Set("alert_grouping_timeout", "null")

--- a/pagerduty/resource_pagerduty_service_test.go
+++ b/pagerduty/resource_pagerduty_service_test.go
@@ -736,7 +736,7 @@ func TestAccPagerDutyService_AutoPauseNotificationsParameters(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "auto_pause_notifications_parameters.0.enabled", "false"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "auto_pause_notifications_parameters.0.timeout", "0"),
+						"pagerduty_service.foo", "auto_pause_notifications_parameters.0.timeout", "120"),
 				),
 			},
 			{
@@ -758,7 +758,7 @@ func TestAccPagerDutyService_AutoPauseNotificationsParameters(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "auto_pause_notifications_parameters.0.enabled", "false"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "auto_pause_notifications_parameters.0.timeout", "0"),
+						"pagerduty_service.foo", "auto_pause_notifications_parameters.0.timeout", "120"),
 				),
 			},
 		},

--- a/pagerdutyplugin/resource_pagerduty_incident_type.go
+++ b/pagerdutyplugin/resource_pagerduty_incident_type.go
@@ -270,7 +270,7 @@ func requestGetIncidentType(ctx context.Context, client *pagerduty.Client, id, p
 }
 
 func flattenIncidentType(ctx context.Context, client *pagerduty.Client, response *pagerduty.IncidentType, parent string) (resourceIncidentTypeModel, error) {
-	if parent != response.Parent.ID {
+	if response.Parent != nil && parent != response.Parent.ID {
 		incidentType, err := client.GetIncidentType(ctx, parent, pagerduty.GetIncidentTypeOptions{})
 		if err != nil {
 			return resourceIncidentTypeModel{}, err

--- a/pagerdutyplugin/resource_pagerduty_jira_cloud_account_mapping_rule.go
+++ b/pagerdutyplugin/resource_pagerduty_jira_cloud_account_mapping_rule.go
@@ -439,12 +439,19 @@ func buildPagerdutyJiraCloudCustomFields(ctx context.Context, list types.List, d
 
 	var customFields []pagerduty.JiraCloudCustomField
 	for _, cf := range target {
+		var v interface{}
+		valueString := cf.Value.ValueString()
+
+		if err := json.Unmarshal([]byte(valueString), &v); err != nil {
+			v = valueString
+		}
+
 		field := pagerduty.JiraCloudCustomField{
 			SourceIncidentField:  nil,
 			TargetIssueField:     cf.TargetIssueField.ValueString(),
 			TargetIssueFieldName: cf.TargetIssueFieldName.ValueString(),
 			Type:                 cf.Type.ValueString(),
-			Value:                cf.Value.ValueString(),
+			Value:                v,
 		}
 		if !cf.SourceIncidentField.IsNull() && !cf.SourceIncidentField.IsUnknown() {
 			field.SourceIncidentField = cf.SourceIncidentField.ValueStringPointer()

--- a/pagerdutyplugin/resource_pagerduty_service_dependency.go
+++ b/pagerdutyplugin/resource_pagerduty_service_dependency.go
@@ -101,14 +101,14 @@ func (r *resourceServiceDependency) Schema(_ context.Context, _ resource.SchemaR
 			"supporting_service": schema.ListNestedBlock{
 				Validators: []validator.List{
 					listvalidator.IsRequired(),
-					listvalidator.SizeAtLeast(1),
+					listvalidator.SizeBetween(1, 1),
 				},
 				NestedObject: supportingServiceBlockObject,
 			},
 			"dependent_service": schema.ListNestedBlock{
 				Validators: []validator.List{
 					listvalidator.IsRequired(),
-					listvalidator.SizeAtLeast(1),
+					listvalidator.SizeBetween(1, 1),
 				},
 				NestedObject: dependencyServiceBlockObject,
 			},
@@ -119,7 +119,7 @@ func (r *resourceServiceDependency) Schema(_ context.Context, _ resource.SchemaR
 		NestedObject: dependencyBlockObject,
 		Validators: []validator.List{
 			listvalidator.IsRequired(),
-			listvalidator.SizeBetween(1, 1),
+			listvalidator.SizeAtLeast(1),
 		},
 		PlanModifiers: []planmodifier.List{
 			listplanmodifier.RequiresReplace(),

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/service.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/service.go
@@ -133,7 +133,7 @@ type Service struct {
 	AcknowledgementTimeout           *int                              `json:"acknowledgement_timeout"`
 	Addons                           []*AddonReference                 `json:"addons,omitempty"`
 	AlertCreation                    string                            `json:"alert_creation,omitempty"`
-	AlertGrouping                    *string                           `json:"alert_grouping"`
+	AlertGrouping                    **string                          `json:"alert_grouping,omitempty"`
 	AlertGroupingTimeout             *int                              `json:"alert_grouping_timeout,omitempty"`
 	AlertGroupingParameters          *AlertGroupingParameters          `json:"alert_grouping_parameters,omitempty"`
 	AutoPauseNotificationsParameters *AutoPauseNotificationsParameters `json:"auto_pause_notifications_parameters,omitempty"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -261,7 +261,7 @@ github.com/hashicorp/terraform-svchost
 # github.com/hashicorp/yamux v0.1.1
 ## explicit; go 1.15
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20250206202923-12b6de611ec0
+# github.com/heimweh/go-pagerduty v0.0.0-20250214190935-c474ec404dae
 ## explicit; go 1.17
 github.com/heimweh/go-pagerduty/pagerduty
 github.com/heimweh/go-pagerduty/persistentconfig

--- a/website/docs/r/alert_grouping_setting.html.markdown
+++ b/website/docs/r/alert_grouping_setting.html.markdown
@@ -47,7 +47,7 @@ The following arguments are supported:
 
 The `config` block contains the following arguments:
 
-* `timeout` - (Optional) The duration in minutes within which to automatically group incoming alerts. This setting is only required and applies when `type` is set to `time`. To continue grouping alerts until the incident is resolved leave this value unset or set it to `null`.
+* `timeout` - (Optional) The duration in seconds within which to automatically group incoming alerts. This setting is only required and applies when `type` is set to `time`. To continue grouping alerts until the incident is resolved leave this value unset or set it to `null`.
 * `aggregate` - (Optional) One of `any` or `all`. This setting is only required and applies when `type` is set to `content_based` or `content_based_intelligent`. Group alerts based on one or all of `fields` value(s).
 * `fields` - (Optional) Alerts will be grouped together if the content of these fields match. This setting is only required and applies when `type` is set to `content_based` or `content_based_intelligent`.
 * `time_window` - (Optional) The maximum amount of time allowed between Alerts. This setting applies only when `type` is set to `intelligent`, `content_based`, `content_based_intelligent`. Value must be between `300` and `3600` or exactly `86400` (86400 is supported only for `content_based` alert grouping). Any Alerts arriving greater than `time_window` seconds apart will not be grouped together. This is a rolling time window and is counted from the most recently grouped alert. The window is extended every time a new alert is added to the group, up to 24 hours. To use the recommended time window leave this value unset or set it to `null`.

--- a/website/docs/r/alert_grouping_setting.html.markdown
+++ b/website/docs/r/alert_grouping_setting.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # pagerduty\_alert\_grouping\_setting
 
-An [alert grouping setting](https://developer.pagerduty.com/api-reference/create-an-alert-grouping-setting)
+An [alert grouping setting](https://developer.pagerduty.com/api-reference/587edbc8ff416-create-an-alert-grouping-setting)
 stores and centralize the configuration used during grouping of the alerts.
 
 ## Example Usage
@@ -23,7 +23,7 @@ resource "pagerduty_service" "basic" {
 	escalation_policy = data.pagerduty_escalation_policy.default.id
 }
 
-resource "pagerduty_alert_grouping_setting" "%[1]s" {
+resource "pagerduty_alert_grouping_setting" "basic_settings" {
   name = "Configuration for type-1 devices"
   type = "content_based"
   services = [pagerduty_service.basic.id]

--- a/website/docs/r/escalation_policy.html.markdown
+++ b/website/docs/r/escalation_policy.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Creates and manages an escalation policy in PagerDuty.
 ---
 
-# pagerduty\_escalation_policy
+# pagerduty\_escalation\_policy
 
 An [escalation policy](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODEyNQ-create-an-escalation-policy) determines what user or schedule will be notified first, second, and so on when an incident is triggered. Escalation policies are used by one or more services.
 
@@ -83,3 +83,7 @@ Escalation policies can be imported using the `id`, e.g.
 ```
 $ terraform import pagerduty_escalation_policy.main PLBP09X
 ```
+
+## Known issues
+
+Block `escalation_rule_assignment_strategy` inside `rule` cannot be set explicitly when a PagerDuty account doesn't have access to the "Teams" feature, it will cause an error `POST API call to https://api.pagerduty.com/escalation_policies failed: 403 Forbidden`, please delete this block.

--- a/website/docs/r/service_dependency.html.markdown
+++ b/website/docs/r/service_dependency.html.markdown
@@ -46,8 +46,8 @@ resource "pagerduty_service_dependency" "bar" {
 The following arguments are supported:
 
   * `dependency` - (Required) The relationship between the `supporting_service` and `dependent_service`. One and only one dependency block must be defined.
-  * `supporting_service` - (Required) The service that supports the dependent service. Dependency supporting service documented below.
-  * `dependent_service` - (Required) The service that dependents on the supporting service. Dependency dependent service documented below.
+  * `supporting_service` - (Required) The service that supports the dependent service. Dependency supporting service documented below. One and only one `supporting_service` dependency block must be defined.
+  * `dependent_service` - (Required) The service that dependents on the supporting service. Dependency dependent service documented below. One and only one `dependent_service` dependency block must be defined.
 
 Dependency supporting and dependent service supports the following:
 


### PR DESCRIPTION
* Fix alert_grouping breaking updates for services using a `content_based_intelligent` alert grouping setting
* Fix time unit for docs of alert_grouping_setting.config.timeout
* Allow intelligent and content_based_intelligent resources to have many services
* Add doc for 403 when assign_to_everyone
* Fix jira cloud custom field value, sending objects as json instead of escaped string
* Fix validation and docs to acknowledge current service dependency behaviour
* Fix allow import of Base incident type

Closes #956
Closes #960
Closes #972
Closes #975
Closes #979
