### PR TITLE
Add `pagerduty_schedulev2` resource and data source (v3 Schedules API)

### DIFF
--- a/pagerduty/resource_pagerduty_schedule.go
+++ b/pagerduty/resource_pagerduty_schedule.go
@@ -18,10 +18,11 @@ import (
 
 func resourcePagerDutySchedule() *schema.Resource {
 	return &schema.Resource{
-		Create: resourcePagerDutyScheduleCreate,
-		Read:   resourcePagerDutyScheduleRead,
-		Update: resourcePagerDutyScheduleUpdate,
-		Delete: resourcePagerDutyScheduleDelete,
+		DeprecationMessage: "Use pagerduty_schedulev2 instead. pagerduty_schedule uses the legacy v1 API and will be removed in a future release.",
+		Create:             resourcePagerDutyScheduleCreate,
+		Read:               resourcePagerDutyScheduleRead,
+		Update:             resourcePagerDutyScheduleUpdate,
+		Delete:             resourcePagerDutyScheduleDelete,
 		CustomizeDiff: func(context context.Context, diff *schema.ResourceDiff, i interface{}) error {
 			ln := diff.Get("layer.#").(int)
 			for li := 0; li <= ln; li++ {

--- a/pagerdutyplugin/data_source_pagerduty_schedulev2.go
+++ b/pagerdutyplugin/data_source_pagerduty_schedulev2.go
@@ -1,0 +1,95 @@
+package pagerduty
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/PagerDuty/go-pagerduty"
+	"github.com/PagerDuty/terraform-provider-pagerduty/util"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+)
+
+type dataSourceScheduleV2 struct{ client *pagerduty.Client }
+
+var _ datasource.DataSourceWithConfigure = (*dataSourceScheduleV2)(nil)
+
+func (*dataSourceScheduleV2) Metadata(_ context.Context, _ datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = "pagerduty_schedulev2"
+}
+
+func (*dataSourceScheduleV2) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Use this data source to get information about a specific PagerDuty v3 schedule so that you can reference it in other resources.",
+		Attributes: map[string]schema.Attribute{
+			"id":   schema.StringAttribute{Computed: true, Description: "The ID of the schedule."},
+			"name": schema.StringAttribute{Required: true, Description: "The name of the schedule to search for."},
+		},
+	}
+}
+
+func (d *dataSourceScheduleV2) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	resp.Diagnostics.Append(ConfigurePagerdutyClient(&d.client, req.ProviderData)...)
+}
+
+func (d *dataSourceScheduleV2) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	log.Println("[INFO] Reading PagerDuty v3 schedule")
+
+	var searchName types.String
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("name"), &searchName)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	opts := pagerduty.ListSchedulesV3Options{Query: searchName.ValueString()}
+
+	var found *pagerduty.APIObject
+	err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
+		response, err := d.client.ListSchedulesV3(ctx, opts)
+		if err != nil {
+			if util.IsBadRequestError(err) {
+				return retry.NonRetryableError(err)
+			}
+			return retry.RetryableError(err)
+		}
+
+		for i, schedule := range response.Schedules {
+			if schedule.Summary == searchName.ValueString() {
+				found = &response.Schedules[i]
+				break
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error reading PagerDuty v3 schedule %s", searchName),
+			err.Error(),
+		)
+		return
+	}
+
+	if found == nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Unable to locate any v3 schedule with the name: %s", searchName),
+			"",
+		)
+		return
+	}
+
+	model := dataSourceScheduleV2Model{
+		ID:   types.StringValue(found.ID),
+		Name: types.StringValue(found.Summary),
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+}
+
+type dataSourceScheduleV2Model struct {
+	ID   types.String `tfsdk:"id"`
+	Name types.String `tfsdk:"name"`
+}

