### PR TITLE
Fix missing device_type for user contact method

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 toolchain go1.24.2
 
 require (
-	github.com/PagerDuty/go-pagerduty v1.8.1-0.20250811172458-d8e009c278a4
+	github.com/PagerDuty/go-pagerduty v1.8.1-0.20250910143746-9bbd1f0aa2a6
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hc-install v0.6.2

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/PagerDuty/go-pagerduty v1.8.1-0.20250811172458-d8e009c278a4 h1:GnL/W0+J3QvOv5KAXNm83EMwOUurCwJK+mPdqUP5lxI=
 github.com/PagerDuty/go-pagerduty v1.8.1-0.20250811172458-d8e009c278a4/go.mod h1:ilimTqwHSBjmvKeYA/yayDBZvzf/CX4Pwa9Qbhekzok=
+github.com/PagerDuty/go-pagerduty v1.8.1-0.20250910143746-9bbd1f0aa2a6 h1:72jM6XG62wQ4vFMXt46vlylEyyaO+sv+LA733wJGmtQ=
+github.com/PagerDuty/go-pagerduty v1.8.1-0.20250910143746-9bbd1f0aa2a6/go.mod h1:ilimTqwHSBjmvKeYA/yayDBZvzf/CX4Pwa9Qbhekzok=
 github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c h1:kMFnB0vCcX7IL/m9Y5LO+KQYv+t1CQOiFe6+SV2J7bE=
 github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=

--- a/pagerduty/provider.go
+++ b/pagerduty/provider.go
@@ -162,6 +162,7 @@ func Provider(isMux bool) *schema.Provider {
 		delete(p.ResourcesMap, "pagerduty_business_service")
 		delete(p.ResourcesMap, "pagerduty_team")
 		delete(p.ResourcesMap, "pagerduty_team_membership")
+		delete(p.ResourcesMap, "pagerduty_user_contact_method")
 	}
 
 	p.ConfigureContextFunc = func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {

--- a/pagerdutyplugin/provider.go
+++ b/pagerdutyplugin/provider.go
@@ -97,6 +97,7 @@ func (p *Provider) Resources(_ context.Context) [](func() resource.Resource) {
 		func() resource.Resource { return &resourceTeam{} },
 		func() resource.Resource { return &resourceUserHandoffNotificationRule{} },
 		func() resource.Resource { return &resourceUserNotificationRule{} },
+		func() resource.Resource { return &resourceUserContactMethod{} },
 		func() resource.Resource { return &resourceEnablement{} },
 	}
 }

--- a/pagerdutyplugin/resource_pagerduty_user_contact_method.go
+++ b/pagerdutyplugin/resource_pagerduty_user_contact_method.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -23,8 +25,9 @@ import (
 type resourceUserContactMethod struct{ client *pagerduty.Client }
 
 var (
-	_ resource.ResourceWithConfigure   = (*resourceUserContactMethod)(nil)
-	_ resource.ResourceWithImportState = (*resourceUserContactMethod)(nil)
+	_ resource.ResourceWithConfigure      = (*resourceUserContactMethod)(nil)
+	_ resource.ResourceWithImportState    = (*resourceUserContactMethod)(nil)
+	_ resource.ResourceWithValidateConfig = (*resourceUserContactMethod)(nil)
 )
 
 func (r *resourceUserContactMethod) Metadata(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -59,9 +62,73 @@ func (r *resourceUserContactMethod) Schema(_ context.Context, _ resource.SchemaR
 			},
 			"send_short_email": schema.BoolAttribute{
 				Optional: true,
+				Computed: true,
 				Default:  booldefault.StaticBool(false),
 			},
+			"device_type": schema.StringAttribute{
+				Optional: true,
+			},
 		},
+	}
+}
+
+func (r *resourceUserContactMethod) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var cfg resourceUserContactMethodModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &cfg)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if cfg.Type.ValueString() == "push_notification_contact_method" {
+		if allowed, got := []string{"android", "ios"}, cfg.DeviceType.ValueString(); !slices.Contains(allowed, got) {
+			resp.Diagnostics.AddAttributeError(path.Root("device_type"), "Invalid value", fmt.Sprintf("Attribute device_type value must be one of %q, got %q", allowed, got))
+			return
+		}
+	}
+
+	a := cfg.Address.ValueString()
+	t := cfg.Type.ValueString()
+	var c int64
+	if !cfg.CountryCode.IsNull() && !cfg.CountryCode.IsUnknown() {
+		c = cfg.CountryCode.ValueInt64()
+	}
+
+	if t == "sms_contact_method" || t == "phone_contact_method" {
+		maxLength := 40
+		if len(a) > maxLength {
+			resp.Diagnostics.AddAttributeError(path.Root("address"), "Invalid phone number", "phone numbers may not exceed 40 characters")
+			return
+		}
+
+		for _, char := range a {
+			isAllowedChar := char == ',' || char == '*' || char == '#'
+			if _, err := strconv.ParseInt(string(char), 10, 64); err != nil && !isAllowedChar {
+				resp.Diagnostics.AddAttributeError(path.Root("address"), "Invalid phone number", "phone numbers may only include digits from 0-9 and the symbols: comma (,), asterisk (*), and pound (#)")
+				return
+			}
+		}
+
+		isMexicoNumber := c == 52
+		if t == "sms_contact_method" && isMexicoNumber && strings.HasPrefix(a, "1") {
+			resp.Diagnostics.AddAttributeError(path.Root("address"), "Invalid Mexico SMS number", fmt.Sprintf("Mexico-based SMS numbers should be free of area code prefixes, so please remove the leading 1 in the number %q", a))
+			return
+		}
+
+		isTrunkPrefixNotSupported := map[int64]string{
+			33: "0",
+			40: "0",
+			44: "0",
+			45: "0",
+			49: "0",
+			61: "0",
+			66: "0",
+			91: "0",
+			1:  "1",
+		}
+		if prefix, ok := isTrunkPrefixNotSupported[c]; ok && strings.HasPrefix(a, prefix) {
+			resp.Diagnostics.AddAttributeError(path.Root("address"), "Invalid phone number format", fmt.Sprintf("Trunk prefixes are not supported for following countries and regions: France, Romania, UK, Denmark, Germany, Australia, Thailand, India and North America, so must be formatted for international use without the leading %s", prefix))
+			return
+		}
 	}
 }
 
