### PR TITLE
Bugfix: Retry if tag assignment is not found

### DIFF
--- a/pagerdutyplugin/resource_pagerduty_tag_assignment.go
+++ b/pagerdutyplugin/resource_pagerduty_tag_assignment.go
@@ -141,6 +141,10 @@ func (r *resourceTagAssignment) requestGetTagAssignents(ctx context.Context, mod
 				break
 			}
 		}
+		// The new tag assignment may not be propagated yet, so retry if not found
+		if !isFound {
+			return retry.RetryableError(fmt.Errorf("tag %s not found for %s entity %s", assign.TagID, assign.EntityType, assign.EntityID))
+		}
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
I ran into the same problem that was raised in issue #1019. After doing some debugging, the issue appears to be caused by a race condition - the PagerDuty API has not fully propagated the tag assignment when the verification check for it runs, so the state for it doesn't get saved. Allowing the `retry.RetryContext` callback function to retry if the tag assignment is not found appears to fix the issue. I validated this by overriding the provider locally with my fix in place and doing a bunch of tag assignments.