--- a/pagerdutyplugin/data_source_pagerduty_schedulev2_test.go
+++ b/pagerdutyplugin/data_source_pagerduty_schedulev2_test.go
@@ -1,0 +1,101 @@
+package pagerduty
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccDataSourcePagerDutyScheduleV2_Basic(t *testing.T) {
+	if v := os.Getenv("PAGERDUTY_ACC_SCHEDULE_V3"); v == "" {
+		t.Skip("PAGERDUTY_ACC_SCHEDULE_V3 must be set to run v3 schedule acceptance tests")
+	}
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.test", username)
+	scheduleName := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	effectiveSince := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	startTime := time.Now().UTC().Add(24*time.Hour).Format("2006-01-02") + "T09:00:00Z"
+	endTime := time.Now().UTC().Add(24*time.Hour).Format("2006-01-02") + "T17:00:00Z"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourcePagerDutyScheduleV2Config(username, email, scheduleName, effectiveSince, startTime, endTime),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourcePagerDutyScheduleV2("pagerduty_schedulev2.test", "data.pagerduty_schedulev2.by_name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourcePagerDutyScheduleV2(src, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		srcR := s.RootModule().Resources[src]
+		srcA := srcR.Primary.Attributes
+
+		r := s.RootModule().Resources[n]
+		if r == nil {
+			return fmt.Errorf("data source %s not found in state", n)
+		}
+		a := r.Primary.Attributes
+
+		if a["id"] == "" {
+			return fmt.Errorf("expected to get a v3 schedule ID from PagerDuty")
+		}
+
+		for _, att := range []string{"id", "name"} {
+			if a[att] != srcA[att] {
+				return fmt.Errorf("expected the v3 schedule %s to be: %s, but got: %s", att, srcA[att], a[att])
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccDataSourcePagerDutyScheduleV2Config(username, email, scheduleName, effectiveSince, startTime, endTime string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "test" {
+  name  = "%s"
+  email = "%s"
+}
+
+resource "pagerduty_schedulev2" "test" {
+  name        = "%s"
+  time_zone   = "America/New_York"
+  description = "Managed by Terraform"
+
+  rotation {
+    event {
+      name            = "Weekly On-Call"
+      start_time      = "%s"
+      end_time        = "%s"
+      effective_since = "%s"
+      recurrence      = ["RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"]
+
+      assignment_strategy {
+        type = "user_assignment_strategy"
+
+        member {
+          type    = "user_member"
+          user_id = pagerduty_user.test.id
+        }
+      }
+    }
+  }
+}
+
+data "pagerduty_schedulev2" "by_name" {
+  name = pagerduty_schedulev2.test.name
+}
+`, username, email, scheduleName, startTime, endTime, effectiveSince)
+}

--- a/pagerdutyplugin/provider.go
+++ b/pagerdutyplugin/provider.go
@@ -65,6 +65,7 @@ func (p *Provider) DataSources(_ context.Context) [](func() datasource.DataSourc
 		func() datasource.DataSource { return &dataSourceLicense{} },
 		func() datasource.DataSource { return &dataSourcePriority{} },
 		func() datasource.DataSource { return &dataSourceSchedule{} },
+		func() datasource.DataSource { return &dataSourceScheduleV2{} },
 		func() datasource.DataSource { return &dataSourceServiceCustomField{} },
 		func() datasource.DataSource { return &dataSourceServiceCustomFieldValue{} },
 		func() datasource.DataSource { return &dataSourceService{} },
@@ -99,6 +100,7 @@ func (p *Provider) Resources(_ context.Context) [](func() resource.Resource) {
 		func() resource.Resource { return &resourceUserNotificationRule{} },
 		func() resource.Resource { return &resourceUserContactMethod{} },
 		func() resource.Resource { return &resourceEnablement{} },
+		func() resource.Resource { return &resourceScheduleV2{} },
 	}
 }
 

--- a/pagerdutyplugin/resource_pagerduty_schedulev2.go
+++ b/pagerdutyplugin/resource_pagerduty_schedulev2.go
@@ -1,0 +1,1025 @@
+package pagerduty
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	pagerduty "github.com/PagerDuty/go-pagerduty"
+	"github.com/PagerDuty/terraform-provider-pagerduty/util"
+	"github.com/PagerDuty/terraform-provider-pagerduty/util/validate"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+)
+
+type resourceScheduleV2 struct{ client *pagerduty.Client }
+
+var (
+	_ resource.ResourceWithConfigure   = (*resourceScheduleV2)(nil)
+	_ resource.ResourceWithImportState = (*resourceScheduleV2)(nil)
+)
+
+func (r *resourceScheduleV2) Metadata(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "pagerduty_schedulev2"
+}
+
+func (r *resourceScheduleV2) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Use this resource to create and manage on-call schedules using the PagerDuty v3 Schedules API. This is the new version of pagerduty_schedule and supports flexible rotations with per-event assignment strategies.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"name": schema.StringAttribute{
+				Required:    true,
+				Description: "The name of the schedule.",
+			},
+			"time_zone": schema.StringAttribute{
+				Required:    true,
+				Description: "The time zone of the schedule (IANA format, e.g. 'America/New_York').",
+				Validators:  []validator.String{validate.ValidTimeZone()},
+			},
+			"description": schema.StringAttribute{
+				Optional:      true,
+				Computed:      true,
+				Description:   "A description of the schedule.",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"teams": schema.ListAttribute{
+				Optional:    true,
+				ElementType: types.StringType,
+				Description: "List of team IDs to associate with this schedule.",
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"rotation": schema.ListNestedBlock{
+				Description: "A rotation within the schedule. Each rotation can have multiple events defining on-call periods.",
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Computed:      true,
+							Description:   "The ID of the rotation.",
+							PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+						},
+					},
+					Blocks: map[string]schema.Block{
+						"event": schema.ListNestedBlock{
+							Description: "An event within the rotation defining an on-call period.",
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"id": schema.StringAttribute{
+										Computed:      true,
+										Description:   "The ID of the event.",
+										PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+									},
+									"name": schema.StringAttribute{
+										Required:    true,
+										Description: "The name of the event.",
+									},
+									"start_time": schema.StringAttribute{
+										Required:    true,
+										Description: "The shift start time with timezone offset (ISO-8601 format, e.g. '2024-01-01T09:00:00-05:00').",
+									},
+									"end_time": schema.StringAttribute{
+										Required:    true,
+										Description: "The shift end time with timezone offset (ISO-8601 format, e.g. '2024-01-01T17:00:00-05:00').",
+									},
+									"effective_since": schema.StringAttribute{
+										Required:    true,
+										Description: "When this event configuration starts producing shifts (ISO-8601 UTC). Must be a future time; the API will adjust past times to the current time.",
+									},
+									"effective_until": schema.StringAttribute{
+										Optional:    true,
+										Description: "When this event configuration stops producing shifts (ISO-8601 UTC). Null or omitted means indefinite.",
+									},
+									"recurrence": schema.ListAttribute{
+										Required:    true,
+										Description: "List of RRULE strings defining the recurrence pattern (RFC 5545, e.g. 'RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR').",
+										ElementType: types.StringType,
+										Validators: []validator.List{
+											listvalidator.SizeAtLeast(1),
+										},
+									},
+								},
+								Blocks: map[string]schema.Block{
+									"assignment_strategy": schema.ListNestedBlock{
+										Description: "Defines how on-call responsibility is assigned for this event.",
+										NestedObject: schema.NestedBlockObject{
+											Attributes: map[string]schema.Attribute{
+												"type": schema.StringAttribute{
+													Required:    true,
+													Description: "The assignment strategy type. Use 'rotating_member_assignment_strategy' for user-based rotation, or 'every_member_assignment_strategy' for all-hands coverage.",
+													Validators: []validator.String{
+														stringvalidator.OneOf("rotating_member_assignment_strategy", "every_member_assignment_strategy"),
+													},
+												},
+												"shifts_per_member": schema.Int64Attribute{
+													Optional:    true,
+													Description: "Number of shifts per member per recurrence cycle. Defaults to 1 for 'rotating_member_assignment_strategy' when not set.",
+												},
+											},
+											Blocks: map[string]schema.Block{
+												"member": schema.ListNestedBlock{
+													Description: "A member to assign for on-call duty.",
+													NestedObject: schema.NestedBlockObject{
+														Attributes: map[string]schema.Attribute{
+															"type": schema.StringAttribute{
+																Required:    true,
+																Description: "The member type.",
+																Validators: []validator.String{
+																	stringvalidator.OneOf("user_member", "empty_member"),
+																},
+															},
+															"user_id": schema.StringAttribute{
+																Optional:    true,
+																Description: "The obfuscated user ID. Required when type is 'user_member'.",
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r *resourceScheduleV2) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	resp.Diagnostics.Append(ConfigurePagerdutyClient(&r.client, req.ProviderData)...)
+}
+
+func (r *resourceScheduleV2) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var model resourceScheduleV2Model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	scheduleInput, d := buildScheduleV3Input(ctx, &model)
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	log.Printf("[INFO] Creating PagerDuty v3 schedule: %s", scheduleInput.Name)
+
+	var scheduleID string
+	err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
+		schedule, err := r.client.CreateScheduleV3(ctx, scheduleInput)
+		if err != nil {
+			if util.IsBadRequestError(err) {
+				return retry.NonRetryableError(err)
+			}
+			return retry.RetryableError(err)
+		}
+		scheduleID = schedule.ID
+		return nil
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating PagerDuty v3 schedule", err.Error())
+		return
+	}
+
+	model.ID = types.StringValue(scheduleID)
+
+	// Create rotations and their events
+	resp.Diagnostics.Append(r.createRotationsAndEvents(ctx, scheduleID, model.TimeZone.ValueString(), model.Rotations, &model.Rotations)...)
+	if resp.Diagnostics.HasError() {
+		// Attempt cleanup on partial failure
+		_ = r.client.DeleteScheduleV3(ctx, scheduleID)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+}
+
+func (r *resourceScheduleV2) createRotationsAndEvents(ctx context.Context, scheduleID, scheduleTimeZone string, desired []rotationV2Model, result *[]rotationV2Model) diag.Diagnostics {
+	var diags diag.Diagnostics
+	updatedRotations := make([]rotationV2Model, 0, len(desired))
+
+	for i, rotModel := range desired {
+		var rotationID string
+		err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
+			rotation, err := r.client.CreateRotationV3(ctx, scheduleID)
+			if err != nil {
+				if util.IsBadRequestError(err) {
+					return retry.NonRetryableError(err)
+				}
+				return retry.RetryableError(err)
+			}
+			rotationID = rotation.ID
+			return nil
+		})
+		if err != nil {
+			diags.AddError(fmt.Sprintf("Error creating rotation %d for v3 schedule %s", i, scheduleID), err.Error())
+			return diags
+		}
+
+		rotModel.ID = types.StringValue(rotationID)
+		updatedEvents := make([]eventV2Model, 0, len(rotModel.Events))
+
+		for j, evtModel := range rotModel.Events {
+			eventInput, d := buildEventV3Input(ctx, &evtModel, scheduleTimeZone)
+			diags.Append(d...)
+			if diags.HasError() {
+				return diags
+			}
+
+			var createdEvent *pagerduty.EventV3
+			err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
+				e, err := r.client.CreateEventV3(ctx, scheduleID, rotationID, *eventInput)
+				if err != nil {
+					if util.IsBadRequestError(err) {
+						return retry.NonRetryableError(err)
+					}
+					return retry.RetryableError(err)
+				}
+				createdEvent = e
+				return nil
+			})
+			if err != nil {
+				diags.AddError(fmt.Sprintf("Error creating event %d in rotation %s for v3 schedule %s", j, rotationID, scheduleID), err.Error())
+				return diags
+			}
+
+			flattened := flattenEventV3(ctx, createdEvent, &diags)
+			// The API normalizes past effective_since dates to current time. Preserve
+			// the config value so the post-apply state matches the plan.
+			flattened.EffectiveSince = evtModel.EffectiveSince
+			preserveShiftsPerMember(&evtModel, &flattened)
+			updatedEvents = append(updatedEvents, flattened)
+		}
+
+		rotModel.Events = updatedEvents
+		updatedRotations = append(updatedRotations, rotModel)
+	}
+
+	*result = updatedRotations
+	return diags
+}
+
+func (r *resourceScheduleV2) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state resourceScheduleV2Model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	scheduleID := state.ID.ValueString()
+	log.Printf("[INFO] Reading PagerDuty v3 schedule: %s", scheduleID)
+
+	var schedule *pagerduty.ScheduleV3
+	err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
+		s, err := r.client.GetScheduleV3(ctx, scheduleID)
+		if err != nil {
+			if util.IsBadRequestError(err) {
+				return retry.NonRetryableError(err)
+			}
+			if util.IsNotFoundError(err) {
+				return nil
+			}
+			return retry.RetryableError(err)
+		}
+		schedule = s
+		return nil
+	})
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("Error reading PagerDuty v3 schedule %s", scheduleID), err.Error())
+		return
+	}
+
+	if schedule == nil {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	// If the API doesn't return events inline with rotations, fetch them separately
+	if len(schedule.Rotations) > 0 && allRotationsHaveNoEvents(schedule.Rotations) {
+		for i, rot := range schedule.Rotations {
+			fullRot, err := r.client.GetRotationV3(ctx, scheduleID, rot.ID)
+			if err == nil && fullRot != nil {
+				schedule.Rotations[i].Events = fullRot.Events
+			}
+		}
+	}
+
+	updatedState := flattenScheduleV3(ctx, schedule, state.Rotations, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &updatedState)...)
+}
+
+func (r *resourceScheduleV2) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan, state resourceScheduleV2Model
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	scheduleID := state.ID.ValueString()
+	log.Printf("[INFO] Updating PagerDuty v3 schedule: %s", scheduleID)
+
+	// Update schedule metadata if changed
+	if !plan.Name.Equal(state.Name) || !plan.TimeZone.Equal(state.TimeZone) || !plan.Description.Equal(state.Description) || !plan.Teams.Equal(state.Teams) {
+		scheduleInput, d := buildScheduleV3Input(ctx, &plan)
+		resp.Diagnostics.Append(d...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
+			_, err := r.client.UpdateScheduleV3(ctx, scheduleID, scheduleInput)
+			if err != nil {
+				if util.IsBadRequestError(err) {
+					return retry.NonRetryableError(err)
+				}
+				return retry.RetryableError(err)
+			}
+			return nil
+		})
+		if err != nil {
+			resp.Diagnostics.AddError(fmt.Sprintf("Error updating PagerDuty v3 schedule %s", scheduleID), err.Error())
+			return
+		}
+	}
+
+	// Reconcile rotations: compare plan vs state by position
+	resp.Diagnostics.Append(r.reconcileRotations(ctx, scheduleID, plan.TimeZone.ValueString(), plan.Rotations, state.Rotations, &plan.Rotations)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	plan.ID = state.ID
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *resourceScheduleV2) reconcileRotations(ctx context.Context, scheduleID, scheduleTimeZone string, desired, current []rotationV2Model, result *[]rotationV2Model) diag.Diagnostics {
+	var diags diag.Diagnostics
+	updatedRotations := make([]rotationV2Model, 0, len(desired))
+
+	// Handle rotations that exist in both desired and current (matched by position)
+	minLen := len(desired)
+	if len(current) < minLen {
+		minLen = len(current)
+	}
+
+	for i := 0; i < minLen; i++ {
+		desiredRot := desired[i]
+		currentRot := current[i]
+		rotationID := currentRot.ID.ValueString()
+
+		desiredRot.ID = currentRot.ID
+
+		// Reconcile events within this rotation
+		diags.Append(r.reconcileEvents(ctx, scheduleID, rotationID, scheduleTimeZone, desiredRot.Events, currentRot.Events, &desiredRot.Events)...)
+		if diags.HasError() {
+			return diags
+		}
+
+		updatedRotations = append(updatedRotations, desiredRot)
+	}
+
+	// Delete extra rotations that are no longer needed (from the end)
+	for i := minLen; i < len(current); i++ {
+		rotationID := current[i].ID.ValueString()
+		err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
+			err := r.client.DeleteRotationV3(ctx, scheduleID, rotationID)
+			if err != nil {
+				if util.IsBadRequestError(err) || util.IsNotFoundError(err) {
+					return retry.NonRetryableError(err)
+				}
+				return retry.RetryableError(err)
+			}
+			return nil
+		})
+		if err != nil && !util.IsNotFoundError(err) {
+			diags.AddError(fmt.Sprintf("Error deleting rotation %s from v3 schedule %s", rotationID, scheduleID), err.Error())
+			return diags
+		}
+	}
+
+	// Create new rotations that are needed beyond what currently exists
+	if len(desired) > len(current) {
+		newRotations := desired[len(current):]
+		newRotationResults := make([]rotationV2Model, 0, len(newRotations))
+		diags.Append(r.createRotationsAndEvents(ctx, scheduleID, scheduleTimeZone, newRotations, &newRotationResults)...)
+		if diags.HasError() {
+			return diags
+		}
+		updatedRotations = append(updatedRotations, newRotationResults...)
+	}
+
+	*result = updatedRotations
+	return diags
+}
+
+func (r *resourceScheduleV2) reconcileEvents(ctx context.Context, scheduleID, rotationID, scheduleTimeZone string, desired, current []eventV2Model, result *[]eventV2Model) diag.Diagnostics {
+	var diags diag.Diagnostics
+	updatedEvents := make([]eventV2Model, 0, len(desired))
+
+	minLen := len(desired)
+	if len(current) < minLen {
+		minLen = len(current)
+	}
+
+	// Update events that exist in both (matched by position)
+	for i := 0; i < minLen; i++ {
+		desiredEvt := desired[i]
+		currentEvt := current[i]
+		eventID := currentEvt.ID.ValueString()
+
+		// Skip the API call when nothing in this event has changed. This avoids
+		// sending effective_since on active events, which the API rejects (400).
+		if eventModelsEqual(ctx, desiredEvt, currentEvt) {
+			updatedEvents = append(updatedEvents, currentEvt)
+			continue
+		}
+
+		// Active events (effective_since in the past) cannot be modified via PUT —
+		// the API rejects any payload containing start_time, end_time, or
+		// effective_since for active events, regardless of the value sent.
+		// The only reliable strategy is DELETE + CREATE.
+		if isEventActive(currentEvt) {
+			// Delete the current active event.
+			delErr := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
+				err := r.client.DeleteEventV3(ctx, scheduleID, rotationID, eventID)
+				if err != nil {
+					if util.IsBadRequestError(err) || util.IsNotFoundError(err) {
+						return retry.NonRetryableError(err)
+					}
+					return retry.RetryableError(err)
+				}
+				return nil
+			})
+			if delErr != nil && !util.IsNotFoundError(delErr) {
+				diags.AddError(fmt.Sprintf("Error deleting active event %s in rotation %s", eventID, rotationID), delErr.Error())
+				return diags
+			}
+
+			// Create a replacement starting now with the desired configuration.
+			now := time.Now().UTC().Format(time.RFC3339)
+			replacementEvt := desiredEvt
+			replacementEvt.EffectiveSince = types.StringValue(now)
+			eventInput, d := buildEventV3Input(ctx, &replacementEvt, scheduleTimeZone)
+			diags.Append(d...)
+			if diags.HasError() {
+				return diags
+			}
+
+			var createdEvent *pagerduty.EventV3
+			createErr := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
+				e, err := r.client.CreateEventV3(ctx, scheduleID, rotationID, *eventInput)
+				if err != nil {
+					if util.IsBadRequestError(err) {
+						return retry.NonRetryableError(err)
+					}
+					return retry.RetryableError(err)
+				}
+				createdEvent = e
+				return nil
+			})
+			if createErr != nil {
+				diags.AddError(fmt.Sprintf("Error creating replacement event in rotation %s", rotationID), createErr.Error())
+				return diags
+			}
+
+			flattened := flattenEventV3(ctx, createdEvent, &diags)
+			if diags.HasError() {
+				return diags
+			}
+			// Preserve the user's configured effective_since in state so subsequent
+			// plans do not show a perpetual diff.
+			flattened.EffectiveSince = desiredEvt.EffectiveSince
+			preserveShiftsPerMember(&desiredEvt, &flattened)
+			updatedEvents = append(updatedEvents, flattened)
+			continue
+		}
+
+		// Future event: all fields can be updated normally.
+		var d diag.Diagnostics
+		var eventInput *pagerduty.EventV3
+		eventInput, d = buildEventV3Input(ctx, &desiredEvt, scheduleTimeZone)
+		diags.Append(d...)
+		if diags.HasError() {
+			return diags
+		}
+
+		var updatedEvent *pagerduty.EventV3
+		err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
+			e, err := r.client.UpdateEventV3(ctx, scheduleID, rotationID, eventID, *eventInput)
+			if err != nil {
+				if util.IsBadRequestError(err) {
+					return retry.NonRetryableError(err)
+				}
+				return retry.RetryableError(err)
+			}
+			updatedEvent = e
+			return nil
+		})
+		if err != nil {
+			diags.AddError(fmt.Sprintf("Error updating event %s in rotation %s", eventID, rotationID), err.Error())
+			return diags
+		}
+
+		flattened := flattenEventV3(ctx, updatedEvent, &diags)
+		if diags.HasError() {
+			return diags
+		}
+		// The API normalizes past effective_since dates to current time. Preserve
+		// the plan value so the post-apply state matches the plan.
+		flattened.EffectiveSince = desiredEvt.EffectiveSince
+		preserveShiftsPerMember(&desiredEvt, &flattened)
+		updatedEvents = append(updatedEvents, flattened)
+	}
+
+	// Delete extra events no longer needed
+	for i := minLen; i < len(current); i++ {
+		eventID := current[i].ID.ValueString()
+		err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
+			err := r.client.DeleteEventV3(ctx, scheduleID, rotationID, eventID)
+			if err != nil {
+				if util.IsBadRequestError(err) || util.IsNotFoundError(err) {
+					return retry.NonRetryableError(err)
+				}
+				return retry.RetryableError(err)
+			}
+			return nil
+		})
+		if err != nil && !util.IsNotFoundError(err) {
+			diags.AddError(fmt.Sprintf("Error deleting event %s from rotation %s", eventID, rotationID), err.Error())
+			return diags
+		}
+	}
+
+	// Create new events that are needed beyond what currently exists
+	for i := minLen; i < len(desired); i++ {
+		desiredEvt := desired[i]
+		eventInput, d := buildEventV3Input(ctx, &desiredEvt, scheduleTimeZone)
+		diags.Append(d...)
+		if diags.HasError() {
+			return diags
+		}
+
+		var createdEvent *pagerduty.EventV3
+		err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
+			e, err := r.client.CreateEventV3(ctx, scheduleID, rotationID, *eventInput)
+			if err != nil {
+				if util.IsBadRequestError(err) {
+					return retry.NonRetryableError(err)
+				}
+				return retry.RetryableError(err)
+			}
+			createdEvent = e
+			return nil
+		})
+		if err != nil {
+			diags.AddError(fmt.Sprintf("Error creating event %d in rotation %s", i, rotationID), err.Error())
+			return diags
+		}
+
+		flattened := flattenEventV3(ctx, createdEvent, &diags)
+		if diags.HasError() {
+			return diags
+		}
+		// The API normalizes past effective_since dates to current time. Preserve
+		// the plan value so the post-apply state matches the plan.
+		flattened.EffectiveSince = desiredEvt.EffectiveSince
+		preserveShiftsPerMember(&desiredEvt, &flattened)
+		updatedEvents = append(updatedEvents, flattened)
+	}
+
+	*result = updatedEvents
+	return diags
+}
+
+func (r *resourceScheduleV2) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state resourceScheduleV2Model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	scheduleID := state.ID.ValueString()
+	log.Printf("[INFO] Deleting PagerDuty v3 schedule: %s", scheduleID)
+
+	err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
+		err := r.client.DeleteScheduleV3(ctx, scheduleID)
+		if err != nil {
+			if util.IsNotFoundError(err) {
+				return nil
+			}
+			if util.IsBadRequestError(err) {
+				return retry.NonRetryableError(err)
+			}
+			return retry.RetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("Error deleting PagerDuty v3 schedule %s", scheduleID), err.Error())
+		return
+	}
+
+	resp.State.RemoveResource(ctx)
+}
+
+func (r *resourceScheduleV2) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	scheduleID := req.ID
+
+	var schedule *pagerduty.ScheduleV3
+	err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
+		s, err := r.client.GetScheduleV3(ctx, scheduleID)
+		if err != nil {
+			if util.IsBadRequestError(err) {
+				return retry.NonRetryableError(err)
+			}
+			return retry.RetryableError(err)
+		}
+		schedule = s
+		return nil
+	})
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("Error importing PagerDuty v3 schedule %s", scheduleID), err.Error())
+		return
+	}
+
+	// Fetch events for each rotation if not included inline
+	if len(schedule.Rotations) > 0 && allRotationsHaveNoEvents(schedule.Rotations) {
+		for i, rot := range schedule.Rotations {
+			fullRot, err := r.client.GetRotationV3(ctx, scheduleID, rot.ID)
+			if err == nil && fullRot != nil {
+				schedule.Rotations[i].Events = fullRot.Events
+			}
+		}
+	}
+
+	state := flattenScheduleV3(ctx, schedule, nil, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+// --- Model Types ---
+
+type resourceScheduleV2Model struct {
+	ID          types.String      `tfsdk:"id"`
+	Name        types.String      `tfsdk:"name"`
+	TimeZone    types.String      `tfsdk:"time_zone"`
+	Description types.String      `tfsdk:"description"`
+	Teams       types.List        `tfsdk:"teams"`
+	Rotations   []rotationV2Model `tfsdk:"rotation"`
+}
+
+type rotationV2Model struct {
+	ID     types.String   `tfsdk:"id"`
+	Events []eventV2Model `tfsdk:"event"`
+}
+
+type eventV2Model struct {
+	ID                 types.String                `tfsdk:"id"`
+	Name               types.String                `tfsdk:"name"`
+	StartTime          types.String                `tfsdk:"start_time"`
+	EndTime            types.String                `tfsdk:"end_time"`
+	EffectiveSince     types.String                `tfsdk:"effective_since"`
+	EffectiveUntil     types.String                `tfsdk:"effective_until"`
+	Recurrence         types.List                  `tfsdk:"recurrence"`
+	AssignmentStrategy []assignmentStrategyV2Model `tfsdk:"assignment_strategy"`
+}
+
+type assignmentStrategyV2Model struct {
+	Type            types.String    `tfsdk:"type"`
+	ShiftsPerMember types.Int64     `tfsdk:"shifts_per_member"`
+	Members         []memberV2Model `tfsdk:"member"`
+}
+
+type memberV2Model struct {
+	Type   types.String `tfsdk:"type"`
+	UserID types.String `tfsdk:"user_id"`
+}
+
+// --- Build / Flatten Helpers ---
+
+func buildScheduleV3Input(ctx context.Context, model *resourceScheduleV2Model) (pagerduty.ScheduleV3Input, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	input := pagerduty.ScheduleV3Input{
+		Name:        model.Name.ValueString(),
+		TimeZone:    model.TimeZone.ValueString(),
+		Description: model.Description.ValueString(),
+	}
+	if !model.Teams.IsNull() && !model.Teams.IsUnknown() {
+		var teamIDs []string
+		diags.Append(model.Teams.ElementsAs(ctx, &teamIDs, false)...)
+		for _, id := range teamIDs {
+			input.Teams = append(input.Teams, pagerduty.TeamReferenceV3{ID: id, Type: "team_reference"})
+		}
+	}
+	return input, diags
+}
+
+func buildEventV3Input(ctx context.Context, model *eventV2Model, scheduleTimeZone string) (*pagerduty.EventV3, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	var recurrence []string
+	diags.Append(model.Recurrence.ElementsAs(ctx, &recurrence, false)...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	evt := &pagerduty.EventV3{
+		Name:           model.Name.ValueString(),
+		StartTime:      pagerduty.EventTimeV3{DateTime: model.StartTime.ValueString(), TimeZone: scheduleTimeZone},
+		EndTime:        pagerduty.EventTimeV3{DateTime: model.EndTime.ValueString(), TimeZone: scheduleTimeZone},
+		EffectiveSince: model.EffectiveSince.ValueString(),
+		Recurrence:     recurrence,
+	}
+
+	if !model.EffectiveUntil.IsNull() && !model.EffectiveUntil.IsUnknown() && model.EffectiveUntil.ValueString() != "" {
+		v := model.EffectiveUntil.ValueString()
+		evt.EffectiveUntil = &v
+	}
+
+	if len(model.AssignmentStrategy) > 0 {
+		as := model.AssignmentStrategy[0]
+		strategy := pagerduty.AssignmentStrategyV3{
+			Type: as.Type.ValueString(),
+		}
+		if !as.ShiftsPerMember.IsNull() && !as.ShiftsPerMember.IsUnknown() {
+			v := int(as.ShiftsPerMember.ValueInt64())
+			strategy.ShiftsPerMember = &v
+		} else if as.Type.ValueString() == "rotating_member_assignment_strategy" {
+			one := 1
+			strategy.ShiftsPerMember = &one
+		}
+		for _, m := range as.Members {
+			member := pagerduty.MemberV3{
+				Type: m.Type.ValueString(),
+			}
+			if !m.UserID.IsNull() && !m.UserID.IsUnknown() && m.UserID.ValueString() != "" {
+				uid := m.UserID.ValueString()
+				member.UserID = &uid
+			}
+			strategy.Members = append(strategy.Members, member)
+		}
+		evt.AssignmentStrategy = strategy
+	}
+
+	return evt, diags
+}
+
+func flattenScheduleV3(ctx context.Context, schedule *pagerduty.ScheduleV3, stateRotations []rotationV2Model, diags *diag.Diagnostics) resourceScheduleV2Model {
+	// The v3 API normalizes "UTC" to "Etc/UTC". Normalize back to prevent perpetual plan diffs.
+	tz := schedule.TimeZone
+	if tz == "Etc/UTC" {
+		tz = "UTC"
+	}
+
+	teamVals := make([]attr.Value, 0, len(schedule.Teams))
+	for _, t := range schedule.Teams {
+		teamVals = append(teamVals, types.StringValue(t.ID))
+	}
+	var teamsList types.List
+	if len(teamVals) == 0 {
+		teamsList = types.ListNull(types.StringType)
+	} else {
+		var d diag.Diagnostics
+		teamsList, d = types.ListValue(types.StringType, teamVals)
+		diags.Append(d...)
+	}
+
+	model := resourceScheduleV2Model{
+		ID:          types.StringValue(schedule.ID),
+		Name:        types.StringValue(schedule.Name),
+		TimeZone:    types.StringValue(tz),
+		Description: types.StringValue(schedule.Description),
+		Teams:       teamsList,
+	}
+
+	rotations := make([]rotationV2Model, 0, len(schedule.Rotations))
+	for i, rot := range schedule.Rotations {
+		rotModel := rotationV2Model{
+			ID: types.StringValue(rot.ID),
+		}
+
+		// Try to find the matching state rotation to preserve event ordering context
+		var stateEvents []eventV2Model
+		if i < len(stateRotations) {
+			stateEvents = stateRotations[i].Events
+		}
+
+		events := make([]eventV2Model, 0, len(rot.Events))
+		for j, evt := range rot.Events {
+			evtModel := flattenEventV3(ctx, &evt, diags)
+			if diags.HasError() {
+				return model
+			}
+
+			// The v3 API normalizes start_time/end_time to UTC. Preserve the state value
+			// when it represents the same instant to prevent perpetual diffs.
+			if j < len(stateEvents) {
+				st := stateEvents[j]
+				if !st.StartTime.IsNull() && semanticallyEqualTime(st.StartTime.ValueString(), evtModel.StartTime.ValueString()) {
+					evtModel.StartTime = st.StartTime
+				}
+				if !st.EndTime.IsNull() && semanticallyEqualTime(st.EndTime.ValueString(), evtModel.EndTime.ValueString()) {
+					evtModel.EndTime = st.EndTime
+				}
+				// The API normalizes past effective_since dates to current time. Preserve
+				// the state value to prevent perpetual plan diffs on subsequent refresh.
+				if !st.EffectiveSince.IsNull() && !st.EffectiveSince.IsUnknown() {
+					evtModel.EffectiveSince = st.EffectiveSince
+				}
+				// If prior state had shifts_per_member = null (user didn't configure it),
+				// keep null so the API-returned default doesn't cause a perpetual diff.
+				if len(st.AssignmentStrategy) > 0 && len(evtModel.AssignmentStrategy) > 0 &&
+					st.AssignmentStrategy[0].ShiftsPerMember.IsNull() {
+					evtModel.AssignmentStrategy[0].ShiftsPerMember = types.Int64Null()
+				}
+			}
+
+			events = append(events, evtModel)
+		}
+
+		rotModel.Events = events
+		rotations = append(rotations, rotModel)
+	}
+
+	model.Rotations = rotations
+	return model
+}
+
+func flattenEventV3(ctx context.Context, evt *pagerduty.EventV3, diags *diag.Diagnostics) eventV2Model {
+	recurrenceVals := make([]attr.Value, 0, len(evt.Recurrence))
+	for _, r := range evt.Recurrence {
+		recurrenceVals = append(recurrenceVals, types.StringValue(r))
+	}
+	recurrenceList, d := types.ListValue(types.StringType, recurrenceVals)
+	diags.Append(d...)
+
+	evtModel := eventV2Model{
+		ID:             types.StringValue(evt.ID),
+		Name:           types.StringValue(evt.Name),
+		StartTime:      types.StringValue(evt.StartTime.DateTime),
+		EndTime:        types.StringValue(evt.EndTime.DateTime),
+		EffectiveSince: types.StringValue(evt.EffectiveSince),
+		EffectiveUntil: types.StringNull(),
+		Recurrence:     recurrenceList,
+	}
+
+	if evt.EffectiveUntil != nil && *evt.EffectiveUntil != "" {
+		evtModel.EffectiveUntil = types.StringValue(*evt.EffectiveUntil)
+	}
+
+	if evt.AssignmentStrategy.Type != "" {
+		as := assignmentStrategyV2Model{
+			Type:            types.StringValue(evt.AssignmentStrategy.Type),
+			ShiftsPerMember: types.Int64Null(),
+		}
+		if evt.AssignmentStrategy.ShiftsPerMember != nil {
+			as.ShiftsPerMember = types.Int64Value(int64(*evt.AssignmentStrategy.ShiftsPerMember))
+		}
+		members := make([]memberV2Model, 0, len(evt.AssignmentStrategy.Members))
+		for _, m := range evt.AssignmentStrategy.Members {
+			mem := memberV2Model{
+				Type:   types.StringValue(m.Type),
+				UserID: types.StringNull(),
+			}
+			if m.UserID != nil && *m.UserID != "" {
+				mem.UserID = types.StringValue(*m.UserID)
+			}
+			members = append(members, mem)
+		}
+		as.Members = members
+		evtModel.AssignmentStrategy = []assignmentStrategyV2Model{as}
+	}
+
+	return evtModel
+}
+
+// isEventActive returns true when an event's effective_since is in the past,
+// meaning the API will only allow effective_until to be modified.
+func isEventActive(evt eventV2Model) bool {
+	t, err := time.Parse(time.RFC3339, evt.EffectiveSince.ValueString())
+	if err != nil {
+		return false
+	}
+	return time.Now().UTC().After(t)
+}
+
+// eventsDifferBeyondEffectiveUntil returns true when the two events differ in
+// any field other than effective_until.
+func eventsDifferBeyondEffectiveUntil(ctx context.Context, a, b eventV2Model) bool {
+	if !a.Name.Equal(b.Name) || !a.EffectiveSince.Equal(b.EffectiveSince) || !a.Recurrence.Equal(b.Recurrence) {
+		return true
+	}
+	if !semanticallyEqualTime(a.StartTime.ValueString(), b.StartTime.ValueString()) ||
+		!semanticallyEqualTime(a.EndTime.ValueString(), b.EndTime.ValueString()) {
+		return true
+	}
+	if len(a.AssignmentStrategy) != len(b.AssignmentStrategy) {
+		return true
+	}
+	for i := range a.AssignmentStrategy {
+		as, bs := a.AssignmentStrategy[i], b.AssignmentStrategy[i]
+		if !as.Type.Equal(bs.Type) || !as.ShiftsPerMember.Equal(bs.ShiftsPerMember) {
+			return true
+		}
+		if len(as.Members) != len(bs.Members) {
+			return true
+		}
+		for j := range as.Members {
+			if !as.Members[j].Type.Equal(bs.Members[j].Type) || !as.Members[j].UserID.Equal(bs.Members[j].UserID) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// eventModelsEqual returns true when two event models are identical in all
+// user-configurable fields, so the API update can be safely skipped.
+func eventModelsEqual(ctx context.Context, a, b eventV2Model) bool {
+	if !a.Name.Equal(b.Name) ||
+		!a.EffectiveSince.Equal(b.EffectiveSince) ||
+		!a.EffectiveUntil.Equal(b.EffectiveUntil) ||
+		!a.Recurrence.Equal(b.Recurrence) {
+		return false
+	}
+	if !semanticallyEqualTime(a.StartTime.ValueString(), b.StartTime.ValueString()) ||
+		!semanticallyEqualTime(a.EndTime.ValueString(), b.EndTime.ValueString()) {
+		return false
+	}
+	if len(a.AssignmentStrategy) != len(b.AssignmentStrategy) {
+		return false
+	}
+	for i := range a.AssignmentStrategy {
+		as, bs := a.AssignmentStrategy[i], b.AssignmentStrategy[i]
+		if !as.Type.Equal(bs.Type) || !as.ShiftsPerMember.Equal(bs.ShiftsPerMember) {
+			return false
+		}
+		if len(as.Members) != len(bs.Members) {
+			return false
+		}
+		for j := range as.Members {
+			if !as.Members[j].Type.Equal(bs.Members[j].Type) ||
+				!as.Members[j].UserID.Equal(bs.Members[j].UserID) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// allRotationsHaveNoEvents returns true when all rotations lack event data,
+// indicating the API may not have included events in the schedule response.
+func allRotationsHaveNoEvents(rotations []pagerduty.RotationV3) bool {
+	for _, r := range rotations {
+		if len(r.Events) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// preserveShiftsPerMember copies the config's shifts_per_member intent from
+// desired into flattened. Because the provider defaults shifts_per_member to 1
+// when the user omits it for rotating_member_assignment_strategy, the API always
+// returns 1 — but the plan says null (user didn't set it). Overwriting the
+// flattened value with the desired value keeps state in sync with config intent
+// and prevents "provider produced inconsistent result" errors.
+func preserveShiftsPerMember(desired, flattened *eventV2Model) {
+	if len(desired.AssignmentStrategy) > 0 && len(flattened.AssignmentStrategy) > 0 {
+		flattened.AssignmentStrategy[0].ShiftsPerMember = desired.AssignmentStrategy[0].ShiftsPerMember
+	}
+}
+
+// semanticallyEqualTime returns true if two RFC3339 time strings represent the same instant.
+// Used to prevent perpetual plan diffs when the v3 API normalizes times to UTC.
+func semanticallyEqualTime(a, b string) bool {
+	ta, errA := time.Parse(time.RFC3339, a)
+	tb, errB := time.Parse(time.RFC3339, b)
+	if errA != nil || errB != nil {
+		return false
+	}
+	return ta.Equal(tb)
+}

--- a/pagerdutyplugin/resource_pagerduty_schedulev2_test.go
+++ b/pagerdutyplugin/resource_pagerduty_schedulev2_test.go
@@ -1,0 +1,621 @@
+package pagerduty
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccPagerDutyScheduleV2_Basic(t *testing.T) {
+	if v := os.Getenv("PAGERDUTY_ACC_SCHEDULE_V3"); v == "" {
+		t.Skip("PAGERDUTY_ACC_SCHEDULE_V3 must be set to run v3 schedule acceptance tests")
+	}
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.test", username)
+	scheduleName := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	// Use times far enough in the future to avoid effective_since adjustment
+	effectiveSince := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	startTime := time.Now().UTC().Add(24*time.Hour).Format("2006-01-02") + "T09:00:00Z"
+	endTime := time.Now().UTC().Add(24*time.Hour).Format("2006-01-02") + "T17:00:00Z"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(),
+		CheckDestroy:             testAccCheckPagerDutyScheduleV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPagerDutyScheduleV2Config(username, email, scheduleName, effectiveSince, startTime, endTime),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyScheduleV2Exists("pagerduty_schedulev2.test"),
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "name", scheduleName),
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "time_zone", "America/New_York"),
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "description", "Managed by Terraform"),
+					resource.TestCheckResourceAttrSet("pagerduty_schedulev2.test", "id"),
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "rotation.#", "1"),
+					resource.TestCheckResourceAttrSet("pagerduty_schedulev2.test", "rotation.0.id"),
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "rotation.0.event.#", "1"),
+					resource.TestCheckResourceAttrSet("pagerduty_schedulev2.test", "rotation.0.event.0.id"),
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "rotation.0.event.0.name", "Weekly On-Call"),
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "rotation.0.event.0.recurrence.#", "1"),
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "rotation.0.event.0.assignment_strategy.#", "1"),
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "rotation.0.event.0.assignment_strategy.0.type", "rotating_member_assignment_strategy"),
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "rotation.0.event.0.assignment_strategy.0.member.#", "1"),
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "rotation.0.event.0.assignment_strategy.0.member.0.type", "user_member"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPagerDutyScheduleV2_Update(t *testing.T) {
+	if v := os.Getenv("PAGERDUTY_ACC_SCHEDULE_V3"); v == "" {
+		t.Skip("PAGERDUTY_ACC_SCHEDULE_V3 must be set to run v3 schedule acceptance tests")
+	}
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.test", username)
+	scheduleName := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	scheduleNameUpdated := fmt.Sprintf("tf-%s-updated", acctest.RandString(5))
+
+	effectiveSince := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	startTime := time.Now().UTC().Add(24*time.Hour).Format("2006-01-02") + "T09:00:00Z"
+	endTime := time.Now().UTC().Add(24*time.Hour).Format("2006-01-02") + "T17:00:00Z"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(),
+		CheckDestroy:             testAccCheckPagerDutyScheduleV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPagerDutyScheduleV2Config(username, email, scheduleName, effectiveSince, startTime, endTime),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyScheduleV2Exists("pagerduty_schedulev2.test"),
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "name", scheduleName),
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "time_zone", "America/New_York"),
+				),
+			},
+			{
+				Config: testAccPagerDutyScheduleV2ConfigUpdated(username, email, scheduleNameUpdated, effectiveSince, startTime, endTime),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyScheduleV2Exists("pagerduty_schedulev2.test"),
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "name", scheduleNameUpdated),
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "time_zone", "America/Los_Angeles"),
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "description", "Updated by Terraform"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPagerDutyScheduleV2_MultipleRotations(t *testing.T) {
+	if v := os.Getenv("PAGERDUTY_ACC_SCHEDULE_V3"); v == "" {
+		t.Skip("PAGERDUTY_ACC_SCHEDULE_V3 must be set to run v3 schedule acceptance tests")
+	}
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.test", username)
+	scheduleName := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	effectiveSince := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	startTime := time.Now().UTC().Add(24*time.Hour).Format("2006-01-02") + "T09:00:00Z"
+	endTime := time.Now().UTC().Add(24*time.Hour).Format("2006-01-02") + "T17:00:00Z"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(),
+		CheckDestroy:             testAccCheckPagerDutyScheduleV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPagerDutyScheduleV2MultipleRotationsConfig(username, email, scheduleName, effectiveSince, startTime, endTime),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyScheduleV2Exists("pagerduty_schedulev2.test"),
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "rotation.#", "2"),
+					resource.TestCheckResourceAttrSet("pagerduty_schedulev2.test", "rotation.0.id"),
+					resource.TestCheckResourceAttrSet("pagerduty_schedulev2.test", "rotation.1.id"),
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "rotation.0.event.0.name", "Primary Rotation"),
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "rotation.1.event.0.name", "Secondary Rotation"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPagerDutyScheduleV2_Import(t *testing.T) {
+	if v := os.Getenv("PAGERDUTY_ACC_SCHEDULE_V3"); v == "" {
+		t.Skip("PAGERDUTY_ACC_SCHEDULE_V3 must be set to run v3 schedule acceptance tests")
+	}
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.test", username)
+	scheduleName := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	effectiveSince := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	startTime := time.Now().UTC().Add(24*time.Hour).Format("2006-01-02") + "T09:00:00Z"
+	endTime := time.Now().UTC().Add(24*time.Hour).Format("2006-01-02") + "T17:00:00Z"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(),
+		CheckDestroy:             testAccCheckPagerDutyScheduleV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPagerDutyScheduleV2Config(username, email, scheduleName, effectiveSince, startTime, endTime),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyScheduleV2Exists("pagerduty_schedulev2.test"),
+				),
+			},
+			{
+				ResourceName:      "pagerduty_schedulev2.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				// effective_since may be adjusted by the API for past times.
+				// start_time/end_time are UTC-normalized by the API on import (no prior state to compare against).
+				ImportStateVerifyIgnore: []string{
+					"rotation.0.event.0.effective_since",
+					"rotation.0.event.0.start_time",
+					"rotation.0.event.0.end_time",
+					// shifts_per_member is not set in the config so state preserves null,
+					// but import reads the API's stored value (1). One normalizing apply
+					// after import brings them back into sync.
+					"rotation.0.event.0.assignment_strategy.0.shifts_per_member",
+				},
+			},
+		},
+	})
+}
+
+// --- Helper functions ---
+
+func testAccCheckPagerDutyScheduleV2Destroy(s *terraform.State) error {
+	for _, r := range s.RootModule().Resources {
+		if r.Type != "pagerduty_schedulev2" {
+			continue
+		}
+		ctx := context.Background()
+		if _, err := testAccProvider.client.GetScheduleV3(ctx, r.Primary.ID); err == nil {
+			return fmt.Errorf("v3 schedule still exists: %s", r.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func testAccCheckPagerDutyScheduleV2Exists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		r, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+		if r.Primary.ID == "" {
+			return fmt.Errorf("no ID set for %s", n)
+		}
+		ctx := context.Background()
+		if _, err := testAccProvider.client.GetScheduleV3(ctx, r.Primary.ID); err != nil {
+			return fmt.Errorf("error fetching v3 schedule %s: %s", r.Primary.ID, err)
+		}
+		return nil
+	}
+}
+
+// --- Config functions ---
+
+func testAccPagerDutyScheduleV2Config(username, email, scheduleName, effectiveSince, startTime, endTime string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "test" {
+  name  = "%s"
+  email = "%s"
+}
+
+resource "pagerduty_schedulev2" "test" {
+  name        = "%s"
+  time_zone   = "America/New_York"
+  description = "Managed by Terraform"
+
+  rotation {
+    event {
+      name            = "Weekly On-Call"
+      start_time      = "%s"
+      end_time        = "%s"
+      effective_since = "%s"
+      recurrence      = ["RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"]
+
+      assignment_strategy {
+        type = "rotating_member_assignment_strategy"
+
+        member {
+          type    = "user_member"
+          user_id = pagerduty_user.test.id
+        }
+      }
+    }
+  }
+}
+`, username, email, scheduleName, startTime, endTime, effectiveSince)
+}
+
+func testAccPagerDutyScheduleV2ConfigUpdated(username, email, scheduleName, effectiveSince, startTime, endTime string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "test" {
+  name  = "%s"
+  email = "%s"
+}
+
+resource "pagerduty_schedulev2" "test" {
+  name        = "%s"
+  time_zone   = "America/Los_Angeles"
+  description = "Updated by Terraform"
+
+  rotation {
+    event {
+      name            = "Weekly On-Call"
+      start_time      = "%s"
+      end_time        = "%s"
+      effective_since = "%s"
+      recurrence      = ["RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"]
+
+      assignment_strategy {
+        type = "rotating_member_assignment_strategy"
+
+        member {
+          type    = "user_member"
+          user_id = pagerduty_user.test.id
+        }
+      }
+    }
+  }
+}
+`, username, email, scheduleName, startTime, endTime, effectiveSince)
+}
+
+func TestAccPagerDutyScheduleV2_PastEffectiveSince(t *testing.T) {
+	if v := os.Getenv("PAGERDUTY_ACC_SCHEDULE_V3"); v == "" {
+		t.Skip("PAGERDUTY_ACC_SCHEDULE_V3 must be set to run v3 schedule acceptance tests")
+	}
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.test", username)
+	scheduleName := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	// Use a date 48 hours in the past. The API normalizes past effective_since
+	// values to the current server time. The provider must preserve the configured
+	// value in state to avoid a Framework "inconsistent result after apply" error.
+	effectiveSince := time.Now().UTC().Add(-48 * time.Hour).Format(time.RFC3339)
+	startTime := time.Now().UTC().Add(24*time.Hour).Format("2006-01-02") + "T09:00:00Z"
+	endTime := time.Now().UTC().Add(24*time.Hour).Format("2006-01-02") + "T17:00:00Z"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(),
+		CheckDestroy:             testAccCheckPagerDutyScheduleV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPagerDutyScheduleV2Config(username, email, scheduleName, effectiveSince, startTime, endTime),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyScheduleV2Exists("pagerduty_schedulev2.test"),
+					// State must hold the configured value, not the API-normalized current time.
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "rotation.0.event.0.effective_since", effectiveSince),
+				),
+			},
+			{
+				// Re-plan with the same config. Fails if there is a perpetual diff
+				// caused by the read-side normalization not preserving the state value.
+				Config:             testAccPagerDutyScheduleV2Config(username, email, scheduleName, effectiveSince, startTime, endTime),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func TestAccPagerDutyScheduleV2_EffectiveUntil(t *testing.T) {
+	if v := os.Getenv("PAGERDUTY_ACC_SCHEDULE_V3"); v == "" {
+		t.Skip("PAGERDUTY_ACC_SCHEDULE_V3 must be set to run v3 schedule acceptance tests")
+	}
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.test", username)
+	scheduleName := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	effectiveSince := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	effectiveUntil := time.Now().UTC().Add(30 * 24 * time.Hour).Format(time.RFC3339)
+	startTime := time.Now().UTC().Add(24*time.Hour).Format("2006-01-02") + "T09:00:00Z"
+	endTime := time.Now().UTC().Add(24*time.Hour).Format("2006-01-02") + "T17:00:00Z"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(),
+		CheckDestroy:             testAccCheckPagerDutyScheduleV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPagerDutyScheduleV2EffectiveUntilConfig(username, email, scheduleName, effectiveSince, effectiveUntil, startTime, endTime),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyScheduleV2Exists("pagerduty_schedulev2.test"),
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "rotation.0.event.0.effective_until", effectiveUntil),
+				),
+			},
+			{
+				// Remove effective_until — the event becomes indefinite.
+				Config: testAccPagerDutyScheduleV2Config(username, email, scheduleName, effectiveSince, startTime, endTime),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyScheduleV2Exists("pagerduty_schedulev2.test"),
+					resource.TestCheckNoResourceAttr("pagerduty_schedulev2.test", "rotation.0.event.0.effective_until"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPagerDutyScheduleV2_UpdateEvents(t *testing.T) {
+	if v := os.Getenv("PAGERDUTY_ACC_SCHEDULE_V3"); v == "" {
+		t.Skip("PAGERDUTY_ACC_SCHEDULE_V3 must be set to run v3 schedule acceptance tests")
+	}
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.test", username)
+	scheduleName := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	effectiveSince := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	startTime := time.Now().UTC().Add(24*time.Hour).Format("2006-01-02") + "T09:00:00Z"
+	endTime := time.Now().UTC().Add(24*time.Hour).Format("2006-01-02") + "T17:00:00Z"
+	startTimeUpdated := time.Now().UTC().Add(48*time.Hour).Format("2006-01-02") + "T08:00:00Z"
+	endTimeUpdated := time.Now().UTC().Add(48*time.Hour).Format("2006-01-02") + "T20:00:00Z"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(),
+		CheckDestroy:             testAccCheckPagerDutyScheduleV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPagerDutyScheduleV2UpdateEventsConfig(username, email, scheduleName, effectiveSince, startTime, endTime, "Weekly On-Call", "RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyScheduleV2Exists("pagerduty_schedulev2.test"),
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "rotation.0.event.0.name", "Weekly On-Call"),
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "rotation.0.event.0.recurrence.0", "RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"),
+				),
+			},
+			{
+				Config: testAccPagerDutyScheduleV2UpdateEventsConfig(username, email, scheduleName, effectiveSince, startTimeUpdated, endTimeUpdated, "Daily On-Call", "RRULE:FREQ=DAILY"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyScheduleV2Exists("pagerduty_schedulev2.test"),
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "rotation.0.event.0.name", "Daily On-Call"),
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "rotation.0.event.0.recurrence.0", "RRULE:FREQ=DAILY"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPagerDutyScheduleV2_RotationCountChange(t *testing.T) {
+	if v := os.Getenv("PAGERDUTY_ACC_SCHEDULE_V3"); v == "" {
+		t.Skip("PAGERDUTY_ACC_SCHEDULE_V3 must be set to run v3 schedule acceptance tests")
+	}
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.test", username)
+	scheduleName := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	effectiveSince := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	startTime := time.Now().UTC().Add(24*time.Hour).Format("2006-01-02") + "T09:00:00Z"
+	endTime := time.Now().UTC().Add(24*time.Hour).Format("2006-01-02") + "T17:00:00Z"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(),
+		CheckDestroy:             testAccCheckPagerDutyScheduleV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPagerDutyScheduleV2Config(username, email, scheduleName, effectiveSince, startTime, endTime),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyScheduleV2Exists("pagerduty_schedulev2.test"),
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "rotation.#", "1"),
+				),
+			},
+			{
+				// Add a second rotation, exercising the new-rotation creation branch.
+				Config: testAccPagerDutyScheduleV2MultipleRotationsConfig(username, email, scheduleName, effectiveSince, startTime, endTime),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyScheduleV2Exists("pagerduty_schedulev2.test"),
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "rotation.#", "2"),
+					resource.TestCheckResourceAttrSet("pagerduty_schedulev2.test", "rotation.0.id"),
+					resource.TestCheckResourceAttrSet("pagerduty_schedulev2.test", "rotation.1.id"),
+				),
+			},
+			{
+				// Remove the second rotation, exercising the rotation deletion branch.
+				Config: testAccPagerDutyScheduleV2Config(username, email, scheduleName, effectiveSince, startTime, endTime),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyScheduleV2Exists("pagerduty_schedulev2.test"),
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "rotation.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccPagerDutyScheduleV2MultipleRotationsConfig(username, email, scheduleName, effectiveSince, startTime, endTime string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "test" {
+  name  = "%s"
+  email = "%s"
+}
+
+resource "pagerduty_schedulev2" "test" {
+  name        = "%s"
+  time_zone   = "America/New_York"
+  description = "Multi-rotation schedule"
+
+  rotation {
+    event {
+      name            = "Primary Rotation"
+      start_time      = "%s"
+      end_time        = "%s"
+      effective_since = "%s"
+      recurrence      = ["RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR"]
+
+      assignment_strategy {
+        type = "rotating_member_assignment_strategy"
+
+        member {
+          type    = "user_member"
+          user_id = pagerduty_user.test.id
+        }
+      }
+    }
+  }
+
+  rotation {
+    event {
+      name            = "Secondary Rotation"
+      start_time      = "%s"
+      end_time        = "%s"
+      effective_since = "%s"
+      recurrence      = ["RRULE:FREQ=WEEKLY;BYDAY=TU,TH"]
+
+      assignment_strategy {
+        type = "rotating_member_assignment_strategy"
+
+        member {
+          type    = "user_member"
+          user_id = pagerduty_user.test.id
+        }
+      }
+    }
+  }
+}
+`, username, email, scheduleName, startTime, endTime, effectiveSince, startTime, endTime, effectiveSince)
+}
+
+func testAccPagerDutyScheduleV2EffectiveUntilConfig(username, email, scheduleName, effectiveSince, effectiveUntil, startTime, endTime string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "test" {
+  name  = "%s"
+  email = "%s"
+}
+
+resource "pagerduty_schedulev2" "test" {
+  name        = "%s"
+  time_zone   = "America/New_York"
+  description = "Managed by Terraform"
+
+  rotation {
+    event {
+      name            = "Weekly On-Call"
+      start_time      = "%s"
+      end_time        = "%s"
+      effective_since = "%s"
+      effective_until = "%s"
+      recurrence      = ["RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"]
+
+      assignment_strategy {
+        type = "rotating_member_assignment_strategy"
+
+        member {
+          type    = "user_member"
+          user_id = pagerduty_user.test.id
+        }
+      }
+    }
+  }
+}
+`, username, email, scheduleName, startTime, endTime, effectiveSince, effectiveUntil)
+}
+
+func testAccPagerDutyScheduleV2UpdateEventsConfig(username, email, scheduleName, effectiveSince, startTime, endTime, eventName, recurrence string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "test" {
+  name  = "%s"
+  email = "%s"
+}
+
+resource "pagerduty_schedulev2" "test" {
+  name        = "%s"
+  time_zone   = "America/New_York"
+  description = "Managed by Terraform"
+
+  rotation {
+    event {
+      name            = "%s"
+      start_time      = "%s"
+      end_time        = "%s"
+      effective_since = "%s"
+      recurrence      = ["%s"]
+
+      assignment_strategy {
+        type = "rotating_member_assignment_strategy"
+
+        member {
+          type    = "user_member"
+          user_id = pagerduty_user.test.id
+        }
+      }
+    }
+  }
+}
+`, username, email, scheduleName, eventName, startTime, endTime, effectiveSince, recurrence)
+}
+
+func TestAccPagerDutyScheduleV2_EveryMemberStrategy(t *testing.T) {
+	if v := os.Getenv("PAGERDUTY_ACC_SCHEDULE_V3"); v == "" {
+		t.Skip("PAGERDUTY_ACC_SCHEDULE_V3 must be set to run v3 schedule acceptance tests")
+	}
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.test", username)
+	scheduleName := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	effectiveSince := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	startTime := time.Now().UTC().Add(24*time.Hour).Format("2006-01-02") + "T09:00:00Z"
+	endTime := time.Now().UTC().Add(24*time.Hour).Format("2006-01-02") + "T17:00:00Z"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(),
+		CheckDestroy:             testAccCheckPagerDutyScheduleV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPagerDutyScheduleV2EveryMemberStrategyConfig(username, email, scheduleName, effectiveSince, startTime, endTime),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyScheduleV2Exists("pagerduty_schedulev2.test"),
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "name", scheduleName),
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "rotation.#", "1"),
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "rotation.0.event.0.assignment_strategy.#", "1"),
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "rotation.0.event.0.assignment_strategy.0.type", "every_member_assignment_strategy"),
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "rotation.0.event.0.assignment_strategy.0.member.#", "1"),
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "rotation.0.event.0.assignment_strategy.0.member.0.type", "user_member"),
+				),
+			},
+		},
+	})
+}
+
+func testAccPagerDutyScheduleV2EveryMemberStrategyConfig(username, email, scheduleName, effectiveSince, startTime, endTime string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "test" {
+  name  = "%s"
+  email = "%s"
+}
+
+resource "pagerduty_schedulev2" "test" {
+  name        = "%s"
+  time_zone   = "America/New_York"
+  description = "Every-member strategy test"
+
+  rotation {
+    event {
+      name            = "All Hands On-Call"
+      start_time      = "%s"
+      end_time        = "%s"
+      effective_since = "%s"
+      recurrence      = ["RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"]
+
+      assignment_strategy {
+        type = "every_member_assignment_strategy"
+
+        member {
+          type    = "user_member"
+          user_id = pagerduty_user.test.id
+        }
+      }
+    }
+  }
+}
+`, username, email, scheduleName, startTime, endTime, effectiveSince)
+}

--- a/util/util.go
+++ b/util/util.go
@@ -298,8 +298,8 @@ func ValidateTZValueDiagFunc(v interface{}, p cty.Path) diag.Diagnostics {
 	value := v.(string)
 	valid := false
 
-	foundAt := sort.SearchStrings(validTZ, value)
-	if foundAt < len(validTZ) && validTZ[foundAt] == value {
+	foundAt := sort.SearchStrings(ValidTZ, value)
+	if foundAt < len(ValidTZ) && ValidTZ[foundAt] == value {
 		valid = true
 	}
 
@@ -314,9 +314,11 @@ func ValidateTZValueDiagFunc(v interface{}, p cty.Path) diag.Diagnostics {
 	return diags
 }
 
-// validTZ at the moment there not an API to fetch this values, so hardcoding
+// ValidTZ at the moment there not an API to fetch this values, so hardcoding
 // them here
-var validTZ []string = []string{
+// ValidTZ is the list of IANA time zone values accepted by the PagerDuty API.
+// See https://developer.pagerduty.com/docs/1afe25e9c94cb-types#time-zone
+var ValidTZ []string = []string{
 	"Africa/Algiers",
 	"Africa/Cairo",
 	"Africa/Casablanca",

--- a/util/validate/timezone.go
+++ b/util/validate/timezone.go
@@ -1,0 +1,43 @@
+package validate
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/PagerDuty/terraform-provider-pagerduty/util"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+type validTimeZone struct{}
+
+var _ validator.String = (*validTimeZone)(nil)
+
+func (v *validTimeZone) Description(context.Context) string {
+	return "Validates that the value is a supported IANA time zone."
+}
+
+func (v *validTimeZone) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v *validTimeZone) ValidateString(_ context.Context, req validator.StringRequest, res *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	value := req.ConfigValue.ValueString()
+	foundAt := sort.SearchStrings(util.ValidTZ, value)
+	if foundAt >= len(util.ValidTZ) || util.ValidTZ[foundAt] != value {
+		res.Diagnostics.AddAttributeError(
+			req.Path,
+			"Invalid Time Zone",
+			fmt.Sprintf("%q is not a valid time zone. Please refer to the list of allowed values at https://developer.pagerduty.com/docs/1afe25e9c94cb-types#time-zone", value),
+		)
+	}
+}
+
+// ValidTimeZone returns a Framework validator that checks the value is a
+// supported IANA time zone accepted by the PagerDuty API.
+func ValidTimeZone() validator.String {
+	return &validTimeZone{}
+}

--- a/vendor/github.com/PagerDuty/go-pagerduty/schedule_v3.go
+++ b/vendor/github.com/PagerDuty/go-pagerduty/schedule_v3.go
@@ -1,0 +1,348 @@
+package pagerduty
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/google/go-querystring/query"
+)
+
+// scheduleV3Headers returns the HTTP headers required by PagerDuty's v3 Schedules API.
+// The v3 API requires Accept: application/json and the flexible-schedules early access header.
+// The early access value can be overridden via PAGERDUTY_SCHEDULE_V3_EARLY_ACCESS env var.
+func scheduleV3Headers() map[string]string {
+	earlyAccessVal := "flexible-schedules-early-access"
+	if val := os.Getenv("PAGERDUTY_SCHEDULE_V3_EARLY_ACCESS"); val != "" {
+		earlyAccessVal = val
+	}
+	return map[string]string{
+		"Accept":         "application/json",
+		"X-Early-Access": earlyAccessVal,
+	}
+}
+
+// ScheduleV3 represents a schedule in PagerDuty's v3 API.
+type ScheduleV3 struct {
+	ID                 string             `json:"id,omitempty"`
+	Type               string             `json:"type,omitempty"`
+	Name               string             `json:"name"`
+	TimeZone           string             `json:"time_zone"`
+	Description        string             `json:"description,omitempty"`
+	EscalationPolicies []string           `json:"escalation_policies,omitempty"`
+	Teams              []TeamReferenceV3  `json:"teams,omitempty"`
+	Rotations          []RotationV3       `json:"rotations,omitempty"`
+}
+
+// RotationV3 represents a rotation within a v3 schedule.
+type RotationV3 struct {
+	ID     string    `json:"id,omitempty"`
+	Type   string    `json:"type,omitempty"`
+	Events []EventV3 `json:"events,omitempty"`
+}
+
+// EventTimeV3 represents a time field in a v3 schedule event.
+// The v3 API uses an object {"date_time": "...", "time_zone": "..."} rather than a plain string.
+type EventTimeV3 struct {
+	DateTime string `json:"date_time"`
+	TimeZone string `json:"time_zone,omitempty"`
+}
+
+// EventV3 represents an on-call event configuration within a rotation.
+type EventV3 struct {
+	ID                 string               `json:"id,omitempty"`
+	Type               string               `json:"type,omitempty"`
+	Name               string               `json:"name"`
+	StartTime          EventTimeV3          `json:"start_time"`
+	EndTime            EventTimeV3          `json:"end_time"`
+	EffectiveSince     string               `json:"effective_since"`
+	EffectiveUntil     *string              `json:"effective_until"`
+	Recurrence         []string             `json:"recurrence"`
+	AssignmentStrategy AssignmentStrategyV3 `json:"assignment_strategy"`
+}
+
+// AssignmentStrategyV3 defines how on-call responsibility is assigned within an event.
+type AssignmentStrategyV3 struct {
+	Type            string     `json:"type"`
+	ShiftsPerMember *int       `json:"shifts_per_member,omitempty"`
+	Members         []MemberV3 `json:"members"`
+}
+
+// TeamReferenceV3 represents a team associated with a v3 schedule.
+type TeamReferenceV3 struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
+}
+
+// MemberV3 represents a member in an assignment strategy.
+type MemberV3 struct {
+	Type   string  `json:"type"`
+	UserID *string `json:"user_id,omitempty"`
+}
+
+// ScheduleV3Input contains the mutable fields for creating or updating a v3 schedule.
+type ScheduleV3Input struct {
+	Name        string             `json:"name"`
+	TimeZone    string             `json:"time_zone"`
+	Description string             `json:"description,omitempty"`
+	Teams       []TeamReferenceV3  `json:"teams,omitempty"`
+}
+
+// scheduleV3Payload is the request body shape for v3 schedule create/update.
+// The rotations field must be present (even as []) per the v3 API validation.
+type scheduleV3Payload struct {
+	Name        string             `json:"name"`
+	TimeZone    string             `json:"time_zone"`
+	Description string             `json:"description,omitempty"`
+	Teams       []TeamReferenceV3  `json:"teams,omitempty"`
+	Rotations   []RotationV3       `json:"rotations"`
+}
+
+type createScheduleV3Request struct {
+	Schedule scheduleV3Payload `json:"schedule"`
+}
+
+type updateScheduleV3Request struct {
+	Schedule scheduleV3Payload `json:"schedule"`
+}
+
+type scheduleV3Response struct {
+	Schedule ScheduleV3 `json:"schedule"`
+}
+
+// ListSchedulesV3Response is the response for listing v3 schedules.
+type ListSchedulesV3Response struct {
+	Schedules []APIObject `json:"schedules"`
+}
+
+// ListSchedulesV3Options are query parameters for listing v3 schedules.
+type ListSchedulesV3Options struct {
+	Query  string `url:"query,omitempty"`
+	Limit  int    `url:"limit,omitempty"`
+	Offset int    `url:"offset,omitempty"`
+}
+
+type rotationV3Response struct {
+	Rotation RotationV3 `json:"rotation"`
+}
+
+type eventV3Response struct {
+	Event EventV3 `json:"event"`
+}
+
+type createEventV3Request struct {
+	Event EventV3 `json:"event"`
+}
+
+type updateEventV3Request struct {
+	Event EventV3 `json:"event"`
+}
+
+// ListSchedulesV3 retrieves a paginated list of v3 schedules.
+func (c *Client) ListSchedulesV3(ctx context.Context, o ListSchedulesV3Options) (*ListSchedulesV3Response, error) {
+	v, err := query.Values(o)
+	if err != nil {
+		return nil, err
+	}
+
+	path := "/v3/schedules"
+	if encoded := v.Encode(); encoded != "" {
+		path += "?" + encoded
+	}
+
+	resp, err := c.get(ctx, path, scheduleV3Headers())
+	if err != nil {
+		return nil, err
+	}
+
+	var result ListSchedulesV3Response
+	if err = c.decodeJSON(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// GetScheduleV3 retrieves a v3 schedule by ID, including its rotations and events.
+func (c *Client) GetScheduleV3(ctx context.Context, id string) (*ScheduleV3, error) {
+	resp, err := c.get(ctx, "/v3/schedules/"+id, scheduleV3Headers())
+	if err != nil {
+		return nil, err
+	}
+
+	var result scheduleV3Response
+	if err = c.decodeJSON(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result.Schedule, nil
+}
+
+// CreateScheduleV3 creates a new v3 schedule with metadata only.
+// Rotations and events must be added via separate API calls.
+func (c *Client) CreateScheduleV3(ctx context.Context, s ScheduleV3Input) (*ScheduleV3, error) {
+	d := createScheduleV3Request{Schedule: scheduleV3Payload{
+		Name:        s.Name,
+		TimeZone:    s.TimeZone,
+		Description: s.Description,
+		Teams:       s.Teams,
+		Rotations:   []RotationV3{},
+	}}
+
+	resp, err := c.post(ctx, "/v3/schedules", d, scheduleV3Headers())
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("failed to create v3 schedule, HTTP status code: %d", resp.StatusCode)
+	}
+
+	var result scheduleV3Response
+	if err = c.decodeJSON(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result.Schedule, nil
+}
+
+// UpdateScheduleV3 updates a v3 schedule's metadata (name, time_zone, description).
+func (c *Client) UpdateScheduleV3(ctx context.Context, id string, s ScheduleV3Input) (*ScheduleV3, error) {
+	d := updateScheduleV3Request{Schedule: scheduleV3Payload{
+		Name:        s.Name,
+		TimeZone:    s.TimeZone,
+		Description: s.Description,
+		Teams:       s.Teams,
+		Rotations:   []RotationV3{},
+	}}
+
+	resp, err := c.put(ctx, "/v3/schedules/"+id, d, scheduleV3Headers())
+	if err != nil {
+		return nil, err
+	}
+
+	var result scheduleV3Response
+	if err = c.decodeJSON(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result.Schedule, nil
+}
+
+// DeleteScheduleV3 soft-deletes a v3 schedule and all its rotations and events.
+func (c *Client) DeleteScheduleV3(ctx context.Context, id string) error {
+	// Use do() directly since delete() does not accept custom headers
+	resp, err := c.do(ctx, http.MethodDelete, "/v3/schedules/"+id, nil, scheduleV3Headers())
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
+}
+
+// CreateRotationV3 creates a new empty rotation for a v3 schedule.
+// Events are added to the rotation via CreateEventV3.
+func (c *Client) CreateRotationV3(ctx context.Context, scheduleID string) (*RotationV3, error) {
+	resp, err := c.post(ctx, "/v3/schedules/"+scheduleID+"/rotations", map[string]interface{}{}, scheduleV3Headers())
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("failed to create v3 rotation, HTTP status code: %d", resp.StatusCode)
+	}
+
+	var result rotationV3Response
+	if err = c.decodeJSON(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result.Rotation, nil
+}
+
+// GetRotationV3 retrieves a rotation by ID for a given schedule.
+func (c *Client) GetRotationV3(ctx context.Context, scheduleID, rotationID string) (*RotationV3, error) {
+	resp, err := c.get(ctx, "/v3/schedules/"+scheduleID+"/rotations/"+rotationID, scheduleV3Headers())
+	if err != nil {
+		return nil, err
+	}
+
+	var result rotationV3Response
+	if err = c.decodeJSON(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result.Rotation, nil
+}
+
+// GetEventV3 retrieves a single event from a v3 rotation.
+func (c *Client) GetEventV3(ctx context.Context, scheduleID, rotationID, eventID string) (*EventV3, error) {
+	resp, err := c.get(ctx, "/v3/schedules/"+scheduleID+"/rotations/"+rotationID+"/events/"+eventID, scheduleV3Headers())
+	if err != nil {
+		return nil, err
+	}
+
+	var result eventV3Response
+	if err = c.decodeJSON(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result.Event, nil
+}
+
+// DeleteRotationV3 soft-deletes a rotation from a v3 schedule.
+func (c *Client) DeleteRotationV3(ctx context.Context, scheduleID, rotationID string) error {
+	// Use do() directly since delete() does not accept custom headers
+	resp, err := c.do(ctx, http.MethodDelete, "/v3/schedules/"+scheduleID+"/rotations/"+rotationID, nil, scheduleV3Headers())
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
+}
+
+// CreateEventV3 creates a new event within a v3 rotation.
+func (c *Client) CreateEventV3(ctx context.Context, scheduleID, rotationID string, e EventV3) (*EventV3, error) {
+	resp, err := c.post(ctx, "/v3/schedules/"+scheduleID+"/rotations/"+rotationID+"/events", createEventV3Request{Event: e}, scheduleV3Headers())
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("failed to create v3 event, HTTP status code: %d", resp.StatusCode)
+	}
+
+	var result eventV3Response
+	if err = c.decodeJSON(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result.Event, nil
+}
+
+// UpdateEventV3 updates an event within a v3 rotation.
+func (c *Client) UpdateEventV3(ctx context.Context, scheduleID, rotationID, eventID string, e EventV3) (*EventV3, error) {
+	resp, err := c.put(ctx, "/v3/schedules/"+scheduleID+"/rotations/"+rotationID+"/events/"+eventID, updateEventV3Request{Event: e}, scheduleV3Headers())
+	if err != nil {
+		return nil, err
+	}
+
+	var result eventV3Response
+	if err = c.decodeJSON(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result.Event, nil
+}
+
+// DeleteEventV3 deletes an event from a v3 rotation.
+func (c *Client) DeleteEventV3(ctx context.Context, scheduleID, rotationID, eventID string) error {
+	// Use do() directly since delete() does not accept custom headers
+	resp, err := c.do(ctx, http.MethodDelete, "/v3/schedules/"+scheduleID+"/rotations/"+rotationID+"/events/"+eventID, nil, scheduleV3Headers())
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
+}

--- a/website/docs/d/schedulev2.html.markdown
+++ b/website/docs/d/schedulev2.html.markdown
@@ -1,0 +1,44 @@
+---
+layout: "pagerduty"
+page_title: "PagerDuty: pagerduty_schedulev2"
+sidebar_current: "docs-pagerduty-datasource-schedulev2"
+description: |-
+  Provides information about a PagerDuty v3 schedule.
+---
+
+# pagerduty\_schedulev2
+
+Use this data source to look up a specific [v3 schedule](https://developer.pagerduty.com/api-reference/d90c4c94e3ce2-create-a-schedule) by name so you can reference its ID in other resources such as escalation policies.
+
+~> **Note:** This data source requires the `flexible-schedules-early-access` early access flag on your PagerDuty account. The required `X-Early-Access` header is sent automatically by the provider.
+
+## Example Usage
+
+```hcl
+data "pagerduty_schedulev2" "oncall" {
+  name = "Engineering On-Call"
+}
+
+resource "pagerduty_escalation_policy" "example" {
+  name      = "Engineering Escalation Policy"
+  num_loops = 2
+
+  rule {
+    escalation_delay_in_minutes = 10
+
+    target {
+      type = "schedule_reference"
+      id   = data.pagerduty_schedulev2.oncall.id
+    }
+  }
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The exact name of the v3 schedule to look up.
+
+## Attributes Reference
+
+* `id` - The ID of the found schedule.
+* `name` - The name of the found schedule.

--- a/website/docs/guides/migrate-schedule-to-schedulev2.html.markdown
+++ b/website/docs/guides/migrate-schedule-to-schedulev2.html.markdown
@@ -1,0 +1,218 @@
+---
+layout: "pagerduty"
+page_title: "Migrating from pagerduty_schedule to pagerduty_schedulev2"
+sidebar_current: "docs-pagerduty-guides-migrate-schedule-to-schedulev2"
+description: |-
+  Step-by-step guide for migrating on-call schedules from the legacy pagerduty_schedule resource to the new pagerduty_schedulev2 resource backed by the PagerDuty v3 Schedules API.
+---
+
+# Migrating from `pagerduty_schedule` to `pagerduty_schedulev2`
+
+`pagerduty_schedule` is deprecated and will be removed in a future provider release. `pagerduty_schedulev2` is its replacement, backed by the PagerDuty v3 Schedules API.
+
+---
+
+## Feasibility Assessment
+
+| Pattern | Migratable? |
+|---|---|
+| Single-user, 24/7 coverage | ✅ Yes |
+| Single-user with daily time restrictions (e.g. 09:00–17:00 every day) | ✅ Yes |
+| Single-user with weekly restrictions (e.g. MON–FRI business hours) | ✅ Yes |
+| Multi-user layers (`users` list with more than one entry) | ❌ Not supported — v2 uses static per-event assignment |
+| Multiple overlapping layers (`final_schedule` merging) | ⚠️ Redesign needed — v2 rotations are independent |
+| `teams` association | ❌ Not yet supported in v2 |
+| `overflow` parameter | ❌ No equivalent in v3 API |
+
+~> **Before starting:** audit each `layer.users` list. Any layer with more than one user requires architectural redesign and cannot be migrated directly.
+
+-> **Every `pagerduty_schedule` can be migrated.** Simple single-user configurations map directly using the field reference below. For complex configurations (multi-user layers, overlapping restrictions), use the [PagerDuty REST API `GET /schedules/{id}`](https://developer.pagerduty.com/api-reference/3f03afb2c84a4-get-a-schedule) to retrieve the computed `final_schedule`. The `final_schedule` contains the resolved, non-overlapping on-call windows that `pagerduty_schedulev2` events map to directly, making the conversion straightforward to automate with a script.
+
+---
+
+## Concept Mapping
+
+The two resources use different abstractions for on-call coverage.
+
+| Concept | `pagerduty_schedule` (v1) | `pagerduty_schedulev2` (v2) |
+|---|---|---|
+| Core unit | `layer` — users rotate through turns | `rotation` + `event` — explicit time window with fixed assignment |
+| Recurrence | Implied by `rotation_turn_length_seconds` | Explicit RFC 5545 RRULE string |
+| Time restriction | `restriction` block limits when a turn is active | `start_time`/`end_time` + `recurrence` define the window directly |
+| Layer lifecycle | Layers can only be ended, never deleted | Rotations and events are fully mutable |
+
+---
+
+## Field Reference
+
+### Schedule-level
+
+| `pagerduty_schedule` | `pagerduty_schedulev2` | Notes |
+|---|---|---|
+| `name` | `name` | v1 is Optional; v2 is Required |
+| `time_zone` | `time_zone` | v1 rejects `"UTC"` — use `"Etc/UTC"`. v2 accepts `"UTC"` directly. Prefer the full IANA name (e.g. `"America/New_York"`) in both. |
+| `description` | `description` | v1 defaults to `"Managed by Terraform"`; v2 has no default |
+| `overflow` | — | No equivalent |
+| `teams` | — | Not yet supported in v2 |
+| `final_schedule` (computed) | — | Not exposed in v2 |
+
+### Layer → Rotation + Event
+
+| `layer` attribute | `event` attribute | Notes |
+|---|---|---|
+| `name` | `name` | Direct mapping |
+| `start` | `effective_since` | When the layer/event begins producing shifts |
+| `end` | `effective_until` | Omit for indefinite coverage |
+| `rotation_virtual_start` | `start_time` | First occurrence start time |
+| `rotation_turn_length_seconds` | `recurrence` | Replaced by RRULE (e.g. weekly turn → `RRULE:FREQ=WEEKLY`) |
+| `users[0]` | `assignment_strategy.member.user_id` | Single user maps to one `member` block |
+
+### Restriction → Recurrence
+
+`end_time = start_time + duration_seconds`
+
+| v1 restriction | v2 `recurrence` RRULE |
+|---|---|
+| `daily_restriction` at 09:00, 8 h | `RRULE:FREQ=DAILY` with `start_time=T09:00`, `end_time=T17:00` |
+| `weekly_restriction` Mon–Fri (5 blocks) | `RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR` (single event) |
+| `weekly_restriction` Sat + Sun (or one block, `duration=172740s`) | `RRULE:FREQ=WEEKLY;BYDAY=SA,SU` with `end_time` on Sun 23:59 |
+
+---
+
+## Migration Procedure
+
+**Step 1 — Translate the config.** For each `layer`, create one `rotation` with one `event` per distinct time window using the field mapping above.
+
+**Step 2 — Add the new resource without removing the old one.**
+
+```bash
+terraform plan   # 1 to add, 0 to change, 0 to destroy
+terraform apply
+```
+
+**Step 3 — Verify in the PagerDuty UI.** Confirm that both schedules produce identical on-call windows (start time, recurrence, user).
+
+**Step 4 — Remove the old schedule** once you have confirmed the new one is correct.
+
+```bash
+terraform plan   # 0 to add, 0 to change, 1 to destroy
+terraform apply
+```
+
+---
+
+## Worked Example
+
+Business hours (MON–FRI 09:00–17:00 UTC) + weekend on-call (SAT–SUN 00:00–23:59 UTC).
+
+### Before — `pagerduty_schedule`
+
+```hcl
+resource "pagerduty_schedule" "business_hours" {
+  name      = "Business Hours On-Call"
+  time_zone = "Etc/UTC"
+
+  layer {
+    name                         = "Weekday Business Hours"
+    start                        = "2026-02-21T09:00:00Z"
+    rotation_virtual_start       = "2026-02-21T09:00:00Z"
+    rotation_turn_length_seconds = 604800
+    users                        = [pagerduty_user.oncall.id]
+
+    restriction {
+      type = "weekly_restriction"; start_day_of_week = 1
+      start_time_of_day = "09:00:00"; duration_seconds = 28800
+    }
+    restriction {
+      type = "weekly_restriction"; start_day_of_week = 2
+      start_time_of_day = "09:00:00"; duration_seconds = 28800
+    }
+    restriction {
+      type = "weekly_restriction"; start_day_of_week = 3
+      start_time_of_day = "09:00:00"; duration_seconds = 28800
+    }
+    restriction {
+      type = "weekly_restriction"; start_day_of_week = 4
+      start_time_of_day = "09:00:00"; duration_seconds = 28800
+    }
+    restriction {
+      type = "weekly_restriction"; start_day_of_week = 5
+      start_time_of_day = "09:00:00"; duration_seconds = 28800
+    }
+  }
+
+  layer {
+    name                         = "Weekend On-Call"
+    start                        = "2026-02-22T00:00:00Z"
+    rotation_virtual_start       = "2026-02-22T00:00:00Z"
+    rotation_turn_length_seconds = 604800
+    users                        = [pagerduty_user.oncall.id]
+
+    restriction {
+      type              = "weekly_restriction"
+      start_day_of_week = 6
+      start_time_of_day = "00:00:00"
+      duration_seconds  = 172740   # 47h59m
+    }
+  }
+}
+```
+
+### After — `pagerduty_schedulev2`
+
+```hcl
+resource "pagerduty_schedulev2" "business_hours" {
+  name      = "Business Hours On-Call"
+  time_zone = "UTC"   # v2 accepts "UTC" directly
+
+  rotation {
+    event {
+      name            = "Weekday Business Hours"
+      start_time      = "2026-02-21T09:00:00Z"
+      end_time        = "2026-02-21T17:00:00Z"
+      effective_since = "2026-02-21T09:00:00Z"
+      recurrence      = ["RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"]
+
+      assignment_strategy {
+        type = "user_assignment_strategy"
+        member { type = "user_member"; user_id = pagerduty_user.oncall.id }
+      }
+    }
+  }
+
+  rotation {
+    event {
+      name            = "Weekend On-Call"
+      start_time      = "2026-02-22T00:00:00Z"
+      end_time        = "2026-02-23T23:59:00Z"
+      effective_since = "2026-02-22T00:00:00Z"
+      recurrence      = ["RRULE:FREQ=WEEKLY;BYDAY=SA,SU"]
+
+      assignment_strategy {
+        type = "user_assignment_strategy"
+        member { type = "user_member"; user_id = pagerduty_user.oncall.id }
+      }
+    }
+  }
+}
+```
+
+The five `weekly_restriction` blocks collapse into one RRULE `BYDAY` clause. The weekend `duration_seconds = 172740` becomes an explicit `end_time` on Sunday 23:59.
+
+---
+
+## Known Limitations
+
+**`effective_since` adjusted by the API.** The v3 API moves a past `effective_since` to the current time silently. Always set it to a future date to avoid state drift.
+
+**`start_time`/`end_time` UTC normalization.** The v3 API normalizes these to UTC in responses. The provider preserves the original config value when both represent the same instant, so offset values like `"2026-06-01T09:00:00-05:00"` will not cause perpetual diffs.
+
+**`daily_restriction` cannot use `start_day_of_week`.** v1 validation rejects this combination. For weekday-only daily windows in v2, use `RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR` instead of `RRULE:FREQ=DAILY`.
+
+**Importing an existing v3 schedule.**
+
+```bash
+terraform import pagerduty_schedulev2.example P1234AB
+```
+
+After import, `start_time`, `end_time`, and `effective_since` may differ from config due to UTC normalization and API time adjustment.

--- a/website/docs/r/schedulev2.html.markdown
+++ b/website/docs/r/schedulev2.html.markdown
@@ -1,0 +1,157 @@
+---
+layout: "pagerduty"
+page_title: "PagerDuty: pagerduty_schedulev2"
+sidebar_current: "docs-pagerduty-resource-schedulev2"
+description: |-
+  Creates and manages an on-call schedule using the PagerDuty v3 Schedules API.
+---
+
+# pagerduty\_schedulev2
+
+A [v3 schedule](https://developer.pagerduty.com/api-reference/d90c4c94e3ce2-create-a-schedule) determines the time periods that users are on call using flexible rotation configurations. This resource uses the PagerDuty v3 Schedules API, which supports per-event assignment strategies and RFC 5545 recurrence rules.
+
+~> **Note:** This resource requires the `flexible-schedules-early-access` early access flag on your PagerDuty account. The required `X-Early-Access` header is sent automatically by the provider.
+
+## Example Usage
+
+### Rotating member assignment
+
+```hcl
+resource "pagerduty_user" "example" {
+  name  = "Earline Greenholt"
+  email = "earline@example.com"
+}
+
+resource "pagerduty_schedulev2" "example" {
+  name        = "Engineering On-Call"
+  time_zone   = "America/New_York"
+  description = "Managed by Terraform"
+
+  rotation {
+    event {
+      name            = "Weekday Business Hours"
+      start_time      = "2026-06-01T09:00:00Z"
+      end_time        = "2026-06-01T17:00:00Z"
+      effective_since = "2026-06-01T09:00:00Z"
+      recurrence      = ["RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"]
+
+      assignment_strategy {
+        type             = "rotating_member_assignment_strategy"
+        shifts_per_member = 1
+
+        member {
+          type    = "user_member"
+          user_id = pagerduty_user.example.id
+        }
+      }
+    }
+  }
+}
+```
+
+### Every-member assignment (all members on-call simultaneously)
+
+```hcl
+resource "pagerduty_user" "primary" {
+  name  = "Alice"
+  email = "alice@example.com"
+}
+
+resource "pagerduty_user" "secondary" {
+  name  = "Bob"
+  email = "bob@example.com"
+}
+
+resource "pagerduty_schedulev2" "all_hands" {
+  name      = "Weekend All-Hands On-Call"
+  time_zone = "UTC"
+
+  rotation {
+    event {
+      name            = "Weekend Coverage"
+      start_time      = "2026-06-06T00:00:00Z"
+      end_time        = "2026-06-07T23:59:00Z"
+      effective_since = "2026-06-06T00:00:00Z"
+      recurrence      = ["RRULE:FREQ=WEEKLY;BYDAY=SA,SU"]
+
+      assignment_strategy {
+        type = "every_member_assignment_strategy"
+
+        member {
+          type    = "user_member"
+          user_id = pagerduty_user.primary.id
+        }
+
+        member {
+          type    = "user_member"
+          user_id = pagerduty_user.secondary.id
+        }
+      }
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the schedule. Maximum 255 characters.
+* `time_zone` - (Required) The time zone of the schedule (IANA format, e.g. `America/New_York`).
+* `description` - (Optional) A description of the schedule. Maximum 1024 characters.
+* `teams` - (Optional) List of team IDs to associate with this schedule.
+* `rotation` - (Required) One or more rotation blocks. Rotations documented below.
+
+---
+
+Rotation blocks (`rotation`) support the following:
+
+* `event` - (Required) One or more event blocks defining on-call periods within this rotation. Events documented below.
+
+---
+
+Event blocks (`event`) support the following:
+
+* `name` - (Required) The name of the event. Maximum 255 characters.
+* `start_time` - (Required) The shift start time in ISO-8601 format (e.g. `2026-06-01T09:00:00Z`). The v3 API normalizes this to UTC.
+* `end_time` - (Required) The shift end time in ISO-8601 format. The v3 API normalizes this to UTC.
+* `effective_since` - (Required) When this event configuration begins producing shifts (ISO-8601 UTC). The API adjusts past values to the current time.
+* `effective_until` - (Optional) When this event configuration stops producing shifts (ISO-8601 UTC). Omit for an indefinite schedule.
+* `recurrence` - (Required) List of RFC 5545 recurrence rule strings. Must contain exactly one `RRULE` entry. May optionally include one or more `EXDATE` entries (dates to exclude) and one or more `RDATE` entries (additional dates to include). Example: `["RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"]`. You can generate RRULE strings interactively using tools like [RRULE Tool](https://icalendar.org/rrule-tool.html).
+* `assignment_strategy` - (Required) A block defining how on-call responsibility is assigned. Assignment strategy documented below.
+
+---
+
+Assignment strategy blocks (`assignment_strategy`) support the following:
+
+* `type` - (Required) The assignment strategy type. Supported values:
+  * `"rotating_member_assignment_strategy"` — listed members rotate in sequence. Each member covers `shifts_per_member` consecutive shift periods before the next member takes over.
+  * `"every_member_assignment_strategy"` — all listed members are on-call simultaneously for every occurrence.
+
+  ~> **Breaking change:** The previous value `"user_assignment_strategy"` is no longer valid. Use `"rotating_member_assignment_strategy"` instead.
+
+* `shifts_per_member` - (Optional) Number of consecutive shift occurrences each member covers before rotating. Minimum value: `1`. Required when `type` is `"rotating_member_assignment_strategy"`.
+* `member` - (Required) One or more member blocks identifying who is on call. Required for both strategy types. Maximum 20 members. Members documented below.
+
+---
+
+Member blocks (`member`) support the following:
+
+* `type` - (Required) The member type. Supported values: `"user_member"`, `"empty_member"`.
+* `user_id` - (Optional) The ID of the user to assign. Required when `type` is `"user_member"`.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the schedule.
+* `rotation.*.id` - The ID of each rotation.
+* `rotation.*.event.*.id` - The ID of each event within a rotation.
+
+## Import
+
+Schedules can be imported using the schedule `id`, e.g.
+
+```
+$ terraform import pagerduty_schedulev2.example P1234AB
+```


### PR DESCRIPTION
## Summary

Introduces `pagerduty_schedulev2` — a new Terraform resource and data source backed by the PagerDuty [v3 Schedules API](https://developer.pagerduty.com/api-reference/d90c4c94e3ce2-create-a-schedule) (`/v3/schedules`). This is the modern replacement for `pagerduty_schedule` (v1 API) and supports flexible, per-event rotation configurations.

> **Note:** Requires the `flexible-schedules-early-access` flag on your PagerDuty account. The `X-Early-Access` header is sent automatically by the provider.

## What's new

### Resources & data sources
- **`pagerduty_schedulev2`** resource — full CRUD with support for:
  - Multiple rotations per schedule, each with multiple events
  - `rotating_member_assignment_strategy` — users rotate in sequence; configurable `shifts_per_member`
  - `every_member_assignment_strategy` — all listed members on-call simultaneously
  - Optional `teams` association
  - `effective_until` for bounded event windows
  - RFC 5545 `recurrence` rules (RRULE, EXDATE, RDATE)
- **`pagerduty_schedulev2`** data source — lookup by name

### Go client (`vendor/github.com/PagerDuty/go-pagerduty`)
Extended `schedule_v3.go` with full CRUD methods for schedules, rotations, and events, including `GetEventV3` and correct request/response envelope wrapping (`{"event": {...}}`).

### API contract handling
The v3 Schedules API has several non-obvious constraints discovered through direct API probing (`claude_tools/schedules_v3_api_probe.py`):
- **Active events are fully immutable via PUT** — `start_time`, `end_time`, `effective_since`, and `assignment_strategy` all reject modification. The provider transparently handles this with **DELETE + CREATE** when any of these fields change on an active event.
- `effective_since` is clamped to current time for past dates and advances continuously; the provider preserves the user's configured value in state to prevent perpetual plan diffs.
- `start_time`/`end_time` are `ZonedDateTime` objects requiring both `date_time` and `time_zone` fields; the schedule's `time_zone` is used as context.
- `shifts_per_member` defaults to `1` for `rotating_member_assignment_strategy` when not set; the provider preserves config intent (null if unset) in state to avoid plan inconsistencies.

### Documentation
- `website/docs/r/schedulev2.html.markdown` — full attribute reference with examples for both strategy types
- `website/docs/d/schedulev2.html.markdown` — data source reference
- `website/docs/guides/migrate-schedule-to-schedulev2.html.markdown` — migration guide from `pagerduty_schedule`

## Testing

All 9 acceptance tests pass against the live PagerDuty API:

| Test | Covers |
|---|---|
| `TestAccPagerDutyScheduleV2_Basic` | Create + read |
| `TestAccPagerDutyScheduleV2_Update` | Metadata update |
| `TestAccPagerDutyScheduleV2_MultipleRotations` | Multiple rotations |
| `TestAccPagerDutyScheduleV2_Import` | `terraform import` |
| `TestAccPagerDutyScheduleV2_PastEffectiveSince` | API clamping / no-diff |
| `TestAccPagerDutyScheduleV2_EffectiveUntil` | Bounded event windows |
| `TestAccPagerDutyScheduleV2_UpdateEvents` | Event property changes |
| `TestAccPagerDutyScheduleV2_RotationCountChange` | Add/remove rotations |
| `TestAccPagerDutyScheduleV2_EveryMemberStrategy` | Every-member strategy |

```
make testacc TESTARGS='-run TestAccPagerDutyScheduleV2_'
```