### PR TITLE
Add opt-in cache for large team membership reads

### DIFF
--- a/pagerdutyplugin/resource_pagerduty_team_membership.go
+++ b/pagerdutyplugin/resource_pagerduty_team_membership.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"net/http"
 	"net/url"
 	"strings"
 	"time"
@@ -24,7 +23,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 )
 
-type resourceTeamMembership struct{ client *pagerduty.Client }
+type resourceTeamMembership struct {
+	client *pagerduty.Client
+}
 
 var (
 	_ resource.ResourceWithConfigure   = (*resourceTeamMembership)(nil)
@@ -77,7 +78,8 @@ func (r *resourceTeamMembership) Create(ctx context.Context, req resource.Create
 	id := model.ID.ValueString()
 	role := model.Role.ValueString()
 
-	model, err := requestGetTeamMembership(ctx, r.client, id, &role, RetryNotFound, &resp.Diagnostics)
+	r.invalidateTeamMembershipCache(model.TeamID.ValueString(), "create")
+	model, err := requestGetTeamMembership(ctx, r.client, id, &role, teamMembershipReadPostWriteVerification, RetryNotFound, &resp.Diagnostics)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Error creating PagerDuty team membership %s", model.ID),
@@ -101,7 +103,7 @@ func (r *resourceTeamMembership) Read(ctx context.Context, req resource.ReadRequ
 	}
 	log.Printf("[INFO] Reading PagerDuty team membership %s", id)
 
-	state, err := requestGetTeamMembership(ctx, r.client, id.ValueString(), nil, !RetryNotFound, &resp.Diagnostics)
+	state, err := requestGetTeamMembership(ctx, r.client, id.ValueString(), nil, teamMembershipReadSteadyState, !RetryNotFound, &resp.Diagnostics)
 	if err != nil {
 		if util.IsNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
@@ -129,7 +131,8 @@ func (r *resourceTeamMembership) Update(ctx context.Context, req resource.Update
 	id := model.ID.ValueString()
 	role := model.Role.ValueString()
 
-	model, err := requestGetTeamMembership(ctx, r.client, id, &role, RetryNotFound, &resp.Diagnostics)
+	r.invalidateTeamMembershipCache(model.TeamID.ValueString(), "update")
+	model, err := requestGetTeamMembership(ctx, r.client, id, &role, teamMembershipReadPostWriteVerification, RetryNotFound, &resp.Diagnostics)
 	if err != nil {
 		if util.IsNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
@@ -193,6 +196,7 @@ func (r *resourceTeamMembership) Delete(ctx context.Context, req resource.Delete
 		return
 	}
 
+	r.invalidateTeamMembershipCache(teamID, "delete")
 	resp.State.RemoveResource(ctx)
 }
 
@@ -209,59 +213,6 @@ type resourceTeamMembershipModel struct {
 	TeamID types.String `tfsdk:"team_id"`
 	UserID types.String `tfsdk:"user_id"`
 	Role   types.String `tfsdk:"role"`
-}
-
-func requestGetTeamMembership(ctx context.Context, client *pagerduty.Client, id string, neededRole *string, retryNotFound bool, diags *diag.Diagnostics) (resourceTeamMembershipModel, error) {
-	var model resourceTeamMembershipModel
-
-	userID, teamID, err := util.ResourcePagerDutyParseColonCompoundID(id)
-	if err != nil {
-		diags.AddError(fmt.Sprintf("Invalid Team Membership ID %s", id), err.Error())
-		return model, nil
-	}
-
-	err = retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
-		offset := uint(0)
-		more := true
-
-		for more {
-			resp, err := client.ListTeamMembers(ctx, teamID, pagerduty.ListTeamMembersOptions{
-				Limit:  100,
-				Offset: offset,
-			})
-			if err != nil {
-				if util.IsBadRequestError(err) {
-					return retry.NonRetryableError(err)
-				}
-				if !retryNotFound && util.IsNotFoundError(err) {
-					return retry.NonRetryableError(err)
-				}
-				return retry.RetryableError(err)
-			}
-
-			for _, m := range resp.Members {
-				if m.User.ID == userID {
-					if neededRole != nil && m.Role != *neededRole {
-						err = fmt.Errorf("Role %q fetched is different from configuration %q", m.Role, *neededRole)
-						return retry.RetryableError(err)
-					}
-					model = flattenTeamMembership(userID, teamID, m.Role)
-					return nil
-				}
-			}
-
-			more = resp.More
-			offset += resp.Limit
-		}
-
-		err = pagerduty.APIError{StatusCode: http.StatusNotFound}
-		if retryNotFound {
-			return retry.RetryableError(err)
-		}
-		return retry.NonRetryableError(err)
-	})
-
-	return model, err
 }
 
 func requestAddTeamMembership(ctx context.Context, client *pagerduty.Client, plan SchemaGetter, diags *diag.Diagnostics) resourceTeamMembershipModel {
@@ -382,4 +333,11 @@ func flattenTeamMembership(userID, teamID, role string) resourceTeamMembershipMo
 
 func flattenTeamMembershipID(userID, teamID string) types.String {
 	return types.StringValue(fmt.Sprintf("%s:%s", userID, teamID))
+}
+
+func (r *resourceTeamMembership) invalidateTeamMembershipCache(teamID, reason string) {
+	if teamID == "" {
+		return
+	}
+	invalidateTeamMembershipReadCache(r.client, teamID, reason)
 }

--- a/pagerdutyplugin/resource_pagerduty_team_membership_read.go
+++ b/pagerdutyplugin/resource_pagerduty_team_membership_read.go
@@ -1,0 +1,389 @@
+package pagerduty
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/PagerDuty/go-pagerduty"
+	"github.com/PagerDuty/terraform-provider-pagerduty/util"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+)
+
+// This file keeps the pagerduty_team_membership read path scalable for large teams.
+// Steady-state reads share one team snapshot per client/team within a single run,
+// while post-write verification always reads through to the API.
+
+const enableTeamMembershipReadCacheEnv = "PAGERDUTY_ENABLE_TEAM_MEMBERSHIP_READ_CACHE"
+
+type teamMembershipSnapshotFetcher func(context.Context, string) (*teamMembershipSnapshot, error)
+type teamMembershipMemberFetcher func(context.Context, string, string) (teamMembershipCacheMember, bool, error)
+
+type teamMembershipReadMode int
+
+const (
+	// teamMembershipReadSteadyState is the normal refresh/read path. It may use
+	// the shared in-memory snapshot cache for repeated lookups within the same run.
+	teamMembershipReadSteadyState teamMembershipReadMode = iota
+	// teamMembershipReadPostWriteVerification is used immediately after create/update
+	// to confirm the remote role state. It always bypasses the shared read cache.
+	teamMembershipReadPostWriteVerification
+)
+
+type teamMembershipCacheMember struct {
+	Role string
+}
+
+type teamMembershipSnapshot struct {
+	generation   uint64
+	fetchedAt    time.Time
+	membersByID  map[string]teamMembershipCacheMember
+	memberCount  int
+	pagesFetched int
+}
+
+type teamMembershipReadCacheEntry struct {
+	snapshot    *teamMembershipSnapshot
+	waitCh      chan struct{}
+	invalidated bool
+}
+
+type teamMembershipSnapshotAccess struct {
+	snapshot *teamMembershipSnapshot
+	waitCh   chan struct{}
+}
+
+type teamMembershipReadCache struct {
+	mu          sync.Mutex
+	entries     map[string]*teamMembershipReadCacheEntry
+	generations map[string]uint64
+	disabled    bool
+}
+
+type teamMembershipReadCacheRegistry struct {
+	mu     sync.Mutex
+	caches map[*pagerduty.Client]*teamMembershipReadCache
+}
+
+// Cache instances are scoped per PagerDuty client so provider aliases do not
+// share team snapshots with each other.
+var globalTeamMembershipReadCaches = newTeamMembershipReadCacheRegistry()
+
+func newTeamMembershipReadCacheRegistry() *teamMembershipReadCacheRegistry {
+	return &teamMembershipReadCacheRegistry{
+		caches: map[*pagerduty.Client]*teamMembershipReadCache{},
+	}
+}
+
+func newTeamMembershipReadCache() *teamMembershipReadCache {
+	_, enabled := os.LookupEnv(enableTeamMembershipReadCacheEnv)
+	if enabled {
+		log.Printf("[INFO] team-members-cache enabled via %s", enableTeamMembershipReadCacheEnv)
+	}
+	return newTeamMembershipReadCacheWithDisabled(!enabled)
+}
+
+func newTeamMembershipReadCacheWithDisabled(disabled bool) *teamMembershipReadCache {
+	return &teamMembershipReadCache{
+		entries:     map[string]*teamMembershipReadCacheEntry{},
+		generations: map[string]uint64{},
+		disabled:    disabled,
+	}
+}
+
+func (registry *teamMembershipReadCacheRegistry) cacheForClient(client *pagerduty.Client) *teamMembershipReadCache {
+	if client == nil {
+		return nil
+	}
+
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+
+	if cache, ok := registry.caches[client]; ok {
+		return cache
+	}
+
+	cache := newTeamMembershipReadCache()
+	registry.caches[client] = cache
+	return cache
+}
+
+func invalidateTeamMembershipReadCache(client *pagerduty.Client, teamID, reason string) {
+	cache := globalTeamMembershipReadCaches.cacheForClient(client)
+	if cache == nil {
+		return
+	}
+	cache.invalidate(teamID, reason)
+}
+
+func (cache *teamMembershipReadCache) lookup(ctx context.Context, teamID, userID string, fetch teamMembershipSnapshotFetcher) (teamMembershipCacheMember, bool, error) {
+	snapshot, err := cache.getSnapshot(ctx, teamID, fetch)
+	if err != nil {
+		return teamMembershipCacheMember{}, false, err
+	}
+
+	member, found := snapshot.membersByID[userID]
+	return member, found, nil
+}
+
+func (cache *teamMembershipReadCache) getSnapshot(ctx context.Context, teamID string, fetch teamMembershipSnapshotFetcher) (*teamMembershipSnapshot, error) {
+	if cache == nil {
+		return fetch(ctx, teamID)
+	}
+	if cache.disabled {
+		log.Printf("[DEBUG] team-members-cache bypass team=%s reason=disabled", teamID)
+		return fetch(ctx, teamID)
+	}
+
+	for {
+		// Same-team lookups share one in-flight fetch so refresh can stay parallel
+		// across teams without re-reading the same team pages for each resource.
+		access := cache.getCachedSnapshotOrWait(teamID)
+		if access.snapshot != nil {
+			return access.snapshot, nil
+		}
+		if access.waitCh != nil {
+			if err := waitForTeamMembershipSnapshot(ctx, access.waitCh); err != nil {
+				return nil, err
+			}
+			continue
+		}
+
+		waitCh := cache.beginSnapshotFetch(teamID)
+
+		log.Printf("[DEBUG] team-members-cache miss team=%s reason=not_present", teamID)
+		snapshot, err := fetch(ctx, teamID)
+
+		storedSnapshot, needsRetry, storeErr := cache.storeFetchedSnapshot(teamID, waitCh, snapshot, err)
+		if storeErr != nil {
+			return nil, storeErr
+		}
+		if needsRetry {
+			continue
+		}
+		return storedSnapshot, nil
+	}
+}
+
+func (cache *teamMembershipReadCache) getCachedSnapshotOrWait(teamID string) teamMembershipSnapshotAccess {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+
+	entry, ok := cache.entries[teamID]
+	if !ok {
+		return teamMembershipSnapshotAccess{}
+	}
+	if entry.snapshot != nil {
+		return teamMembershipSnapshotAccess{snapshot: entry.snapshot}
+	}
+
+	return teamMembershipSnapshotAccess{waitCh: entry.waitCh}
+}
+
+func (cache *teamMembershipReadCache) beginSnapshotFetch(teamID string) chan struct{} {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+
+	waitCh := make(chan struct{})
+	cache.entries[teamID] = &teamMembershipReadCacheEntry{waitCh: waitCh}
+	return waitCh
+}
+
+func waitForTeamMembershipSnapshot(ctx context.Context, waitCh chan struct{}) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-waitCh:
+		return nil
+	}
+}
+
+func (cache *teamMembershipReadCache) storeFetchedSnapshot(teamID string, waitCh chan struct{}, snapshot *teamMembershipSnapshot, fetchErr error) (*teamMembershipSnapshot, bool, error) {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+
+	current := cache.entries[teamID]
+	entryChanged := current == nil || current.waitCh != waitCh || current.snapshot != nil
+	if entryChanged {
+		if fetchErr != nil {
+			return nil, false, fetchErr
+		}
+		return snapshot, false, nil
+	}
+
+	if current.invalidated {
+		// An in-flight fetch cannot be cancelled safely, so invalidate marks its
+		// result as disposable and forces the caller to refetch on completion.
+		delete(cache.entries, teamID)
+		close(waitCh)
+		if fetchErr != nil {
+			return nil, false, fetchErr
+		}
+		return nil, true, nil
+	}
+
+	if fetchErr != nil {
+		delete(cache.entries, teamID)
+		close(waitCh)
+		return nil, false, fetchErr
+	}
+
+	generation := cache.generations[teamID] + 1
+	cache.generations[teamID] = generation
+	snapshot.generation = generation
+	current.snapshot = snapshot
+	close(waitCh)
+
+	logTeamMembershipCacheStore(teamID, snapshot)
+	return snapshot, false, nil
+}
+
+func (cache *teamMembershipReadCache) invalidate(teamID, reason string) {
+	if cache == nil || cache.disabled {
+		return
+	}
+
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+
+	entry, ok := cache.entries[teamID]
+	if !ok {
+		return
+	}
+
+	var generation uint64
+	if entry.snapshot != nil {
+		generation = entry.snapshot.generation
+	}
+
+	if entry.snapshot == nil && entry.waitCh != nil {
+		// Writes can race with an in-flight read. Marking the entry invalid lets
+		// the fetch finish, but prevents that stale snapshot from being reused.
+		entry.invalidated = true
+		logTeamMembershipCacheInvalidate(teamID, generation, reason)
+		return
+	}
+
+	delete(cache.entries, teamID)
+	logTeamMembershipCacheInvalidate(teamID, generation, reason)
+}
+
+func requestGetTeamMembership(ctx context.Context, client *pagerduty.Client, id string, neededRole *string, mode teamMembershipReadMode, retryNotFound bool, diags *diag.Diagnostics) (resourceTeamMembershipModel, error) {
+	if mode == teamMembershipReadPostWriteVerification {
+		return requestGetTeamMembershipUncached(ctx, client, id, neededRole, retryNotFound, diags)
+	}
+
+	cache := globalTeamMembershipReadCaches.cacheForClient(client)
+	return requestGetTeamMembershipWithFetcher(ctx, id, neededRole, retryNotFound, diags, func(ctx context.Context, teamID, userID string) (teamMembershipCacheMember, bool, error) {
+		return cache.lookup(ctx, teamID, userID, func(ctx context.Context, teamID string) (*teamMembershipSnapshot, error) {
+			return fetchTeamMembershipSnapshot(ctx, client, teamID)
+		})
+	})
+}
+
+func logTeamMembershipCacheStore(teamID string, snapshot *teamMembershipSnapshot) {
+	log.Printf("[DEBUG] team-members-cache store team=%s generation=%d members=%d pages=%d", teamID, snapshot.generation, snapshot.memberCount, snapshot.pagesFetched)
+}
+
+func logTeamMembershipCacheInvalidate(teamID string, generation uint64, reason string) {
+	log.Printf("[DEBUG] team-members-cache invalidate team=%s generation=%d reason=%s", teamID, generation, reason)
+}
+
+func requestGetTeamMembershipUncached(ctx context.Context, client *pagerduty.Client, id string, neededRole *string, retryNotFound bool, diags *diag.Diagnostics) (resourceTeamMembershipModel, error) {
+	// Post-write verification reads fresh remote state so the cache cannot mask
+	// eventual consistency or role propagation delays.
+	return requestGetTeamMembershipWithFetcher(ctx, id, neededRole, retryNotFound, diags, func(ctx context.Context, teamID, userID string) (teamMembershipCacheMember, bool, error) {
+		snapshot, err := fetchTeamMembershipSnapshot(ctx, client, teamID)
+		if err != nil {
+			return teamMembershipCacheMember{}, false, err
+		}
+
+		member, found := snapshot.membersByID[userID]
+		return member, found, nil
+	})
+}
+
+func requestGetTeamMembershipWithFetcher(ctx context.Context, id string, neededRole *string, retryNotFound bool, diags *diag.Diagnostics, fetchMember teamMembershipMemberFetcher) (resourceTeamMembershipModel, error) {
+	var model resourceTeamMembershipModel
+
+	userID, teamID, err := util.ResourcePagerDutyParseColonCompoundID(id)
+	if err != nil {
+		diags.AddError(fmt.Sprintf("Invalid Team Membership ID %s", id), err.Error())
+		return model, nil
+	}
+
+	err = retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
+		member, found, err := fetchMember(ctx, teamID, userID)
+		if err != nil {
+			return teamMembershipRetryError(err, retryNotFound)
+		}
+
+		if !found {
+			return teamMembershipNotFoundRetryError(retryNotFound)
+		}
+
+		if neededRole != nil && member.Role != *neededRole {
+			err = fmt.Errorf("Role %q fetched is different from configuration %q", member.Role, *neededRole)
+			return retry.RetryableError(err)
+		}
+
+		model = flattenTeamMembership(userID, teamID, member.Role)
+		return nil
+	})
+
+	return model, err
+}
+
+func teamMembershipRetryError(err error, retryNotFound bool) *retry.RetryError {
+	if util.IsBadRequestError(err) {
+		return retry.NonRetryableError(err)
+	}
+	if !retryNotFound && util.IsNotFoundError(err) {
+		return retry.NonRetryableError(err)
+	}
+	return retry.RetryableError(err)
+}
+
+func teamMembershipNotFoundRetryError(retryNotFound bool) *retry.RetryError {
+	err := pagerduty.APIError{StatusCode: http.StatusNotFound}
+	if retryNotFound {
+		return retry.RetryableError(err)
+	}
+	return retry.NonRetryableError(err)
+}
+
+func fetchTeamMembershipSnapshot(ctx context.Context, client *pagerduty.Client, teamID string) (*teamMembershipSnapshot, error) {
+	snapshot := &teamMembershipSnapshot{
+		fetchedAt:   time.Now(),
+		membersByID: map[string]teamMembershipCacheMember{},
+	}
+
+	offset := uint(0)
+	more := true
+
+	for more {
+		resp, err := client.ListTeamMembers(ctx, teamID, pagerduty.ListTeamMembersOptions{
+			Limit:  100,
+			Offset: offset,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		snapshot.pagesFetched++
+		for _, m := range resp.Members {
+			snapshot.membersByID[m.User.ID] = teamMembershipCacheMember{Role: m.Role}
+		}
+
+		more = resp.More
+		offset += resp.Limit
+	}
+
+	snapshot.memberCount = len(snapshot.membersByID)
+	return snapshot, nil
+}

--- a/pagerdutyplugin/resource_pagerduty_team_membership_read_test.go
+++ b/pagerdutyplugin/resource_pagerduty_team_membership_read_test.go
@@ -1,0 +1,590 @@
+package pagerduty
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	pathpkg "path"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/PagerDuty/go-pagerduty"
+	"github.com/PagerDuty/terraform-provider-pagerduty/util"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+func TestTeamMembershipReadCacheLookupReusesSnapshot(t *testing.T) {
+	t.Parallel()
+
+	cache := newTeamMembershipReadCacheWithDisabled(false)
+	var fetchCount atomic.Int32
+
+	fetch := testCountingSnapshotFetcher(&fetchCount, testSnapshot(1,
+		testMemberRole("user-a", "manager"),
+		testMemberRole("user-b", "observer"),
+	))
+
+	snapA, err := cache.getSnapshot(context.Background(), "team-1", fetch)
+	if err != nil {
+		t.Fatalf("getSnapshot failed: %v", err)
+	}
+
+	snapB, err := cache.getSnapshot(context.Background(), "team-1", fetch)
+	if err != nil {
+		t.Fatalf("getSnapshot failed: %v", err)
+	}
+
+	if got := fetchCount.Load(); got != 1 {
+		t.Fatalf("expected exactly one fetch, got %d", got)
+	}
+	if snapA.generation != 1 || snapB.generation != 1 {
+		t.Fatalf("expected cached generation 1, got %d and %d", snapA.generation, snapB.generation)
+	}
+}
+
+func TestTeamMembershipReadCacheLookupReturnsMemberFromSnapshot(t *testing.T) {
+	t.Parallel()
+
+	cache := newTeamMembershipReadCacheWithDisabled(false)
+	var fetchCount atomic.Int32
+
+	fetch := testCountingSnapshotFetcher(&fetchCount, testSnapshot(1,
+		testMemberRole("user-a", "manager"),
+		testMemberRole("user-b", "observer"),
+	))
+
+	memberA, foundA, err := cache.lookup(context.Background(), "team-1", "user-a", fetch)
+	if err != nil {
+		t.Fatalf("lookup user-a failed: %v", err)
+	}
+	if !foundA || memberA.Role != "manager" {
+		t.Fatalf("unexpected lookup result for user-a: found=%t role=%q", foundA, memberA.Role)
+	}
+
+	memberB, foundB, err := cache.lookup(context.Background(), "team-1", "user-b", fetch)
+	if err != nil {
+		t.Fatalf("lookup user-b failed: %v", err)
+	}
+	if !foundB || memberB.Role != "observer" {
+		t.Fatalf("unexpected lookup result for user-b: found=%t role=%q", foundB, memberB.Role)
+	}
+
+	if got := fetchCount.Load(); got != 1 {
+		t.Fatalf("expected exactly one fetch, got %d", got)
+	}
+}
+
+func TestTeamMembershipReadCacheInvalidateForcesRefetch(t *testing.T) {
+	t.Parallel()
+
+	cache := newTeamMembershipReadCacheWithDisabled(false)
+	var fetchCount atomic.Int32
+
+	fetch := func(_ context.Context, teamID string) (*teamMembershipSnapshot, error) {
+		count := fetchCount.Add(1)
+		return testSnapshot(int(count),
+			testMemberRole("user-a", "manager"),
+		), nil
+	}
+
+	snapA, err := cache.getSnapshot(context.Background(), "team-1", fetch)
+	if err != nil {
+		t.Fatalf("first getSnapshot failed: %v", err)
+	}
+
+	cache.invalidate("team-1", "test")
+
+	snapB, err := cache.getSnapshot(context.Background(), "team-1", fetch)
+	if err != nil {
+		t.Fatalf("second getSnapshot failed: %v", err)
+	}
+
+	if got := fetchCount.Load(); got != 2 {
+		t.Fatalf("expected refetch after invalidation, got %d fetches", got)
+	}
+	if snapA.generation == snapB.generation {
+		t.Fatalf("expected a new generation after invalidation, got %d and %d", snapA.generation, snapB.generation)
+	}
+}
+
+func TestTeamMembershipReadCacheConcurrentLookupDeduplicatesFetch(t *testing.T) {
+	t.Parallel()
+
+	cache := newTeamMembershipReadCacheWithDisabled(false)
+	var fetchCount atomic.Int32
+	started := make(chan struct{})
+	var startOnce sync.Once
+
+	fetch := func(_ context.Context, teamID string) (*teamMembershipSnapshot, error) {
+		fetchCount.Add(1)
+		startOnce.Do(func() { close(started) })
+		time.Sleep(25 * time.Millisecond)
+		return testSnapshot(1, testMemberRole("user-a", "manager")), nil
+	}
+
+	const workers = 8
+	var wg sync.WaitGroup
+	errs := make(chan error, workers)
+
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, found, err := cache.lookup(context.Background(), "team-1", "user-a", fetch)
+			if err != nil {
+				errs <- err
+				return
+			}
+			if !found {
+				errs <- errLookupNotFound
+			}
+		}()
+	}
+
+	<-started
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent lookup failed: %v", err)
+		}
+	}
+
+	if got := fetchCount.Load(); got != 1 {
+		t.Fatalf("expected a single fetch for concurrent lookups, got %d", got)
+	}
+}
+
+func TestTeamMembershipReadCacheDisabledBypassesStorage(t *testing.T) {
+	t.Parallel()
+
+	cache := newTeamMembershipReadCacheWithDisabled(true)
+	var fetchCount atomic.Int32
+
+	fetch := testCountingSnapshotFetcher(&fetchCount, testSnapshot(1,
+		testMemberRole("user-a", "manager"),
+	))
+
+	for i := 0; i < 2; i++ {
+		_, found, err := cache.lookup(context.Background(), "team-1", "user-a", fetch)
+		if err != nil {
+			t.Fatalf("lookup %d failed: %v", i, err)
+		}
+		if !found {
+			t.Fatalf("lookup %d did not find expected user", i)
+		}
+	}
+
+	if got := fetchCount.Load(); got != 2 {
+		t.Fatalf("expected cache-disabled path to fetch every time, got %d", got)
+	}
+}
+
+func TestTeamMembershipReadCacheFetchErrorDoesNotPoisonCache(t *testing.T) {
+	t.Parallel()
+
+	cache := newTeamMembershipReadCacheWithDisabled(false)
+	var fetchCount atomic.Int32
+
+	fetch := func(_ context.Context, teamID string) (*teamMembershipSnapshot, error) {
+		count := fetchCount.Add(1)
+		if count == 1 {
+			return nil, errors.New("transient fetch error")
+		}
+		return testSnapshot(1, testMemberRole("user-a", "manager")), nil
+	}
+
+	_, found, err := cache.lookup(context.Background(), "team-1", "user-a", fetch)
+	if err == nil {
+		t.Fatal("expected first lookup to fail")
+	}
+	if found {
+		t.Fatal("expected first lookup to not report found")
+	}
+
+	member, found, err := cache.lookup(context.Background(), "team-1", "user-a", fetch)
+	if err != nil {
+		t.Fatalf("second lookup failed: %v", err)
+	}
+	if !found || member.Role != "manager" {
+		t.Fatalf("unexpected second lookup result: found=%t role=%q", found, member.Role)
+	}
+	if got := fetchCount.Load(); got != 2 {
+		t.Fatalf("expected fetch error path to refetch, got %d fetches", got)
+	}
+}
+
+func TestFetchTeamMembershipSnapshotPaginates(t *testing.T) {
+	t.Parallel()
+
+	client, requests := newTestTeamMembershipClient(t, map[string][]testTeamMemberPage{
+		"team-1": {
+			{
+				Members: []testTeamMember{
+					{UserID: "user-a", Role: "manager"},
+					{UserID: "user-b", Role: "observer"},
+				},
+				More:   true,
+				Limit:  2,
+				Offset: 0,
+			},
+			{
+				Members: []testTeamMember{
+					{UserID: "user-c", Role: "responder"},
+				},
+				More:   false,
+				Limit:  2,
+				Offset: 2,
+			},
+		},
+	})
+
+	snapshot, err := fetchTeamMembershipSnapshot(context.Background(), client, "team-1")
+	if err != nil {
+		t.Fatalf("fetchTeamMembershipSnapshot failed: %v", err)
+	}
+
+	if snapshot.memberCount != 3 {
+		t.Fatalf("expected 3 members, got %d", snapshot.memberCount)
+	}
+	if snapshot.pagesFetched != 2 {
+		t.Fatalf("expected 2 pages fetched, got %d", snapshot.pagesFetched)
+	}
+	if snapshot.membersByID["user-c"].Role != "responder" {
+		t.Fatalf("expected user-c role responder, got %q", snapshot.membersByID["user-c"].Role)
+	}
+	if got := requests.Load(); got != 2 {
+		t.Fatalf("expected 2 API requests, got %d", got)
+	}
+}
+
+func TestFetchTeamMembershipSnapshotHandlesEmptyTeam(t *testing.T) {
+	t.Parallel()
+
+	client, requests := newTestTeamMembershipClient(t, map[string][]testTeamMemberPage{
+		"team-1": {
+			{
+				Members: nil,
+				More:    false,
+				Limit:   100,
+				Offset:  0,
+			},
+		},
+	})
+
+	snapshot, err := fetchTeamMembershipSnapshot(context.Background(), client, "team-1")
+	if err != nil {
+		t.Fatalf("fetchTeamMembershipSnapshot failed: %v", err)
+	}
+
+	if snapshot.memberCount != 0 {
+		t.Fatalf("expected 0 members, got %d", snapshot.memberCount)
+	}
+	if snapshot.pagesFetched != 1 {
+		t.Fatalf("expected 1 page fetched for empty team, got %d", snapshot.pagesFetched)
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("expected 1 API request, got %d", got)
+	}
+}
+
+func TestRequestGetTeamMembershipUsesCacheForSteadyStateRead(t *testing.T) {
+	client, requests := newTestTeamMembershipClient(t, map[string][]testTeamMemberPage{
+		"team-1": {
+			{
+				Members: []testTeamMember{
+					{UserID: "user-a", Role: "manager"},
+					{UserID: "user-b", Role: "observer"},
+				},
+				More:   false,
+				Limit:  100,
+				Offset: 0,
+			},
+		},
+	})
+	enableTeamMembershipReadCacheForClient(client)
+	var diags diag.Diagnostics
+
+	modelA, err := requestGetTeamMembership(context.Background(), client, "user-a:team-1", nil, teamMembershipReadSteadyState, false, &diags)
+	if err != nil {
+		t.Fatalf("first requestGetTeamMembership failed: %v", err)
+	}
+	modelB, err := requestGetTeamMembership(context.Background(), client, "user-b:team-1", nil, teamMembershipReadSteadyState, false, &diags)
+	if err != nil {
+		t.Fatalf("second requestGetTeamMembership failed: %v", err)
+	}
+
+	if modelA.Role.ValueString() != "manager" || modelB.Role.ValueString() != "observer" {
+		t.Fatalf("unexpected roles: %q %q", modelA.Role.ValueString(), modelB.Role.ValueString())
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("expected steady-state reads to reuse cached snapshot, got %d requests", got)
+	}
+}
+
+func TestRequestGetTeamMembershipBypassesCacheForPostWriteVerification(t *testing.T) {
+	client, requests := newTestTeamMembershipClient(t, map[string][]testTeamMemberPage{
+		"team-1": {
+			{
+				Members: []testTeamMember{
+					{UserID: "user-a", Role: "manager"},
+				},
+				More:   false,
+				Limit:  100,
+				Offset: 0,
+			},
+		},
+	})
+	enableTeamMembershipReadCacheForClient(client)
+	var diags diag.Diagnostics
+
+	_, err := requestGetTeamMembership(context.Background(), client, "user-a:team-1", nil, teamMembershipReadSteadyState, false, &diags)
+	if err != nil {
+		t.Fatalf("cached requestGetTeamMembership failed: %v", err)
+	}
+
+	role := "manager"
+	_, err = requestGetTeamMembership(context.Background(), client, "user-a:team-1", &role, teamMembershipReadPostWriteVerification, true, &diags)
+	if err != nil {
+		t.Fatalf("post-write verification requestGetTeamMembership failed: %v", err)
+	}
+
+	if got := requests.Load(); got != 2 {
+		t.Fatalf("expected post-write verification path to bypass cache, got %d requests", got)
+	}
+}
+
+func TestRequestGetTeamMembershipReturnsNotFoundForMissingMember(t *testing.T) {
+	client, requests := newTestTeamMembershipClient(t, map[string][]testTeamMemberPage{
+		"team-1": {
+			{
+				Members: []testTeamMember{
+					{UserID: "user-a", Role: "manager"},
+				},
+				More:   false,
+				Limit:  100,
+				Offset: 0,
+			},
+		},
+	})
+	enableTeamMembershipReadCacheForClient(client)
+	var diags diag.Diagnostics
+
+	_, err := requestGetTeamMembership(context.Background(), client, "user-missing:team-1", nil, teamMembershipReadSteadyState, false, &diags)
+	if err == nil {
+		t.Fatal("expected missing member lookup to fail")
+	}
+	if !util.IsNotFoundError(err) {
+		t.Fatalf("expected not found error, got %v", err)
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("expected one API request for missing member lookup, got %d", got)
+	}
+}
+
+func TestRequestGetTeamMembershipReturnsNotFoundForMissingTeam(t *testing.T) {
+	t.Parallel()
+
+	client, requests := newTestTeamMembershipClient(t, map[string][]testTeamMemberPage{})
+	var diags diag.Diagnostics
+
+	_, err := requestGetTeamMembership(context.Background(), client, "user-a:team-missing", nil, teamMembershipReadSteadyState, false, &diags)
+	if err == nil {
+		t.Fatal("expected missing team lookup to fail")
+	}
+	if !util.IsNotFoundError(err) {
+		t.Fatalf("expected not found error, got %v", err)
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("expected one API request for missing team lookup, got %d", got)
+	}
+}
+
+func TestTeamMembershipReadCacheInvalidateDuringInflightFetchRefetches(t *testing.T) {
+	t.Parallel()
+
+	cache := newTeamMembershipReadCacheWithDisabled(false)
+	var fetchCount atomic.Int32
+	firstFetchStarted := make(chan struct{})
+	releaseFirstFetch := make(chan struct{})
+
+	fetch := func(_ context.Context, teamID string) (*teamMembershipSnapshot, error) {
+		count := fetchCount.Add(1)
+		if count == 1 {
+			close(firstFetchStarted)
+			<-releaseFirstFetch
+		}
+
+		role := "observer"
+		if count == 1 {
+			role = "manager"
+		}
+
+		return testSnapshot(1, testMemberRole("user-a", role)), nil
+	}
+
+	resultCh := make(chan teamMembershipCacheMember, 1)
+	errCh := make(chan error, 1)
+
+	go func() {
+		member, found, err := cache.lookup(context.Background(), "team-1", "user-a", fetch)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		if !found {
+			errCh <- errLookupNotFound
+			return
+		}
+		resultCh <- member
+	}()
+
+	<-firstFetchStarted
+	cache.invalidate("team-1", "test")
+	close(releaseFirstFetch)
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("lookup failed: %v", err)
+	case member := <-resultCh:
+		if member.Role != "observer" {
+			t.Fatalf("expected refetched role after invalidation, got %q", member.Role)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for lookup to complete after invalidation")
+	}
+
+	if got := fetchCount.Load(); got != 2 {
+		t.Fatalf("expected invalidation during inflight fetch to trigger a second fetch, got %d", got)
+	}
+}
+
+var errLookupNotFound = &lookupError{message: "lookup did not find expected user"}
+
+type lookupError struct {
+	message string
+}
+
+func (e *lookupError) Error() string {
+	return e.message
+}
+
+func testSnapshot(pagesFetched int, members ...testTeamMembership) *teamMembershipSnapshot {
+	snapshotMembers := make(map[string]teamMembershipCacheMember, len(members))
+	for _, member := range members {
+		snapshotMembers[member.userID] = teamMembershipCacheMember{Role: member.role}
+	}
+
+	return &teamMembershipSnapshot{
+		fetchedAt:    time.Now(),
+		membersByID:  snapshotMembers,
+		memberCount:  len(members),
+		pagesFetched: pagesFetched,
+	}
+}
+
+func enableTeamMembershipReadCacheForClient(client *pagerduty.Client) {
+	globalTeamMembershipReadCaches = newTeamMembershipReadCacheRegistry()
+	globalTeamMembershipReadCaches.caches[client] = newTeamMembershipReadCacheWithDisabled(false)
+}
+
+func testCountingSnapshotFetcher(fetchCount *atomic.Int32, snapshot *teamMembershipSnapshot) teamMembershipSnapshotFetcher {
+	return func(_ context.Context, teamID string) (*teamMembershipSnapshot, error) {
+		fetchCount.Add(1)
+		return snapshot, nil
+	}
+}
+
+func testMemberRole(userID, role string) testTeamMembership {
+	return testTeamMembership{
+		userID: userID,
+		role:   role,
+	}
+}
+
+type testTeamMembership struct {
+	userID string
+	role   string
+}
+
+type testTeamMember struct {
+	UserID string
+	Role   string
+}
+
+type testTeamMemberPage struct {
+	Members []testTeamMember
+	More    bool
+	Limit   uint
+	Offset  uint
+}
+
+func newTestTeamMembershipClient(t *testing.T, pages map[string][]testTeamMemberPage) (*pagerduty.Client, *atomic.Int32) {
+	t.Helper()
+
+	var requests atomic.Int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+
+		requests.Add(1)
+		teamID := pathpkg.Base(pathpkg.Dir(r.URL.Path))
+		offset := uint(0)
+		if v := r.URL.Query().Get("offset"); v != "" {
+			i, err := strconv.Atoi(v)
+			if err != nil {
+				t.Fatalf("invalid offset %q: %v", v, err)
+			}
+			offset = uint(i)
+		}
+
+		var page testTeamMemberPage
+		found := false
+		for _, candidate := range pages[teamID] {
+			if candidate.Offset == offset {
+				page = candidate
+				found = true
+				break
+			}
+		}
+		if !found {
+			http.Error(w, `{"error":{"message":"not found","code":2100}}`, http.StatusNotFound)
+			return
+		}
+
+		var members []map[string]any
+		for _, member := range page.Members {
+			members = append(members, map[string]any{
+				"user": map[string]any{
+					"id":   member.UserID,
+					"type": "user_reference",
+				},
+				"role": member.Role,
+			})
+		}
+
+		resp := map[string]any{
+			"members": members,
+			"limit":   page.Limit,
+			"offset":  page.Offset,
+			"more":    page.More,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatalf("failed to encode response: %v", err)
+		}
+	})
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	client := pagerduty.NewClient("test-token", WithHTTPClient(server.Client()), pagerduty.WithAPIEndpoint(server.URL))
+	return client, &requests
+}


