### PR TITLE
Skip validation for unknown push device type

### DIFF
--- a/pagerdutyplugin/resource_pagerduty_user_contact_method.go
+++ b/pagerdutyplugin/resource_pagerduty_user_contact_method.go
@@ -80,9 +80,11 @@ func (r *resourceUserContactMethod) ValidateConfig(ctx context.Context, req reso
 	}
 
 	if cfg.Type.ValueString() == "push_notification_contact_method" {
-		if allowed, got := []string{"android", "ios"}, cfg.DeviceType.ValueString(); !slices.Contains(allowed, got) {
-			resp.Diagnostics.AddAttributeError(path.Root("device_type"), "Invalid value", fmt.Sprintf("Attribute device_type value must be one of %q, got %q", allowed, got))
-			return
+		if !cfg.DeviceType.IsNull() && !cfg.DeviceType.IsUnknown() {
+			if allowed, got := []string{"android", "ios"}, cfg.DeviceType.ValueString(); !slices.Contains(allowed, got) {
+				resp.Diagnostics.AddAttributeError(path.Root("device_type"), "Invalid value", fmt.Sprintf("Attribute device_type value must be one of %q, got %q", allowed, got))
+				return
+			}
 		}
 	}
 


### PR DESCRIPTION
Closes #1076

```
+go test ./pagerdutyplugin -run TestAccPagerDutyUserContactMethod -v
=== RUN   TestAccPagerDutyUserContactMethod_import
--- PASS: TestAccPagerDutyUserContactMethod_import (19.54s)
=== RUN   TestAccPagerDutyUserContactMethodEmail_Basic
--- PASS: TestAccPagerDutyUserContactMethodEmail_Basic (28.33s)
=== RUN   TestAccPagerDutyUserContactMethodPhone_Basic
--- PASS: TestAccPagerDutyUserContactMethodPhone_Basic (34.59s)
=== RUN   TestAccPagerDutyUserContactMethodPhone_FormatValidation
--- PASS: TestAccPagerDutyUserContactMethodPhone_FormatValidation (0.33s)
=== RUN   TestAccPagerDutyUserContactMethodPhone_EnforceUpdateIfAlreadyExist
--- PASS: TestAccPagerDutyUserContactMethodPhone_EnforceUpdateIfAlreadyExist (29.00s)
=== RUN   TestAccPagerDutyUserContactMethodSMS_Basic
--- PASS: TestAccPagerDutyUserContactMethodSMS_Basic (28.66s)
=== RUN   TestAccPagerDutyUserContactMethodPhone_NoPermaDiffWhenOmittingCountryCode
--- PASS: TestAccPagerDutyUserContactMethodPhone_NoPermaDiffWhenOmittingCountryCode (21.20s)
PASS
ok      github.com/PagerDuty/terraform-provider-pagerduty/pagerdutyplugin       162.275s
```