### PR TITLE
feat: add new `pagerduty_teams` data source

### DIFF
--- a/pagerduty/data_source_pagerduty_teams.go
+++ b/pagerduty/data_source_pagerduty_teams.go
@@ -1,0 +1,112 @@
+package pagerduty
+
+import (
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/heimweh/go-pagerduty/pagerduty"
+)
+
+func dataSourcePagerDutyTeams() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourcePagerDutyTeamsRead,
+
+		Schema: map[string]*schema.Schema{
+			"query": {
+				Description: "Filters the result, showing only the records whose name matches the query.",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
+			"teams": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "List of teams whose name matches the query.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"summary": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourcePagerDutyTeamsRead(d *schema.ResourceData, meta interface{}) error {
+	client, err := meta.(*Config).Client()
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] Reading PagerDuty teams")
+
+	query := d.Get("query").(string)
+
+	o := &pagerduty.ListTeamsOptions{}
+	if query != "" {
+		o.Query = query
+	}
+
+	var pdTeams = make([]*pagerduty.Team, 0, 25)
+	more := true
+	offset := 0
+
+	for more {
+		log.Printf("[DEBUG] Getting PagerDuty teams at offset %d", offset)
+		retry.Retry(5*time.Minute, func() *retry.RetryError {
+			resp, _, err := client.Teams.List(o)
+			if err != nil {
+				if isErrCode(err, http.StatusBadRequest) {
+					return retry.NonRetryableError(err)
+				}
+
+				// Delaying retry by 30s as recommended by PagerDuty
+				// https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/#what-are-possible-workarounds-to-the-events-api-rate-limit
+				time.Sleep(30 * time.Second)
+				return retry.RetryableError(err)
+			}
+
+			pdTeams = append(pdTeams, resp.Teams...)
+			more = resp.More
+			offset += resp.Limit
+			o.Offset = offset
+
+			return nil
+		})
+	}
+
+	var teams []map[string]interface{}
+	for _, team := range pdTeams {
+		teams = append(teams, map[string]interface{}{
+			"id":          team.ID,
+			"name":        team.Name,
+			"summary":     team.Summary,
+			"description": team.Description,
+		})
+	}
+
+	// Since this data doesn't have a unique ID, this force this data to be
+	// refreshed in every Terraform apply
+	d.SetId(strconv.FormatInt(time.Now().Unix(), 10))
+	d.Set("teams", teams)
+
+	return nil
+}

--- a/pagerduty/data_source_pagerduty_teams_test.go
+++ b/pagerduty/data_source_pagerduty_teams_test.go
@@ -1,0 +1,87 @@
+package pagerduty
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccDataSourcePagerDutyTeams_Basic(t *testing.T) {
+	teamname1 := fmt.Sprintf("tf-team-%s", acctest.RandString(5))
+	teamname2 := fmt.Sprintf("tf-team-%s", acctest.RandString(5))
+	teamname3 := fmt.Sprintf("tf-team-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourcePagerDutyTeamsConfig(teamname1, teamname2, teamname3),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourcePagerDutyTeamsExists("data.pagerduty_teams.test_all_teams"),
+					testAccDataSourcePagerDutyTeamsExists("data.pagerduty_teams.test_by_1_team"),
+					resource.TestCheckResourceAttrSet(
+						"data.pagerduty_users.test_all_teams", "teams.#"),
+					resource.TestCheckTypeSetElemNestedAttrs(
+						"data.pagerduty_users.test_all_teams",
+						"teams.*",
+						map[string]string{
+							"name": teamname1,
+						}),
+					resource.TestCheckTypeSetElemNestedAttrs(
+						"data.pagerduty_users.test_all_teams",
+						"teams.*",
+						map[string]string{
+							"name": teamname2,
+						}),
+					resource.TestCheckTypeSetElemNestedAttrs(
+						"data.pagerduty_users.test_all_teams",
+						"teams.*",
+						map[string]string{
+							"name": teamname3,
+						}),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourcePagerDutyTeamsExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		r := s.RootModule().Resources[n]
+		a := r.Primary.Attributes
+
+		if a["id"] == "" {
+			return fmt.Errorf("Expected to get a team ID from PagerDuty")
+		}
+
+		return nil
+	}
+}
+
+func testAccDataSourcePagerDutyTeamsConfig(teamname1, teamname2, teamname3 string) string {
+	return fmt.Sprintf(`
+    resource "pagerduty_team" "test1" {
+        name        = "%s"
+    }
+    resource "pagerduty_team" "test2" {
+        name        = "%s"
+    }
+	resource "pagerduty_team" "test3" {
+        name        = "%s"
+    }
+
+    data "pagerduty_teams" "test_by_1_team" {
+      depends_on = [pagerduty_team.test1, pagerduty_team.test2, pagerduty_team.test3]
+      query = "%s"
+    }
+
+    data "pagerduty_teams" "test_all_teams" {
+      depends_on = [pagerduty_team.test1, pagerduty_team.test2, pagerduty_team.test3]
+    }
+`, teamname1, teamname2, teamname3, teamname1)
+}

