### PR TITLE
[ORCA-5250] Add support for Event Orchestration Automation trigger_types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/hashicorp/terraform-plugin-mux v0.13.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.31.0
 	github.com/hashicorp/terraform-plugin-testing v1.6.0
-	github.com/heimweh/go-pagerduty v0.0.0-20250319162404-3d9cf89703c0
+	github.com/heimweh/go-pagerduty v0.0.0-20250414155133-f9f4e0b0c59b
 )
 
 require (
@@ -76,5 +76,3 @@ require (
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 )
-
-replace github.com/heimweh/go-pagerduty => github.com/alexzakabluk/go-pagerduty v0.0.0-20250325172012-9f2ddcb0c5f6

--- a/go.mod
+++ b/go.mod
@@ -77,4 +77,4 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 )
 
-replace github.com/heimweh/go-pagerduty => github.com/alenapan/go-pagerduty v0.0.0-20250324143909-5c8050f3efbb
+replace github.com/heimweh/go-pagerduty => github.com/alexzakabluk/go-pagerduty v0.0.0-20250325172012-9f2ddcb0c5f6

--- a/go.mod
+++ b/go.mod
@@ -76,3 +76,5 @@ require (
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 )
+
+replace github.com/heimweh/go-pagerduty => github.com/alenapan/go-pagerduty v0.0.0-20250324143909-5c8050f3efbb

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c h1:kMFnB0vCcX
 github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
-github.com/alenapan/go-pagerduty v0.0.0-20250324143909-5c8050f3efbb h1:72hZSr4DmLTJ+a7M2rn8BZiRIfRA6mg0HxFmBHxeZhs=
-github.com/alenapan/go-pagerduty v0.0.0-20250324143909-5c8050f3efbb/go.mod h1:r59w5iyN01Qvi734yA5hZldbSeJJmsJzee/1kQ/MK7s=
+github.com/alexzakabluk/go-pagerduty v0.0.0-20250325172012-9f2ddcb0c5f6 h1:bBzBqFH4kzRTDcsppiBU/oB2G2bM+2h250C5i+WqHTY=
+github.com/alexzakabluk/go-pagerduty v0.0.0-20250325172012-9f2ddcb0c5f6/go.mod h1:r59w5iyN01Qvi734yA5hZldbSeJJmsJzee/1kQ/MK7s=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c h1:kMFnB0vCcX
 github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
+github.com/alenapan/go-pagerduty v0.0.0-20250324143909-5c8050f3efbb h1:72hZSr4DmLTJ+a7M2rn8BZiRIfRA6mg0HxFmBHxeZhs=
+github.com/alenapan/go-pagerduty v0.0.0-20250324143909-5c8050f3efbb/go.mod h1:r59w5iyN01Qvi734yA5hZldbSeJJmsJzee/1kQ/MK7s=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
@@ -105,8 +107,6 @@ github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
-github.com/heimweh/go-pagerduty v0.0.0-20250319162404-3d9cf89703c0 h1:2pDG970Xt+LcTfrFXju2wID3AG/Yn5KR3FdMIbJ2+Ok=
-github.com/heimweh/go-pagerduty v0.0.0-20250319162404-3d9cf89703c0/go.mod h1:r59w5iyN01Qvi734yA5hZldbSeJJmsJzee/1kQ/MK7s=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,6 @@ github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c h1:kMFnB0vCcX
 github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
-github.com/alexzakabluk/go-pagerduty v0.0.0-20250325172012-9f2ddcb0c5f6 h1:bBzBqFH4kzRTDcsppiBU/oB2G2bM+2h250C5i+WqHTY=
-github.com/alexzakabluk/go-pagerduty v0.0.0-20250325172012-9f2ddcb0c5f6/go.mod h1:r59w5iyN01Qvi734yA5hZldbSeJJmsJzee/1kQ/MK7s=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
@@ -107,6 +105,8 @@ github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
+github.com/heimweh/go-pagerduty v0.0.0-20250414155133-f9f4e0b0c59b h1:5t9zhRQsn3IFnfLwdbJlsnuHz2UH+OT/XAMfH519PQU=
+github.com/heimweh/go-pagerduty v0.0.0-20250414155133-f9f4e0b0c59b/go.mod h1:r59w5iyN01Qvi734yA5hZldbSeJJmsJzee/1kQ/MK7s=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=

