### PR TITLE
Validate timeout is only applicable for time-based alert grouping

### DIFF
--- a/pagerdutyplugin/resource_pagerduty_alert_grouping_setting.go
+++ b/pagerdutyplugin/resource_pagerduty_alert_grouping_setting.go
@@ -140,7 +140,14 @@ func (r *resourceAlertGroupingSetting) ValidateConfig(ctx context.Context, req r
 		if model.Config.Attributes()["aggregate"].IsNull() {
 			resp.Diagnostics.AddAttributeError(path.Root("config").AtName("aggregate"), "Invalid value", "'aggregate' cannot be blank")
 		}
-		return
+	}
+
+	if t != pagerduty.AlertGroupingSettingTimeType && !model.Config.Attributes()["timeout"].IsNull() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("config").AtName("timeout"),
+			"Invalid configuration",
+			fmt.Sprintf("'timeout' is only applicable when type is %q, got %q", pagerduty.AlertGroupingSettingTimeType, t),
+		)
 	}
 }
 

--- a/pagerdutyplugin/resource_pagerduty_alert_grouping_setting_test.go
+++ b/pagerdutyplugin/resource_pagerduty_alert_grouping_setting_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -687,6 +688,40 @@ resource "pagerduty_alert_grouping_setting" "foo" {
 	}
 	services = [pagerduty_service.foo.id]
 }`, service1, name)
+}
+
+func TestAccPagerDutyAlertGroupingSetting_Intelligent_TimeoutRejected(t *testing.T) {
+	ref := fmt.Sprint("tf-", acctest.RandString(5))
+	service := fmt.Sprint("tf-", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+data "pagerduty_escalation_policy" "default" {
+	name = "Default"
+}
+
+resource "pagerduty_service" "%[2]s" {
+	name = "%[2]s"
+	escalation_policy = data.pagerduty_escalation_policy.default.id
+}
+
+resource "pagerduty_alert_grouping_setting" "%[1]s" {
+	name = "%[1]s"
+	type = "intelligent"
+	services = [pagerduty_service.%[2]s.id]
+	config {
+		timeout = 60
+	}
+}`, ref, service),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`'timeout' is only applicable when type is "time"`),
+			},
+		},
+	})
 }
 
 func testAccPagerDutyAlertGroupingSettingServiceNotExist(ref, service, name string) string {


### PR DESCRIPTION
## Summary

When a user sets `config.timeout` on a non-`time` alert grouping setting (e.g. `intelligent` or `content_based`), the provider silently nulls it during `ModifyPlan`. This causes Terraform core to reject the plan with:

```
Error: Provider produced invalid plan

planned value cty.NullVal(cty.Number) does not match config value cty.NumberIntVal(60).
```

This is confusing because:
- The user gets told "this is a bug in the provider"
- There is no indication that `timeout` is invalid for the chosen type

Experienced with provider version **v3.32.1**.

This PR adds a validation check in `ValidateConfig` so the user gets a clear, actionable error message:

```
'timeout' is only applicable when type is "time", got "intelligent"
```

## Changes

- `resource_pagerduty_alert_grouping_setting.go`: add `timeout` validation in `ValidateConfig`
- `resource_pagerduty_alert_grouping_setting_test.go`: add test confirming `timeout` with `intelligent` type is rejected