--- a/pagerduty/data_source_pagerduty_teams_test.go
+++ b/pagerduty/data_source_pagerduty_teams_test.go
@@ -24,21 +24,21 @@ func TestAccDataSourcePagerDutyTeams_Basic(t *testing.T) {
 					testAccDataSourcePagerDutyTeamsExists("data.pagerduty_teams.test_all_teams"),
 					testAccDataSourcePagerDutyTeamsExists("data.pagerduty_teams.test_by_1_team"),
 					resource.TestCheckResourceAttrSet(
-						"data.pagerduty_users.test_all_teams", "teams.#"),
+						"data.pagerduty_teams.test_all_teams", "teams.#"),
 					resource.TestCheckTypeSetElemNestedAttrs(
-						"data.pagerduty_users.test_all_teams",
+						"data.pagerduty_teams.test_all_teams",
 						"teams.*",
 						map[string]string{
 							"name": teamname1,
 						}),
 					resource.TestCheckTypeSetElemNestedAttrs(
-						"data.pagerduty_users.test_all_teams",
+						"data.pagerduty_teams.test_all_teams",
 						"teams.*",
 						map[string]string{
 							"name": teamname2,
 						}),
 					resource.TestCheckTypeSetElemNestedAttrs(
-						"data.pagerduty_users.test_all_teams",
+						"data.pagerduty_teams.test_all_teams",
 						"teams.*",
 						map[string]string{
 							"name": teamname3,

--- a/pagerduty/provider.go
+++ b/pagerduty/provider.go
@@ -93,6 +93,7 @@ func Provider(isMux bool) *schema.Provider {
 			"pagerduty_licenses":                                   dataSourcePagerDutyLicenses(),
 			"pagerduty_user_contact_method":                        dataSourcePagerDutyUserContactMethod(),
 			"pagerduty_team":                                       dataSourcePagerDutyTeam(),
+			"pagerduty_teams":                                      dataSourcePagerDutyTeams(),
 			"pagerduty_vendor":                                     dataSourcePagerDutyVendor(),
 			"pagerduty_service":                                    dataSourcePagerDutyService(),
 			"pagerduty_service_integration":                        dataSourcePagerDutyServiceIntegration(),

--- a/website/docs/d/teams.html.markdown
+++ b/website/docs/d/teams.html.markdown
@@ -1,0 +1,41 @@
+---
+layout: "pagerduty"
+page_title: "PagerDuty: pagerduty_teams"
+sidebar_current: "docs-pagerduty-datasource-teams"
+description: |-
+  Get information about a team that you can use with escalation_policies, schedules etc.
+---
+
+# pagerduty\_teams
+
+Use this data source to [list teams][1] in your PagerDuty account.
+
+## Example Usage
+
+```hcl
+data "pagerduty_teams" "all_teams" {}
+
+# Fetch only teams whose name matches "devops"
+data "pagerduty_teams" "devops" {
+  query = "devops"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `query` - (Optional) Filters the result, showing only the records whose name matches the query.
+
+## Attributes Reference
+
+* `teams` - The teams found.
+
+### Teams (`teams`) supports the following:
+
+* `id` - The ID of the team.
+* `name` - The name of the team.
+* `summary` - A short-form, server-generated string that provides succinct, important information about an object suitable for primary labeling of an entity in a client. In many cases, this will be identical to name, though it is not intended to be an identifier.
+* `description` - The description of the team.
+
+[1]: https://developer.pagerduty.com/api-reference/0138639504311-list-teams

--- a/website/pagerduty.erb
+++ b/website/pagerduty.erb
@@ -40,6 +40,9 @@
                 <li<%= sidebar_current("docs-pagerduty-datasource-team") %>>
                     <a href="/docs/providers/pagerduty/d/team.html">pagerduty_team</a>
                 </li>
+                <li<%= sidebar_current("docs-pagerduty-datasource-teams") %>>
+                    <a href="/docs/providers/pagerduty/d/teams.html">pagerduty_teams</a>
+                </li>
                 <li<%= sidebar_current("docs-pagerduty-datasource-team-members") %>>
                     <a href="/docs/providers/pagerduty/d/team_members.html">pagerduty_team_members</a>
                 </li>


### PR DESCRIPTION
This PR adds a new data source to query all the PagerDuty teams matching the given `query`. If no `query`, the data source will fetch all the teams.

```terraform

data "pagerduty_teams" "all_teams" {}

# Assuming there are teams in PD with names:
# example-team-1
# example-team-2
# example-team-3
data "pagerduty_teams" "my_example_team" {
  query = "example-team-"
}
```

Implementation is based on the following API documentation: https://developer.pagerduty.com/api-reference/0138639504311-list-teams.

## New Acceptance Tests Results...

```bash
$ make testacc TESTARGS='-count=1 -run TestAccDataSourcePagerDutyTeams_Basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -count=1 -run TestAccDataSourcePagerDutyTeams_Basic -timeout 120m
?       github.com/PagerDuty/terraform-provider-pagerduty       [no test files]
=== RUN   TestAccDataSourcePagerDutyTeams_Basic
--- PASS: TestAccDataSourcePagerDutyTeams_Basic (10.09s)
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerduty     10.994s
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerdutyplugin       0.740s [no tests to run]
?       github.com/PagerDuty/terraform-provider-pagerduty/scripts       [no test files]
testing: warning: no tests to run
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/util  0.898s [no tests to run]
?       github.com/PagerDuty/terraform-provider-pagerduty/util/apiutil  [no test files]
?       github.com/PagerDuty/terraform-provider-pagerduty/util/validate [no test files]
```