### PR TITLE
Allow deleting alert_grouping_parameters with a time_window equal to 86400

### DIFF
--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -352,7 +352,7 @@ func customizePagerDutyServiceDiff(context context.Context, diff *schema.Resourc
 		if agpType == "content_based" && (aggregateVal == "" || len(fieldsVal) == 0) {
 			return fmt.Errorf("When using Alert grouping parameters configuration of type \"content_based\" is in use, attributes \"aggregate\" and \"fields\" are required")
 		}
-		if timeWindowVal == 86400 && agpType != "content_based" {
+		if timeWindowVal == 86400 && agpType != "" && agpType != "content_based" {
 			return fmt.Errorf("Alert grouping parameters configuration attribute \"time_window\" with a value of 86400 is only supported by \"content-based\" type Alert Grouping")
 		}
 		if (aggregateVal != "" || len(fieldsVal) > 0) && (agpType != "" && hasChangeAgpType && agpType != "content_based") {
@@ -590,20 +590,25 @@ func flattenService(d *schema.ResourceData, service *pagerduty.Service) error {
 	d.Set("created_at", service.CreatedAt)
 	d.Set("escalation_policy", service.EscalationPolicy.ID)
 	d.Set("description", service.Description)
+	d.Set("alert_creation", service.AlertCreation)
+	d.Set("last_incident_timestamp", service.LastIncidentTimestamp)
+
 	if service.AutoResolveTimeout == nil {
 		d.Set("auto_resolve_timeout", "null")
 	} else {
 		d.Set("auto_resolve_timeout", strconv.Itoa(*service.AutoResolveTimeout))
 	}
-	d.Set("last_incident_timestamp", service.LastIncidentTimestamp)
+
 	if service.AcknowledgementTimeout == nil {
 		d.Set("acknowledgement_timeout", "null")
 	} else {
 		d.Set("acknowledgement_timeout", strconv.Itoa(*service.AcknowledgementTimeout))
 	}
-	d.Set("alert_creation", service.AlertCreation)
-	if service.AlertGrouping != nil && *service.AlertGrouping != nil && **service.AlertGrouping != "" {
-		d.Set("alert_grouping", **service.AlertGrouping)
+
+	if service.AlertGrouping != nil && *service.AlertGrouping != nil {
+		if ag := **service.AlertGrouping; ag != "" && ag != "rules" {
+			d.Set("alert_grouping", ag)
+		}
 	}
 	if service.AlertGroupingTimeout == nil {
 		d.Set("alert_grouping_timeout", "null")


### PR DESCRIPTION
```
+go test ./pagerduty -run TestAccPagerDutyService_ -v
=== RUN   TestAccPagerDutyService_AlertGrouping
--- PASS: TestAccPagerDutyService_AlertGrouping (0.00s)
=== RUN   TestAccPagerDutyService_AlertGroupingContentBased
--- PASS: TestAccPagerDutyService_AlertGroupingContentBased (71.03s)
=== RUN   TestAccPagerDutyService_AlertContentGroupingIntelligentTimeWindow
--- PASS: TestAccPagerDutyService_AlertContentGroupingIntelligentTimeWindow (21.03s)
=== RUN   TestAccPagerDutyService_AlertGroupingParametersAddConfigField
--- PASS: TestAccPagerDutyService_AlertGroupingParametersAddConfigField (21.28s)
=== RUN   TestAccPagerDutyService_AutoPauseNotificationsParameters
--- PASS: TestAccPagerDutyService_AutoPauseNotificationsParameters (26.96s)
=== RUN   TestAccPagerDutyService_import
--- PASS: TestAccPagerDutyService_import (10.07s)
=== RUN   TestAccPagerDutyService_Basic
--- PASS: TestAccPagerDutyService_Basic (24.49s)
=== RUN   TestAccPagerDutyService_BasicWithIncidentUrgencyRules
--- PASS: TestAccPagerDutyService_BasicWithIncidentUrgencyRules (30.79s)
=== RUN   TestAccPagerDutyService_FromBasicToCustomIncidentUrgencyRules
--- PASS: TestAccPagerDutyService_FromBasicToCustomIncidentUrgencyRules (21.06s)
=== RUN   TestAccPagerDutyService_Delete24HAlertGrouping
--- PASS: TestAccPagerDutyService_Delete24HAlertGrouping (36.86s)
PASS
```