### PR TITLE
Add jira cloud to oauth scope

### DIFF
--- a/pagerdutyplugin/config.go
+++ b/pagerdutyplugin/config.go
@@ -180,6 +180,8 @@ func availableOauthScopes() []string {
 		"extension_schemas.read",
 		"extensions.read",
 		"extensions.write",
+		"incident_types.read",
+		"incident_types.write",
 		"incident_workflows.read",
 		"incident_workflows.write",
 		"incident_workflows:instances.write",
@@ -190,6 +192,8 @@ func availableOauthScopes() []string {
 		"jira_cloud_rules.write",
 		"licenses.read",
 		"notifications.read",
+		"oauth_delegations.read",
+		"oauth_delegations.write",
 		"oncalls.read",
 		"priorities.read",
 		"response_plays.read",
@@ -218,6 +222,11 @@ func availableOauthScopes() []string {
 		"users:sessions.read",
 		"users:sessions.write",
 		"vendors.read",
+		"webhook_subscriptions.read",
+		"webhook_subscriptions.write",
+		"workflow_integrations.read",
+		"workflow_integrations:connections.read",
+		"workflow_integrations:connections.write",
 	}
 }
 


### PR DESCRIPTION
`availableOauthScopes()` is missing the pagerduty jira cloud permissions. I assume this meant that JIRA cloud resources only authenticated with a PagerDuty API key. Oauth should be fixed to work as well.

```
"message": "Token missing required scopes",
"required_scopes": "jira_cloud_accounts.read",
```
Provider version 3.26.0
Terraform version 1.3.7

Docs show scope is wide enough to create jira cloud resources --https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/guides/pagerduty_api_support_status 