### PR TITLE
Fix issue where condition cannot currently be an empty string

### DIFF
--- a/pagerduty/resource_pagerduty_incident_workflow_trigger.go
+++ b/pagerduty/resource_pagerduty_incident_workflow_trigger.go
@@ -262,6 +262,8 @@ func flattenIncidentWorkflowEnabledServices(s []*pagerduty.ServiceReference) []s
 }
 
 func buildIncidentWorkflowTriggerStruct(d *schema.ResourceData, forUpdate bool) (*pagerduty.IncidentWorkflowTrigger, error) {
+	triggerType := d.Get("type").(string)
+
 	iwt := pagerduty.IncidentWorkflowTrigger{
 		SubscribedToAllServices: d.Get("subscribed_to_all_services").(bool),
 	}
@@ -270,7 +272,7 @@ func buildIncidentWorkflowTriggerStruct(d *schema.ResourceData, forUpdate bool) 
 		iwt.Workflow = &pagerduty.IncidentWorkflow{
 			ID: d.Get("workflow").(string),
 		}
-		iwt.TriggerType = pagerduty.IncidentWorkflowTriggerTypeFromString(d.Get("type").(string))
+		iwt.TriggerType = pagerduty.IncidentWorkflowTriggerTypeFromString(triggerType)
 	}
 
 	if services, ok := d.GetOk("services"); ok {
@@ -280,7 +282,6 @@ func buildIncidentWorkflowTriggerStruct(d *schema.ResourceData, forUpdate bool) 
 	// Special handling for condition to support empty string conditions
 	// GetOk won't return true for empty strings, but we need to set them
 	// for conditional triggers that execute on incident creation
-	triggerType := d.Get("type").(string)
 	if triggerType == "conditional" {
 		condStr := d.Get("condition").(string)
 		iwt.Condition = &condStr

--- a/pagerduty/resource_pagerduty_incident_workflow_trigger.go
+++ b/pagerduty/resource_pagerduty_incident_workflow_trigger.go
@@ -282,10 +282,7 @@ func buildIncidentWorkflowTriggerStruct(d *schema.ResourceData, forUpdate bool) 
 	// Special handling for condition to support empty string conditions
 	// GetOk won't return true for empty strings, but we need to set them
 	// for conditional triggers that execute on incident creation
-	if triggerType == "conditional" {
-		condStr := d.Get("condition").(string)
-		iwt.Condition = &condStr
-	} else if condition, ok := d.GetOk("condition"); ok {
+	if condition, ok := d.GetOk("condition"); triggerType == "conditional" || ok {
 		condStr := condition.(string)
 		iwt.Condition = &condStr
 	}

--- a/pagerduty/resource_pagerduty_incident_workflow_trigger.go
+++ b/pagerduty/resource_pagerduty_incident_workflow_trigger.go
@@ -277,7 +277,14 @@ func buildIncidentWorkflowTriggerStruct(d *schema.ResourceData, forUpdate bool) 
 		iwt.Services = buildIncidentWorkflowTriggerServices(services)
 	}
 
-	if condition, ok := d.GetOk("condition"); ok {
+	// Special handling for condition to support empty string conditions
+	// GetOk won't return true for empty strings, but we need to set them
+	// for conditional triggers that execute on incident creation
+	triggerType := d.Get("type").(string)
+	if triggerType == "conditional" {
+		condStr := d.Get("condition").(string)
+		iwt.Condition = &condStr
+	} else if condition, ok := d.GetOk("condition"); ok {
 		condStr := condition.(string)
 		iwt.Condition = &condStr
 	}

--- a/pagerduty/resource_pagerduty_incident_workflow_trigger_test.go
+++ b/pagerduty/resource_pagerduty_incident_workflow_trigger_test.go
@@ -519,3 +519,28 @@ func testAccCheckPagerDutyIncidentWorkflowTriggerExists(n string) resource.TestC
 		return nil
 	}
 }
+
+func TestBuildIncidentWorkflowTriggerStruct_HandlesEmptyCondition(t *testing.T) {
+	r := resourcePagerDutyIncidentWorkflowTrigger()
+	d := r.Data(nil)
+
+	d.Set("type", "conditional")
+	d.Set("workflow", "DUMMY_WORKFLOW_ID")
+	d.Set("condition", "")
+	d.Set("subscribed_to_all_services", true)
+
+	triggerStruct, err := buildIncidentWorkflowTriggerStruct(d, true)
+	if err != nil {
+		t.Fatalf("Error building incident workflow trigger struct: %v", err)
+	}
+
+	if triggerStruct.Condition == nil {
+		t.Error("Expected condition to be an empty string, got nil")
+	} else if *triggerStruct.Condition != "" {
+		t.Errorf("Expected condition to be an empty string, got %q", *triggerStruct.Condition)
+	}
+
+	if triggerStruct.TriggerType != pagerduty.IncidentWorkflowTriggerTypeConditional {
+		t.Errorf("Expected trigger type to be conditional, got %s", triggerStruct.TriggerType.String())
+	}
+}

--- a/pagerduty/resource_pagerduty_incident_workflow_trigger_test.go
+++ b/pagerduty/resource_pagerduty_incident_workflow_trigger_test.go
@@ -480,6 +480,77 @@ func TestAccPagerDutyIncidentWorkflowTrigger_CannotChangeType(t *testing.T) {
 	})
 }
 
