### PR TITLE
feat: esc policy data source supports teams/description

### DIFF
--- a/pagerdutyplugin/data_source_pagerduty_escalation_policy_test.go
+++ b/pagerdutyplugin/data_source_pagerduty_escalation_policy_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAccDataSourcePagerDutyEscalationPolicy_Basic(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.com", username)
+	email := fmt.Sprintf("%s@foo.test", username)
 	teamName := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
 

--- a/pagerdutyplugin/data_source_pagerduty_escalation_policy_test.go
+++ b/pagerdutyplugin/data_source_pagerduty_escalation_policy_test.go
@@ -11,7 +11,8 @@ import (
 
 func TestAccDataSourcePagerDutyEscalationPolicy_Basic(t *testing.T) {
 	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
-	email := fmt.Sprintf("%s@foo.test", username)
+	email := fmt.Sprintf("%s@foo.com", username)
+	teamName := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
@@ -19,7 +20,7 @@ func TestAccDataSourcePagerDutyEscalationPolicy_Basic(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourcePagerDutyEscalationPolicyConfig(username, email, escalationPolicy),
+				Config: testAccDataSourcePagerDutyEscalationPolicyConfig(username, email, teamName, escalationPolicy),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourcePagerDutyEscalationPolicy("pagerduty_escalation_policy.test", "data.pagerduty_escalation_policy.by_name"),
 				),
@@ -41,7 +42,7 @@ func testAccDataSourcePagerDutyEscalationPolicy(src, n string) resource.TestChec
 			return fmt.Errorf("Expected to get a escalation policy ID from PagerDuty")
 		}
 
-		testAtts := []string{"id", "name"}
+		testAtts := []string{"id", "name", "description", "teams"}
 
 		for _, att := range testAtts {
 			if a[att] != srcA[att] {
@@ -53,16 +54,22 @@ func testAccDataSourcePagerDutyEscalationPolicy(src, n string) resource.TestChec
 	}
 }
 
-func testAccDataSourcePagerDutyEscalationPolicyConfig(username, email, escalationPolicy string) string {
+func testAccDataSourcePagerDutyEscalationPolicyConfig(username, email, teamName, escalationPolicy string) string {
 	return fmt.Sprintf(`
 resource "pagerduty_user" "test" {
   name  = "%s"
   email = "%s"
 }
 
+resource "pagerduty_team" "test" {
+  name  = "%s"
+}
+
 resource "pagerduty_escalation_policy" "test" {
   name        = "%s"
   num_loops   = 2
+	description = "test description"
+	teams       = [pagerduty_team.test.id]
 
   rule {
     escalation_delay_in_minutes = 10
@@ -77,5 +84,5 @@ resource "pagerduty_escalation_policy" "test" {
 data "pagerduty_escalation_policy" "by_name" {
   name = pagerduty_escalation_policy.test.name
 }
-`, username, email, escalationPolicy)
+`, username, email, teamName, escalationPolicy)
 }

--- a/website/docs/d/escalation_policy.html.markdown
+++ b/website/docs/d/escalation_policy.html.markdown
@@ -36,5 +36,7 @@ The following arguments are supported:
 ## Attributes Reference
 * `id` - The ID of the found escalation policy.
 * `name` - The short name of the found escalation policy.
+* `description` - The description of the found escalation policy.
+* `teams` - The IDs of the teams associated with the found escalation policy.
 
 [1]: https://developer.pagerduty.com/api-reference/b3A6Mjc0ODEyNA-list-escalation-policies


### PR DESCRIPTION
This addresses issue #1022 and adds support for `teams` and `description` computed attributes to the `data.pagerduty_escalation_policy` data source.