### PR TITLE
Fix service update not returning `alert_grouping_setting`

### DIFF
--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -540,7 +540,7 @@ func resourcePagerDutyServiceUpdateContext(ctx context.Context, d *schema.Resour
 
 	log.Printf("[INFO] Updating PagerDuty service %s", d.Id())
 
-	_, _, err = client.Services.Update(d.Id(), service)
+	updatedService, _, err := client.Services.Update(d.Id(), service)
 	if err != nil {
 		diags = diag.FromErr(handleNotFoundError(err, d))
 		return
@@ -557,7 +557,7 @@ func resourcePagerDutyServiceUpdateContext(ctx context.Context, d *schema.Resour
 		}
 	}
 
-	diags = append(diags, diag.FromErr(fetchService(d, meta, handleNotFoundError))...)
+	diags = append(diags, diag.FromErr(flattenService(d, updatedService))...)
 	return
 }
 


### PR DESCRIPTION
Effectively reverts #1029 and should fix #1068 by using the results of the service update call instead of running a separate call to retrieve the service immediately after updating. It seems the API returns inconsistent results immediately after an update to the service.