### PR DESCRIPTION
## Summary

This PR adds an opt-in in-memory cache for `pagerduty_team_membership` reads to reduce repeated `/teams/{id}/members` list calls for large teams.

This is intended to address the scaling problem described in #318, where `terraform plan` / refresh becomes very slow when a single team has a large number of memberships managed as individual `pagerduty_team_membership` resources.

The cache is enabled only when `PAGERDUTY_ENABLE_TEAM_MEMBERSHIP_READ_CACHE=1` is set.

## Background

Today, each `pagerduty_team_membership` read walks the team members list from the beginning until it finds the target user. For large teams, and especially when many resources share the same `team_id`, this causes the provider to re-read the same paginated team member list many times during a single refresh.

This PR changes the steady-state read path so that, when enabled, memberships for the same team share a single snapshot within the same Terraform run.

## What changed

- add a dedicated read-path helper for `pagerduty_team_membership`
- add an opt-in in-memory cache for team membership reads
- make cache access concurrency-safe and deduplicate in-flight snapshot fetches for the same team
- share one team snapshot across repeated steady-state reads for the same team
- invalidate the cached snapshot after `Create`, `Update`, and `Delete`
- bypass the cache for post-write verification reads
- add unit tests for cache reuse, invalidation, pagination, missing members/teams, and fetch error recovery