+func TestAccPagerDutyIncidentWorkflowTrigger_UpdateToEmptyCondition(t *testing.T) {
+	name := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	configFn := func(condition string) string {
+		return fmt.Sprintf(`
+resource "pagerduty_user" "example" {
+  name  = "%s-user"
+  email = "%[1]s-user@foo.test"
+}
+
+resource "pagerduty_escalation_policy" "test" {
+  name      = "%[1]s-ep"
+  rule {
+    escalation_delay_in_minutes = 10
+    target {
+      type = "user_reference"
+      id   = pagerduty_user.example.id
+    }
+  }
+}
+
+resource "pagerduty_service" "test" {
+  name = "%[1]s"
+  escalation_policy = pagerduty_escalation_policy.test.id
+}
+
+resource "pagerduty_incident_workflow" "test" {
+  name = "%[1]s-incident-workflow"
+}
+
+resource "pagerduty_incident_workflow_trigger" "test" {
+  type       = "conditional"
+  workflow   = pagerduty_incident_workflow.test.id
+  condition  = "%s"
+  subscribed_to_all_services = false
+  services = [pagerduty_service.test.id]
+}
+`, name, condition)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckIncidentWorkflows(t)
+		},
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: configFn("incident.priority matches 'P1'"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyIncidentWorkflowTriggerExists("pagerduty_incident_workflow_trigger.test"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_incident_workflow_trigger.test", "type", "conditional"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_incident_workflow_trigger.test", "condition", "incident.priority matches 'P1'"),
+				),
+			},
+			{
+				Config: configFn(""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyIncidentWorkflowTriggerExists("pagerduty_incident_workflow_trigger.test"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_incident_workflow_trigger.test", "type", "conditional"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_incident_workflow_trigger.test", "condition", ""),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckPagerDutyIncidentWorkflowTriggerDestroy(s *terraform.State) error {
 	client, _ := testAccProvider.Meta().(*Config).Client()
 	for _, r := range s.RootModule().Resources {
@@ -517,30 +588,5 @@ func testAccCheckPagerDutyIncidentWorkflowTriggerExists(n string) resource.TestC
 		}
 
 		return nil
-	}
-}
-
-func TestBuildIncidentWorkflowTriggerStruct_HandlesEmptyCondition(t *testing.T) {
-	r := resourcePagerDutyIncidentWorkflowTrigger()
-	d := r.Data(nil)
-
-	d.Set("type", "conditional")
-	d.Set("workflow", "DUMMY_WORKFLOW_ID")
-	d.Set("condition", "")
-	d.Set("subscribed_to_all_services", true)
-
-	triggerStruct, err := buildIncidentWorkflowTriggerStruct(d, true)
-	if err != nil {
-		t.Fatalf("Error building incident workflow trigger struct: %v", err)
-	}
-
-	if triggerStruct.Condition == nil {
-		t.Error("Expected condition to be an empty string, got nil")
-	} else if *triggerStruct.Condition != "" {
-		t.Errorf("Expected condition to be an empty string, got %q", *triggerStruct.Condition)
-	}
-
-	if triggerStruct.TriggerType != pagerduty.IncidentWorkflowTriggerTypeConditional {
-		t.Errorf("Expected trigger type to be conditional, got %s", triggerStruct.TriggerType.String())
 	}
 }


### PR DESCRIPTION
This should fix: https://github.com/PagerDuty/terraform-provider-pagerduty/issues/671

An empty string is perfectly valid for `condition` where type is set to `conditional` - this effectively sets it to trigger on incident creation. The issue is, `GetOk` isn't sufficient for this, because an error will return if it's the zero value (`""`) despite the fact we actually want this.

Specifying `"incident.status matches 'triggered'"` as a workaround has the unfortunate effect that when the ticket is reassigned, it still counts as 'triggered' rather than created - effectively re-running the workflow if the ticket is reassigned, which may not be desired. Adding this fix solves this issue so we can reliably use the Terraform provider.