--- a/pagerduty/event_orchestration_path_util.go
+++ b/pagerduty/event_orchestration_path_util.go
@@ -104,6 +104,12 @@ var eventOrchestrationAutomationActionSchema = map[string]*schema.Schema{
 			Schema: eventOrchestrationAutomationActionObjectSchema,
 		},
 	},
+	"trigger_types": {
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem:     &schema.Schema{Type: schema.TypeString},
+	},
 }
 
 func invalidExtractionRegexTemplateNilConfig() string {
@@ -297,11 +303,12 @@ func expandEventOrchestrationPathAutomationActions(v interface{}) []*pagerduty.E
 	for _, i := range v.([]interface{}) {
 		a := i.(map[string]interface{})
 		aa := &pagerduty.EventOrchestrationPathAutomationAction{
-			Name:       a["name"].(string),
-			Url:        a["url"].(string),
-			AutoSend:   a["auto_send"].(bool),
-			Headers:    expandEventOrchestrationAutomationActionObjects(a["header"]),
-			Parameters: expandEventOrchestrationAutomationActionObjects(a["parameter"]),
+			Name:         a["name"].(string),
+			Url:          a["url"].(string),
+			AutoSend:     a["auto_send"].(bool),
+			Headers:      expandEventOrchestrationAutomationActionObjects(a["header"]),
+			Parameters:   expandEventOrchestrationAutomationActionObjects(a["parameter"]),
+			TriggerTypes: expandEventOrchestrationAutomationTriggerTypes(a["trigger_types"]),
 		}
 
 		result = append(result, aa)
@@ -321,6 +328,20 @@ func expandEventOrchestrationAutomationActionObjects(v interface{}) []*pagerduty
 		}
 
 		result = append(result, obj)
+	}
+
+	return result
+}
+
+func expandEventOrchestrationAutomationTriggerTypes(v interface{}) []string {
+	if v == nil {
+		return nil
+	}
+
+	var result []string
+
+	for _, i := range v.([]interface{}) {
+		result = append(result, i.(string))
 	}
 
 	return result
@@ -346,11 +367,12 @@ func flattenEventOrchestrationAutomationActions(v []*pagerduty.EventOrchestratio
 
 	for _, i := range v {
 		pdaa := map[string]interface{}{
-			"name":      i.Name,
-			"url":       i.Url,
-			"auto_send": i.AutoSend,
-			"header":    flattenEventOrchestrationAutomationActionObjects(i.Headers),
-			"parameter": flattenEventOrchestrationAutomationActionObjects(i.Parameters),
+			"name":          i.Name,
+			"url":           i.Url,
+			"auto_send":     i.AutoSend,
+			"header":        flattenEventOrchestrationAutomationActionObjects(i.Headers),
+			"parameter":     flattenEventOrchestrationAutomationActionObjects(i.Parameters),
+			"trigger_types": i.TriggerTypes,
 		}
 
 		result = append(result, pdaa)

--- a/pagerduty/resource_pagerduty_event_orchestration_path_global_test.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_global_test.go
@@ -326,6 +326,8 @@ func testAccCheckPagerDutyEventOrchestrationPathGlobalAutomationActionsConfig(t,
 									key = "region"
 									value = "us"
 								}
+								
+								trigger_types = ["alert_suppressed"]
 							}
 					}
 				}
@@ -355,6 +357,8 @@ func testAccCheckPagerDutyEventOrchestrationPathGlobalAutomationActionsConfig(t,
 							key = "region1"
 							value = "us1"
 						}
+
+						trigger_types = ["alert_suspended"]
 					}
 				}
 			}
@@ -384,6 +388,8 @@ func testAccCheckPagerDutyEventOrchestrationPathGlobalAutomationActionsParamsUpd
 									key = "source_region"
 									value = "eu"
 								}
+
+								trigger_types = ["alert_triggered"]
 							}
 					}
 				}
@@ -404,6 +410,8 @@ func testAccCheckPagerDutyEventOrchestrationPathGlobalAutomationActionsParamsUpd
 							key = "source2"
 							value = "orch2"
 						}
+
+						trigger_types = ["alert_triggered"]
 					}
 				}
 			}
@@ -424,6 +432,7 @@ func testAccCheckPagerDutyEventOrchestrationPathGlobalAutomationActionsParamsDel
 							automation_action {
 								name = "test"
 								url = "https://test.com"
+								trigger_types = ["alert_triggered"]
 							}
 					}
 				}
@@ -434,6 +443,7 @@ func testAccCheckPagerDutyEventOrchestrationPathGlobalAutomationActionsParamsDel
 					automation_action {
 						name = "catch-all test upd"
 						url = "https://catch-all-test-upd.com"
+						trigger_types = ["alert_triggered"]
 					}
 				}
 			}

