### PR TITLE
Make event config for slack connections a set

### DIFF
--- a/pagerduty/resource_pagerduty_slack_connection.go
+++ b/pagerduty/resource_pagerduty_slack_connection.go
@@ -70,7 +70,7 @@ func resourcePagerDutySlackConnection() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"events": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Required: true,
 							Elem: &schema.Schema{
 								Type: schema.TypeString,


### PR DESCRIPTION
Updates the `pagerduty_slack_connection` to use `schema.TypeSet` instead of `schema.TypeList`, as the order the events are defined shouldn't report a change in a plan output.

Should resolve https://github.com/PagerDuty/terraform-provider-pagerduty/issues/999.