### PR TITLE
Fix user contact method device type inconsistency

### DIFF
--- a/pagerdutyplugin/resource_pagerduty_user_contact_method.go
+++ b/pagerdutyplugin/resource_pagerduty_user_contact_method.go
@@ -400,7 +400,13 @@ func flattenUserContactMethod(response *pagerduty.ContactMethod, userID string) 
 		SendShortEmail: types.BoolValue(response.SendShortEmail),
 		Type:           types.StringValue(response.Type),
 		UserID:         types.StringValue(userID),
-		DeviceType:     types.StringValue(response.DeviceType),
 	}
+
+	if response.DeviceType == "" {
+		model.DeviceType = types.StringNull()
+	} else {
+		model.DeviceType = types.StringValue(response.DeviceType)
+	}
+
 	return model
 }


### PR DESCRIPTION
```
+go test ./pagerdutyplugin -run TestAccPagerDutyUserContactMethod -v
=== RUN   TestAccPagerDutyUserContactMethod_import
--- PASS: TestAccPagerDutyUserContactMethod_import (19.13s)
=== RUN   TestAccPagerDutyUserContactMethodEmail_Basic
--- PASS: TestAccPagerDutyUserContactMethodEmail_Basic (27.60s)
=== RUN   TestAccPagerDutyUserContactMethodPhone_Basic
--- PASS: TestAccPagerDutyUserContactMethodPhone_Basic (31.58s)
=== RUN   TestAccPagerDutyUserContactMethodPhone_FormatValidation
--- PASS: TestAccPagerDutyUserContactMethodPhone_FormatValidation (0.37s)
=== RUN   TestAccPagerDutyUserContactMethodPhone_EnforceUpdateIfAlreadyExist
--- PASS: TestAccPagerDutyUserContactMethodPhone_EnforceUpdateIfAlreadyExist (27.09s)
=== RUN   TestAccPagerDutyUserContactMethodSMS_Basic
--- PASS: TestAccPagerDutyUserContactMethodSMS_Basic (27.49s)
=== RUN   TestAccPagerDutyUserContactMethodPhone_NoPermaDiffWhenOmittingCountryCode
--- PASS: TestAccPagerDutyUserContactMethodPhone_NoPermaDiffWhenOmittingCountryCode (23.63s)
PASS
ok  	github.com/PagerDuty/terraform-provider-pagerduty/pagerdutyplugin	158.068s
```

Closes: #1056