## Performance impact

Without this cache, if you have many membership resources for a single team, Terraform may walk the same paginated team-members list repeatedly during refresh/plan. With the cache enabled, steady-state reads for that team share a single snapshot fetch within the same provider process.

This changes the repeated-read pattern from roughly `O(resources * pages)` to `O(pages)` per team for steady-state reads, which should significantly reduce API rate-limit pressure and execution time for large teams.

## Cache scope

This is a short-lived in-memory cache scoped to a single Terraform provider process. It is only used within one Terraform run and is not persisted across separate plan/apply executions.

## Why this is opt-in

I kept this behind `PAGERDUTY_ENABLE_TEAM_MEMBERSHIP_READ_CACHE=1` instead of enabling it by default because the optimization is specifically aimed at accounts with very large teams and many `pagerduty_team_membership` resources sharing the same `team_id`.

There is an explicit tradeoff here:

- for large teams with many memberships, sharing a single team snapshot can dramatically reduce repeated list calls
- for small teams, or for configurations with only one/few membership resources, this can be slower
- the reason is that the snapshot path reads the full team member list, while the existing behavior can stop early as soon as the target user is found

Because of that tradeoff, I chose to keep the current behavior as the default and make the cache an opt-in feature for users who already know they are hitting this scaling problem.

## Scope

This PR only changes the `pagerduty_team_membership` read path. Similar list-based read patterns in other resources are out of scope for this change.

## Testing

- added unit tests covering cache reuse, invalidation, pagination, missing members/teams, and fetch error recovery
- verified the Go test suite locally
- I have not yet run a manual large-team performance comparison against a real PagerDuty account, and I do not currently have access to a suitable PagerDuty account with teams for end-to-end Terraform verification

## References

- Relates to #318
