### PR TITLE
Fix #318: reduce repeated API calls for pagerduty_team_membership reads

### DIFF
--- a/pagerdutyplugin/resource_pagerduty_team_membership.go
+++ b/pagerdutyplugin/resource_pagerduty_team_membership.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/PagerDuty/go-pagerduty"
@@ -22,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"golang.org/x/sync/singleflight"
 )
 
 type resourceTeamMembership struct{ client *pagerduty.Client }
@@ -30,6 +32,90 @@ var (
 	_ resource.ResourceWithConfigure   = (*resourceTeamMembership)(nil)
 	_ resource.ResourceWithImportState = (*resourceTeamMembership)(nil)
 )
+
+// teamMemberCaches is the global per-client cache registry.
+// The resource struct is recreated per RPC, so the *pagerduty.Client pointer
+// (a stable singleton per provider instance) is the only viable cache key.
+var teamMemberCaches sync.Map // key: *pagerduty.Client, value: *teamMemberCache
+
+type teamMemberCache struct {
+	group   singleflight.Group
+	mu      sync.RWMutex
+	members map[string][]pagerduty.Member // teamID → full member list
+}
+
+func teamMemberCacheFor(client *pagerduty.Client) *teamMemberCache {
+	v, _ := teamMemberCaches.LoadOrStore(client, &teamMemberCache{
+		members: make(map[string][]pagerduty.Member),
+	})
+	return v.(*teamMemberCache)
+}
+
+// getMembers returns the full member list for teamID, fetching once and caching
+// for subsequent calls within the same run. Concurrent calls for the same team
+// are deduplicated via singleflight so only one API page-walk occurs.
+func (c *teamMemberCache) getMembers(ctx context.Context, client *pagerduty.Client, teamID string) ([]pagerduty.Member, error) {
+	c.mu.RLock()
+	if members, ok := c.members[teamID]; ok {
+		c.mu.RUnlock()
+		return members, nil
+	}
+	c.mu.RUnlock()
+
+	result, err, _ := c.group.Do(teamID, func() (any, error) {
+		// Re-check after winning the singleflight race — another goroutine may
+		// have populated the cache between our RLock miss and this point.
+		c.mu.RLock()
+		if members, ok := c.members[teamID]; ok {
+			c.mu.RUnlock()
+			return members, nil
+		}
+		c.mu.RUnlock()
+
+		members, err := fetchAllTeamMembers(ctx, client, teamID)
+		if err != nil {
+			return nil, err
+		}
+
+		c.mu.Lock()
+		c.members[teamID] = members
+		c.mu.Unlock()
+
+		log.Printf("[DEBUG] team-members-cache stored team=%s count=%d", teamID, len(members))
+		return members, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.([]pagerduty.Member), nil
+}
+
+func (c *teamMemberCache) invalidate(teamID string) {
+	c.mu.Lock()
+	delete(c.members, teamID)
+	c.mu.Unlock()
+}
+
+func fetchAllTeamMembers(ctx context.Context, client *pagerduty.Client, teamID string) ([]pagerduty.Member, error) {
+	var all []pagerduty.Member
+	offset := uint(0)
+	more := true
+
+	for more {
+		resp, err := client.ListTeamMembers(ctx, teamID, pagerduty.ListTeamMembersOptions{
+			Limit:  100,
+			Offset: offset,
+		})
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, resp.Members...)
+		more = resp.More
+		offset += resp.Limit
+	}
+
+	return all, nil
+}
 
 func (r *resourceTeamMembership) Metadata(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = "pagerduty_team_membership"
@@ -77,6 +163,7 @@ func (r *resourceTeamMembership) Create(ctx context.Context, req resource.Create
 	id := model.ID.ValueString()
 	role := model.Role.ValueString()
 
+	teamMemberCacheFor(r.client).invalidate(model.TeamID.ValueString())
 	model, err := requestGetTeamMembership(ctx, r.client, id, &role, RetryNotFound, &resp.Diagnostics)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -129,6 +216,7 @@ func (r *resourceTeamMembership) Update(ctx context.Context, req resource.Update
 	id := model.ID.ValueString()
 	role := model.Role.ValueString()
 
+	teamMemberCacheFor(r.client).invalidate(model.TeamID.ValueString())
 	model, err := requestGetTeamMembership(ctx, r.client, id, &role, RetryNotFound, &resp.Diagnostics)
 	if err != nil {
 		if util.IsNotFoundError(err) {
@@ -193,6 +281,7 @@ func (r *resourceTeamMembership) Delete(ctx context.Context, req resource.Delete
 		return
 	}
 
+	teamMemberCacheFor(r.client).invalidate(teamID)
 	resp.State.RemoveResource(ctx)
 }
 
@@ -220,45 +309,43 @@ func requestGetTeamMembership(ctx context.Context, client *pagerduty.Client, id 
 		return model, nil
 	}
 
+	cache := teamMemberCacheFor(client)
+
 	err = retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
-		offset := uint(0)
-		more := true
-
-		for more {
-			resp, err := client.ListTeamMembers(ctx, teamID, pagerduty.ListTeamMembersOptions{
-				Limit:  100,
-				Offset: offset,
-			})
-			if err != nil {
-				if util.IsBadRequestError(err) {
-					return retry.NonRetryableError(err)
-				}
-				if !retryNotFound && util.IsNotFoundError(err) {
-					return retry.NonRetryableError(err)
-				}
-				return retry.RetryableError(err)
+		members, err := cache.getMembers(ctx, client, teamID)
+		if err != nil {
+			// Ensure the next retry fetches fresh data rather than a poison entry.
+			cache.invalidate(teamID)
+			if util.IsBadRequestError(err) {
+				return retry.NonRetryableError(err)
 			}
-
-			for _, m := range resp.Members {
-				if m.User.ID == userID {
-					if neededRole != nil && m.Role != *neededRole {
-						err = fmt.Errorf("Role %q fetched is different from configuration %q", m.Role, *neededRole)
-						return retry.RetryableError(err)
-					}
-					model = flattenTeamMembership(userID, teamID, m.Role)
-					return nil
-				}
+			if !retryNotFound && util.IsNotFoundError(err) {
+				return retry.NonRetryableError(err)
 			}
-
-			more = resp.More
-			offset += resp.Limit
-		}
-
-		err = pagerduty.APIError{StatusCode: http.StatusNotFound}
-		if retryNotFound {
 			return retry.RetryableError(err)
 		}
-		return retry.NonRetryableError(err)
+
+		for _, m := range members {
+			if m.User.ID == userID {
+				if neededRole != nil && m.Role != *neededRole {
+					// Role not yet propagated — drop the cached snapshot so the
+					// next attempt reads the current state from the API.
+					cache.invalidate(teamID)
+					return retry.RetryableError(fmt.Errorf("Role %q fetched is different from configuration %q", m.Role, *neededRole))
+				}
+				model = flattenTeamMembership(userID, teamID, m.Role)
+				return nil
+			}
+		}
+
+		notFoundErr := pagerduty.APIError{StatusCode: http.StatusNotFound}
+		if retryNotFound {
+			// Membership not yet visible — drop the snapshot so the next attempt
+			// re-fetches and can observe the newly created member.
+			cache.invalidate(teamID)
+			return retry.RetryableError(notFoundErr)
+		}
+		return retry.NonRetryableError(notFoundErr)
 	})
 
 	return model, err

--- a/pagerdutyplugin/resource_pagerduty_team_membership_test.go
+++ b/pagerdutyplugin/resource_pagerduty_team_membership_test.go
@@ -171,6 +171,63 @@ func TestAccPagerDutyTeamMembership_DestroyWithEscalationPolicyDependantAndMulti
 	})
 }
 
+// TestAccPagerDutyTeamMembership_MultipleMembers verifies that multiple
+// memberships on the same team are all read back correctly. This exercises
+// the shared-cache path where the second Read serves from the cached snapshot
+// rather than re-fetching the full member list.
+func TestAccPagerDutyTeamMembership_MultipleMembers(t *testing.T) {
+	userA := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	userB := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	team := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(),
+		CheckDestroy:             testAccCheckPagerDutyTeamMembershipDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyTeamMembershipMultipleMembersConfig(userA, userB, team),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyTeamMembershipExists("pagerduty_team_membership.user_a"),
+					testAccCheckPagerDutyTeamMembershipExists("pagerduty_team_membership.user_b"),
+					resource.TestCheckResourceAttr("pagerduty_team_membership.user_a", "role", "manager"),
+					resource.TestCheckResourceAttr("pagerduty_team_membership.user_b", "role", "observer"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccPagerDutyTeamMembership_RoleUpdateReflectsAfterWrite verifies that
+// after a role change the updated role is read back correctly, confirming that
+// the cache is invalidated on Update so stale data is never returned.
+func TestAccPagerDutyTeamMembership_RoleUpdateReflectsAfterWrite(t *testing.T) {
+	user := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	team := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(),
+		CheckDestroy:             testAccCheckPagerDutyTeamMembershipDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyTeamMembershipWithRoleConfig(user, team, "observer"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyTeamMembershipExists("pagerduty_team_membership.foo"),
+					resource.TestCheckResourceAttr("pagerduty_team_membership.foo", "role", "observer"),
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyTeamMembershipWithRoleConfig(user, team, "manager"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyTeamMembershipExists("pagerduty_team_membership.foo"),
+					resource.TestCheckResourceAttr("pagerduty_team_membership.foo", "role", "manager"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckPagerDutyTeamMembershipDestroy(s *terraform.State) error {
 	for _, r := range s.RootModule().Resources {
 		if r.Type != "pagerduty_team_membership" {
@@ -307,6 +364,37 @@ resource "pagerduty_team_membership" "foo" {
   role    = "%[3]v"
 }
 `, user, team, role)
+}
+
+func testAccCheckPagerDutyTeamMembershipMultipleMembersConfig(userA, userB, team string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "user_a" {
+  name  = "%[1]s"
+  email = "%[1]s@foo.test"
+}
+
+resource "pagerduty_user" "user_b" {
+  name  = "%[2]s"
+  email = "%[2]s@foo.test"
+}
+
+resource "pagerduty_team" "foo" {
+  name        = "%[3]s"
+  description = "foo"
+}
+
+resource "pagerduty_team_membership" "user_a" {
+  user_id = pagerduty_user.user_a.id
+  team_id = pagerduty_team.foo.id
+  role    = "manager"
+}
+
+resource "pagerduty_team_membership" "user_b" {
+  user_id = pagerduty_user.user_b.id
+  team_id = pagerduty_team.foo.id
+  role    = "observer"
+}
+`, userA, userB, team)
 }
 
 func testAccCheckPagerDutyTeamMembershipDestroyWithEscalationPolicyDependant(userFoo, userBar, team, role, escalationPolicy string) string {


### PR DESCRIPTION
## Problem

Closes #318.

During `terraform plan` / refresh, each `pagerduty_team_membership` resource independently paginates the full team member list to find its user. With N membership resources on the same team of M members, that is **N × ceil(M/100) API calls** — for a team of 500 with 100 managed memberships, 500 API calls where 5 would suffice.

## Solution

Add a per-client in-memory cache for team member lists, backed by [`singleflight`](https://pkg.go.dev/golang.org/x/sync/singleflight). The first read for a given `team_id` fetches all pages and stores the result; every subsequent read in the same Terraform run serves directly from the map.

- **`singleflight`** deduplicates concurrent in-flight fetches for the same team (Terraform's default parallelism is 10), so only one page-walk happens even under parallel refresh.
- **Cache is invalidated** after `Create`, `Update`, and `Delete` so the post-write verification read always observes current API state.
- **No opt-in required** — the cache is always active and never regresses single-resource configurations.

## Complexity

All changes are confined to `resource_pagerduty_team_membership.go`. No new files.

| | PR #1108 | This PR |
|---|---|---|
| New files | 2 | 0 |
| Net lines (impl) | +337 | +87 |
| Opt-in env var | Required | Not needed |
| In-flight dedup | Custom channels | `singleflight` |
| Invalidation | Generation counters | `delete(map, teamID)` |
| Read modes introduced | 2 | 0 |

## Acceptance test results

All 9 acceptance tests passed against the live PagerDuty API (run time ~4m 25s):

```
--- PASS: TestAccPagerDutyTeamMembership_import (20.90s)
--- PASS: TestAccPagerDutyTeamMembership_importWithRole (19.80s)
--- PASS: TestAccPagerDutyTeamMembership_Basic (18.69s)
--- PASS: TestAccPagerDutyTeamMembership_WithRole (17.84s)
--- PASS: TestAccPagerDutyTeamMembership_WithRoleConsistentlyAssigned (28.84s)
--- PASS: TestAccPagerDutyTeamMembership_DestroyWithEscalationPolicyDependant (48.77s)
--- PASS: TestAccPagerDutyTeamMembership_DestroyWithEscalationPolicyDependantAndMultipleTeams (60.04s)
--- PASS: TestAccPagerDutyTeamMembership_MultipleMembers (20.68s)           ← new
--- PASS: TestAccPagerDutyTeamMembership_RoleUpdateReflectsAfterWrite (28.31s)  ← new
PASS
ok  	github.com/PagerDuty/terraform-provider-pagerduty/pagerdutyplugin	265.169s
```

The two new tests specifically protect against regressions in the cache path:

- **`MultipleMembers`** — two users on the same team with different roles are both read back correctly (exercises the shared-cache path).
- **`RoleUpdateReflectsAfterWrite`** — a role change is immediately visible after update (exercises cache invalidation on write).