--- a/pagerduty/resource_pagerduty_event_orchestration_path_service.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_service.go
@@ -41,6 +41,12 @@ func buildEventOrchestrationPathServiceCatchAllActionsSchema() map[string]*schem
 						Type:     schema.TypeString,
 						Required: true,
 					},
+					"trigger_types": {
+						Type:     schema.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem:     &schema.Schema{Type: schema.TypeString},
+					},
 				},
 			},
 		},
@@ -512,7 +518,8 @@ func expandServicePathPagerDutyAutomationActions(v interface{}) []*pagerduty.Eve
 	for _, i := range v.([]interface{}) {
 		a := i.(map[string]interface{})
 		pdaa := &pagerduty.EventOrchestrationPathPagerdutyAutomationAction{
-			ActionId: a["action_id"].(string),
+			ActionId:     a["action_id"].(string),
+			TriggerTypes: expandEventOrchestrationAutomationTriggerTypes(a["trigger_types"]),
 		}
 
 		result = append(result, pdaa)
@@ -609,8 +616,9 @@ func flattenServicePathPagerDutyAutomationActions(v []*pagerduty.EventOrchestrat
 	var result []interface{}
 
 	for _, i := range v {
-		pdaa := map[string]string{
-			"action_id": i.ActionId,
+		pdaa := map[string]interface{}{
+			"action_id":     i.ActionId,
+			"trigger_types": i.TriggerTypes,
 		}
 
 		result = append(result, pdaa)

--- a/pagerduty/resource_pagerduty_event_orchestration_path_service_test.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_service_test.go
@@ -59,7 +59,7 @@ func TestAccPagerDutyEventOrchestrationPathService_Basic(t *testing.T) {
 					append(
 						baseChecks,
 						resource.TestCheckResourceAttr(
-							resourceName, "set.0.rule.0.actions.0.automation_action.0.auto_send", "false",
+							resourceName, "set.0.rule.0.actions.0.automation_action.0.auto_send", "true",
 						),
 					)...,
 				),
@@ -370,29 +370,31 @@ func testAccCheckPagerDutyEventOrchestrationPathServiceAutomationActionsConfig(e
 				rule {
 					label = "rule 1"
 					actions {
-							automation_action {
-								name = "test"
-								url = "https://test.com"
-								auto_send = true
+						automation_action {
+							name = "test"
+							url = "https://test.com"
+							auto_send = true
 
-								header {
-									key = "foo"
-									value = "bar"
-								}
-								header {
-									key = "baz"
-									value = "buz"
-								}
-
-								parameter {
-									key = "source"
-									value = "orch"
-								}
-								parameter {
-									key = "region"
-									value = "us"
-								}
+							header {
+								key = "foo"
+								value = "bar"
 							}
+							header {
+								key = "baz"
+								value = "buz"
+							}
+
+							parameter {
+								key = "source"
+								value = "orch"
+							}
+							parameter {
+								key = "region"
+								value = "us"
+							}
+
+							trigger_types = ["alert_triggered"]
+						}
 					}
 				}
 			}
@@ -421,6 +423,8 @@ func testAccCheckPagerDutyEventOrchestrationPathServiceAutomationActionsConfig(e
 							key = "region1"
 							value = "us1"
 						}
+
+						trigger_types = ["alert_suspended"]
 					}
 				}
 			}
@@ -438,19 +442,22 @@ func testAccCheckPagerDutyEventOrchestrationPathServiceAutomationActionsParamsUp
 				rule {
 					label = "rule 1"
 					actions {
-							automation_action {
-								name = "test1"
-								url = "https://test1.com"
+						automation_action {
+							name = "test1"
+							url = "https://test1.com"
+							auto_send = true
 
-								header {
-									key = "foo1"
-									value = "bar1"
-								}
-								parameter {
-									key = "source_region"
-									value = "eu"
-								}
+							header {
+								key = "foo1"
+								value = "bar1"
 							}
+							parameter {
+								key = "source_region"
+								value = "eu"
+							}
+							
+							trigger_types = ["alert_suppressed"]
+						}
 					}
 				}
 			}
@@ -470,6 +477,8 @@ func testAccCheckPagerDutyEventOrchestrationPathServiceAutomationActionsParamsUp
 							key = "source2"
 							value = "orch2"
 						}
+
+						trigger_types = ["alert_triggered"]
 					}
 				}
 			}