@@ -135,7 +202,8 @@ func (r *resourceUserContactMethod) Update(ctx context.Context, req resource.Upd
 	}
 	log.Printf("[INFO] Updating PagerDuty user contact method %s", plan.ID)
 
-	_, err := r.client.UpdateUserContactMethodWthContext(ctx, plan.UserID, plan.ContactMethod)
+	response, err := r.client.UpdateUserContactMethodWthContext(ctx, plan.UserID, plan.ContactMethod)
+	processedResponse, err := r.processUpdateContactMethodResponse(ctx, plan.UserID, plan.ID, &plan.ContactMethod, response, err)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Error updating PagerDuty user contact method %s", plan.ID),
@@ -143,6 +211,7 @@ func (r *resourceUserContactMethod) Update(ctx context.Context, req resource.Upd
 		)
 		return
 	}
+	_ = processedResponse
 
 	model, err = requestGetUserContactMethod(ctx, r.client, plan.UserID, plan.ID, true, &resp.Diagnostics)
 	if err != nil {
@@ -214,15 +283,16 @@ func (r *resourceUserContactMethod) ImportState(ctx context.Context, req resourc
 }
 
 type resourceUserContactMethodModel struct {
-	ID             types.String
-	UserID         types.String
-	Address        types.String
-	Blacklisted    types.Bool
-	CountryCode    types.Int64
-	Enabled        types.Bool
-	Label          types.String
-	SendShortEmail types.Bool
-	Type           types.String
+	ID             types.String `tfsdk:"id"`
+	UserID         types.String `tfsdk:"user_id"`
+	Address        types.String `tfsdk:"address"`
+	Blacklisted    types.Bool   `tfsdk:"blacklisted"`
+	CountryCode    types.Int64  `tfsdk:"country_code"`
+	Enabled        types.Bool   `tfsdk:"enabled"`
+	Label          types.String `tfsdk:"label"`
+	SendShortEmail types.Bool   `tfsdk:"send_short_email"`
+	Type           types.String `tfsdk:"type"`
+	DeviceType     types.String `tfsdk:"device_type"`
 }
 
 type ContactMethod struct {
@@ -263,8 +333,70 @@ func buildPagerdutyContactMethod(model *resourceUserContactMethodModel) ContactM
 	if !model.CountryCode.IsNull() && !model.CountryCode.IsUnknown() {
 		contactMethod.CountryCode = int(model.CountryCode.ValueInt64())
 	}
+	if !model.DeviceType.IsNull() && !model.DeviceType.IsUnknown() {
+		contactMethod.DeviceType = model.DeviceType.ValueString()
+	}
 
 	return ContactMethod{ContactMethod: contactMethod, UserID: model.UserID.ValueString()}
+}
+
+func (r *resourceUserContactMethod) updateContactMethodCall(ctx context.Context, userID, contactMethodID string, contactMethod *pagerduty.ContactMethod) (*pagerduty.ContactMethod, error) {
+	return r.client.UpdateUserContactMethodWthContext(ctx, userID, *contactMethod)
+}
+
+func (r *resourceUserContactMethod) processUpdateContactMethodResponse(ctx context.Context, userID, contactMethodID string, contactMethod *pagerduty.ContactMethod, response *pagerduty.ContactMethod, err error) (*pagerduty.ContactMethod, error) {
+	if err != nil {
+		log.Println("[CG]", err.Error())
+		log.Printf("[CG] %#v", err)
+		isUniqueContactError := strings.Contains(err.Error(), "User Contact method must be unique")
+		if !isUniqueContactError {
+			return nil, err
+		}
+
+		existingContact, err := r.findExistingContactMethod(ctx, userID, contactMethod)
+		if err != nil {
+			return nil, err
+		}
+
+		err = r.client.DeleteUserContactMethodWithContext(ctx, userID, existingContact.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		_, err = r.updateContactMethodCall(ctx, userID, contactMethodID, contactMethod)
+		if err != nil {
+			return nil, err
+		}
+
+		existingContact, err = r.findExistingContactMethod(ctx, userID, contactMethod)
+		if err != nil {
+			return nil, err
+		}
+		return existingContact, nil
+	}
+
+	return response, nil
+}
+
+func (r *resourceUserContactMethod) findExistingContactMethod(ctx context.Context, userID string, contactMethod *pagerduty.ContactMethod) (*pagerduty.ContactMethod, error) {
+	contactMethods, err := r.client.ListUserContactMethodsWithContext(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("[User Contact method must be unique] but failed to fetch existing ones: %w", err)
+	}
+
+	for _, contact := range contactMethods.ContactMethods {
+		if r.isSameContactMethod(&contact, contactMethod) {
+			return r.client.GetUserContactMethodWithContext(ctx, userID, contact.ID)
+		}
+	}
+
+	return nil, fmt.Errorf("[User Contact method must be unique]")
+}
+
+func (r *resourceUserContactMethod) isSameContactMethod(existingContact, newContact *pagerduty.ContactMethod) bool {
+	return existingContact.Type == newContact.Type &&
+		existingContact.Address == newContact.Address &&
+		existingContact.CountryCode == newContact.CountryCode
 }
 
 func flattenUserContactMethod(response *pagerduty.ContactMethod, userID string) resourceUserContactMethodModel {

--- a/pagerdutyplugin/resource_pagerduty_user_contact_method_test.go
+++ b/pagerdutyplugin/resource_pagerduty_user_contact_method_test.go
@@ -97,7 +97,7 @@ func TestAccPagerDutyUserContactMethodPhone_FormatValidation(t *testing.T) {
 			{
 				Config:      testAccCheckPagerDutyUserContactMethodPhoneFormatValidationConfig(username, email, "sms_contact_method", "52", "15558889999"),
 				PlanOnly:    true,
-				ExpectError: regexp.MustCompile("Mexico-based SMS numbers should be free of area code prefixes, so please remove the leading 1 in the number"),
+				ExpectError: regexp.MustCompile(`Mexico-based SMS numbers should be free of area code prefixes, so please\s+remove the leading 1 in the number`),
 			},
 		},
 	})

--- a/vendor/github.com/PagerDuty/go-pagerduty/alert_grouping_setting.go
+++ b/vendor/github.com/PagerDuty/go-pagerduty/alert_grouping_setting.go
@@ -17,8 +17,9 @@ type AlertGroupingSettingConfigTime struct {
 // AlertGroupingSettingConfigIntelligent is the configuration content for a
 // AlertGroupingSetting of type "intelligent"
 type AlertGroupingSettingConfigIntelligent struct {
-	TimeWindow            uint  `json:"time_window"`
-	RecommendedTimeWindow *uint `json:"recommended_time_window,omitempty"`
+	TimeWindow            uint     `json:"time_window"`
+	RecommendedTimeWindow *uint    `json:"recommended_time_window,omitempty"`
+	IagFields             []string `json:"iag_fields"`
 }
 
 // AlertGroupingSettingConfigContentBased is the configuration content for a

--- a/vendor/github.com/PagerDuty/go-pagerduty/user.go
+++ b/vendor/github.com/PagerDuty/go-pagerduty/user.go
@@ -52,6 +52,7 @@ type ContactMethod struct {
 	Blacklisted    bool   `json:"blacklisted,omitempty"`
 	CountryCode    int    `json:"country_code,omitempty"`
 	Enabled        bool   `json:"enabled,omitempty"`
+	DeviceType     string `json:"device_type,omitempty"`
 }
 
 // OncallHandoffNotificationRule is a handoff notification rule

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/PagerDuty/go-pagerduty v1.8.1-0.20250811172458-d8e009c278a4
+# github.com/PagerDuty/go-pagerduty v1.8.1-0.20250910143746-9bbd1f0aa2a6
 ## explicit; go 1.19
 github.com/PagerDuty/go-pagerduty
 # github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c


### PR DESCRIPTION
```
+go test ./pagerdutyplugin -run TestAccPagerDutyUserContactMethod -v
=== RUN   TestAccPagerDutyUserContactMethod_import
--- PASS: TestAccPagerDutyUserContactMethod_import (18.97s)
=== RUN   TestAccPagerDutyUserContactMethodEmail_Basic
--- PASS: TestAccPagerDutyUserContactMethodEmail_Basic (29.39s)
=== RUN   TestAccPagerDutyUserContactMethodPhone_Basic
--- PASS: TestAccPagerDutyUserContactMethodPhone_Basic (33.45s)
=== RUN   TestAccPagerDutyUserContactMethodPhone_FormatValidation
--- PASS: TestAccPagerDutyUserContactMethodPhone_FormatValidation (0.33s)
=== RUN   TestAccPagerDutyUserContactMethodPhone_EnforceUpdateIfAlreadyExist
--- PASS: TestAccPagerDutyUserContactMethodPhone_EnforceUpdateIfAlreadyExist (28.70s)
=== RUN   TestAccPagerDutyUserContactMethodSMS_Basic
--- PASS: TestAccPagerDutyUserContactMethodSMS_Basic (28.96s)
=== RUN   TestAccPagerDutyUserContactMethodPhone_NoPermaDiffWhenOmittingCountryCode
--- PASS: TestAccPagerDutyUserContactMethodPhone_NoPermaDiffWhenOmittingCountryCode (21.27s)
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerdutyplugin       161.625s
```

Pending: Add field in API client library [https://github.com/PagerDuty/go-pagerduty/pull/562]() and `go vendor`