@@ -487,10 +496,11 @@ func testAccCheckPagerDutyEventOrchestrationPathServiceAutomationActionsParamsDe
 				rule {
 					label = "rule 1"
 					actions {
-							automation_action {
-								name = "test"
-								url = "https://test.com"
-							}
+						automation_action {
+							name = "test"
+							url = "https://test.com"
+							trigger_types = ["alert_triggered"]
+						}
 					}
 				}
 			}
@@ -500,6 +510,8 @@ func testAccCheckPagerDutyEventOrchestrationPathServiceAutomationActionsParamsDe
 					automation_action {
 						name = "catch-all test upd"
 						url = "https://catch-all-test-upd.com"
+						auto_send = true
+						trigger_types = ["alert_suppressed"]
 					}
 				}
 			}
@@ -554,6 +566,7 @@ func testAccCheckPagerDutyEventOrchestrationPathServiceAllActionsConfig(ep, s st
 						annotate = "Routed through an event orchestration"
 						pagerduty_automation_action {
 							action_id = "01CSB5SMOKCKVRI5GN0LJG7SMB"
+							trigger_types = ["alert_suppressed"]
 						}
 						severity = "critical"
 						event_action = "trigger"
@@ -612,6 +625,7 @@ func testAccCheckPagerDutyEventOrchestrationPathServiceAllActionsConfig(ep, s st
 					annotate = "Routed through an event orchestration - catch-all rule"
 					pagerduty_automation_action {
 						action_id = "01CSB5SMOKCKVRI5GN0LJG7SMC"
+						trigger_types = ["alert_suspended"]
 					}
 					severity = "warning"
 					event_action = "trigger"
@@ -661,6 +675,7 @@ func testAccCheckPagerDutyEventOrchestrationPathServiceAllActionsUpdateConfig(ep
 						annotate = "Routed through a service orchestration!"
 						pagerduty_automation_action {
 							action_id = "01CSB5SMOKCKVRI5GN0LJG7SMBUPDATED"
+							trigger_types = ["alert_suspended"]
 						}
 						severity = "warning"
 						event_action = "resolve"
@@ -733,6 +748,7 @@ func testAccCheckPagerDutyEventOrchestrationPathServiceAllActionsUpdateConfig(ep
 					annotate = "[UPD] Routed through an event orchestration - catch-all rule"
 					pagerduty_automation_action {
 						action_id = "01CSB5SMOKCKVRI5GN0LJG7SMD"
+						trigger_types = ["alert_triggered"]
 					}
 					severity = "info"
 					event_action = "resolve"

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/event_orchestration_path.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/event_orchestration_path.go
@@ -81,6 +81,7 @@ type EventOrchestrationPathIncidentCustomFieldUpdate struct {
 
 type EventOrchestrationPathPagerdutyAutomationAction struct {
 	ActionId string `json:"action_id,omitempty"`
+	TriggerTypes []string `json:"trigger_types,omitempty"`
 }
 
 type EventOrchestrationPathAutomationAction struct {
@@ -89,6 +90,7 @@ type EventOrchestrationPathAutomationAction struct {
 	AutoSend   bool                                            `json:"auto_send,omitempty"`
 	Headers    []*EventOrchestrationPathAutomationActionObject `json:"headers"`
 	Parameters []*EventOrchestrationPathAutomationActionObject `json:"parameters"`
+	TriggerTypes []string `json:"trigger_types,omitempty"`
 }
 
 type EventOrchestrationPathAutomationActionObject struct {

--- a/vendor/github.com/heimweh/go-pagerduty/pagerduty/event_orchestration_path.go
+++ b/vendor/github.com/heimweh/go-pagerduty/pagerduty/event_orchestration_path.go
@@ -80,17 +80,17 @@ type EventOrchestrationPathIncidentCustomFieldUpdate struct {
 }
 
 type EventOrchestrationPathPagerdutyAutomationAction struct {
-	ActionId string `json:"action_id,omitempty"`
+	ActionId     string   `json:"action_id,omitempty"`
 	TriggerTypes []string `json:"trigger_types,omitempty"`
 }
 
 type EventOrchestrationPathAutomationAction struct {
-	Name       string                                          `json:"name,omitempty"`
-	Url        string                                          `json:"url,omitempty"`
-	AutoSend   bool                                            `json:"auto_send,omitempty"`
-	Headers    []*EventOrchestrationPathAutomationActionObject `json:"headers"`
-	Parameters []*EventOrchestrationPathAutomationActionObject `json:"parameters"`
-	TriggerTypes []string `json:"trigger_types,omitempty"`
+	Name         string                                          `json:"name,omitempty"`
+	Url          string                                          `json:"url,omitempty"`
+	AutoSend     bool                                            `json:"auto_send,omitempty"`
+	Headers      []*EventOrchestrationPathAutomationActionObject `json:"headers"`
+	Parameters   []*EventOrchestrationPathAutomationActionObject `json:"parameters"`
+	TriggerTypes []string                                        `json:"trigger_types,omitempty"`
 }
 
 type EventOrchestrationPathAutomationActionObject struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -261,7 +261,7 @@ github.com/hashicorp/terraform-svchost
 # github.com/hashicorp/yamux v0.1.1
 ## explicit; go 1.15
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20250319162404-3d9cf89703c0 => github.com/alenapan/go-pagerduty v0.0.0-20250324143909-5c8050f3efbb
+# github.com/heimweh/go-pagerduty v0.0.0-20250319162404-3d9cf89703c0 => github.com/alexzakabluk/go-pagerduty v0.0.0-20250325172012-9f2ddcb0c5f6
 ## explicit; go 1.17
 github.com/heimweh/go-pagerduty/pagerduty
 github.com/heimweh/go-pagerduty/persistentconfig
@@ -561,4 +561,4 @@ google.golang.org/protobuf/types/known/timestamppb
 # gopkg.in/ini.v1 v1.67.0
 ## explicit
 gopkg.in/ini.v1
-# github.com/heimweh/go-pagerduty => github.com/alenapan/go-pagerduty v0.0.0-20250324143909-5c8050f3efbb
+# github.com/heimweh/go-pagerduty => github.com/alexzakabluk/go-pagerduty v0.0.0-20250325172012-9f2ddcb0c5f6

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -261,7 +261,7 @@ github.com/hashicorp/terraform-svchost
 # github.com/hashicorp/yamux v0.1.1
 ## explicit; go 1.15
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20250319162404-3d9cf89703c0
+# github.com/heimweh/go-pagerduty v0.0.0-20250319162404-3d9cf89703c0 => github.com/alenapan/go-pagerduty v0.0.0-20250324143909-5c8050f3efbb
 ## explicit; go 1.17
 github.com/heimweh/go-pagerduty/pagerduty
 github.com/heimweh/go-pagerduty/persistentconfig
@@ -561,3 +561,4 @@ google.golang.org/protobuf/types/known/timestamppb
 # gopkg.in/ini.v1 v1.67.0
 ## explicit
 gopkg.in/ini.v1
+# github.com/heimweh/go-pagerduty => github.com/alenapan/go-pagerduty v0.0.0-20250324143909-5c8050f3efbb

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -261,7 +261,7 @@ github.com/hashicorp/terraform-svchost
 # github.com/hashicorp/yamux v0.1.1
 ## explicit; go 1.15
 github.com/hashicorp/yamux
-# github.com/heimweh/go-pagerduty v0.0.0-20250319162404-3d9cf89703c0 => github.com/alexzakabluk/go-pagerduty v0.0.0-20250325172012-9f2ddcb0c5f6
+# github.com/heimweh/go-pagerduty v0.0.0-20250414155133-f9f4e0b0c59b
 ## explicit; go 1.17
 github.com/heimweh/go-pagerduty/pagerduty
 github.com/heimweh/go-pagerduty/persistentconfig
@@ -561,4 +561,3 @@ google.golang.org/protobuf/types/known/timestamppb
 # gopkg.in/ini.v1 v1.67.0
 ## explicit
 gopkg.in/ini.v1
-# github.com/heimweh/go-pagerduty => github.com/alexzakabluk/go-pagerduty v0.0.0-20250325172012-9f2ddcb0c5f6

--- a/website/docs/r/event_orchestration_global.html.markdown
+++ b/website/docs/r/event_orchestration_global.html.markdown
@@ -82,13 +82,15 @@ resource "pagerduty_event_orchestration_global" "global" {
       }
     }
     rule {
-      label = "Otherwise, set the incident to P1 and run a diagnostic"
+      label = "Otherwise, set the incident to P1, pause for 10 mins and run a diagnostic once the alert is suspended"
       actions {
         priority = data.pagerduty_priority.p1.id
+        suspend = 600
         automation_action {
           name = "db-diagnostic"
           url = "https://example.com/run-diagnostic"
           auto_send = true
+          trigger_types = ["alert_suspended"]
         }
       }
     }
@@ -130,10 +132,11 @@ The following arguments are supported:
 * `incident_custom_field_update` - (Optional) Assign a custom field to the resulting incident.
   * `id` - (Required) The custom field id
   * `value` - (Required) The value to assign to this custom field
-* `automation_action` - (Optional) Create a [Webhook](https://support.pagerduty.com/docs/event-orchestration#webhooks) associated with the resulting incident.
+* `automation_action` - (Optional) Create a [Webhook](https://support.pagerduty.com/docs/event-orchestration#webhooks) to be run for certain alert states.
   * `name` - (Required) Name of this Webhook.
   * `url` - (Required) The API endpoint where PagerDuty's servers will send the webhook request.
-  * `auto_send` - (Optional) When true, PagerDuty's servers will automatically send this webhook request as soon as the resulting incident is created. When false, your incident responder will be able to manually trigger the Webhook via the PagerDuty website and mobile app.
+  * `auto_send` - (Optional) When true, PagerDuty's servers will automatically send this webhook request as soon as the resulting incident or alert is created. When false, your incident responder will be able to manually trigger the Webhook via the PagerDuty website and mobile app.
+  * `trigger_types` - (Optional) The Webhook will be associated (or automatically triggered, if `auto_send` is `true`) with the incident or alert, whenever an alert reaches the specified state. Allowed values are: `["alert_triggered"]`, `["alert_suspended"]`, `["alert_suppressed"]`. NOTE: `auto_send` must be `true` for trigger types of `["alert_suspended"]` and `["alert_suppressed"]`
   * `header` - (Optional) Specify custom key/value pairs that'll be sent with the webhook request as request headers.
     * `key` - (Required) Name to identify the header
     * `value` - (Required) Value of this header


### PR DESCRIPTION
## Changes

This PR introduces the following changes:
- Adds support for the `trigger_types` property on the `automation_action` and `pagerduty_automation_action` attributes in the following resources:
  - `pagerduty_event_orchestration_global` (this resource only supports the `automation_action` attribute)
  - `pagerduty_event_orchestration_service` (supports both the `automation_action` and the `pagerduty_automation_action` attrbiutes)
- Documents the new `trigger_types` attribute

## Testing

### Resource schema changes

- [x] Acceptance tests are passing: ![image](https://github.com/user-attachments/assets/c6f7f78a-88c1-46db-a4e5-0b233000c1de)

**Manual QA**

Tested with the local version of the TF Provider by setting `dev_overrides`:

- [x] Upgrading to the new version of the TF Provider doesn't break the existing Webhook and Automation Action configs, just keeps showing `trigger_types` in the diff, as expected:
  - TF Config: https://github.com/PagerDuty/terraform-provider-pagerduty-internal/blob/827cc1e34202b972df4bd28f8648659b9fc2c036/main.tf
  - `terraform plan` / `terraform apply` outputs: ![image](https://github.com/user-attachments/assets/c8af266d-4983-473f-93cd-ef6be5c11b69) ![image](https://github.com/user-attachments/assets/7e81e82f-d595-443b-9b20-1d186e1c3fe3)
- [x] Adding `trigger_types` to the config makes the diff go away:
  - TF Config: https://github.com/PagerDuty/terraform-provider-pagerduty-internal/blob/2b37f81d3b2f489a697ef2dbb9cbbe63478791ca/main.tf
  - `terraform plan` / `terraform apply` outputs: ![image](https://github.com/user-attachments/assets/635b72f5-4c10-410e-943b-fcabcdce0267)
- [x] Adding rules with automation `trigger_types` / updating `trigger_types` works:
  - TF Config: https://github.com/PagerDuty/terraform-provider-pagerduty-internal/blob/c807a4302e941226f1feb3d2fe85fcad7827cf43/main.tf
  - `terraform plan` / `terraform apply` outputs: ![image](https://github.com/user-attachments/assets/82c817e8-c32d-466f-8413-4b6bfa14784c)
- [x] Validation works:
  - Can only be an array of one string element: ![image](https://github.com/user-attachments/assets/db2903fc-7251-4350-b462-97e91285ba46)

### Documentation changes

Used the TF Doc Preview Tool: https://registry.terraform.io/tools/doc-preview

- [x] `pagerduty_event_orchestration_global`: ![image](https://github.com/user-attachments/assets/9eea89aa-547c-44cc-a7d2-558b1c1483db)
- [x] `pagerduty_event_orchestration_service`: ![image](https://github.com/user-attachments/assets/acf0c837-f806-493a-a006-3f00cca530ce)