### PR TITLE
Add SizeAtMost(1) validator to use_app_oauth_scoped_token block

### DIFF
--- a/pagerdutyplugin/provider.go
+++ b/pagerdutyplugin/provider.go
@@ -8,12 +8,14 @@ import (
 	"strings"
 
 	"github.com/PagerDuty/go-pagerduty"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -28,6 +30,9 @@ func (p *Provider) Metadata(_ context.Context, _ provider.MetadataRequest, resp 
 
 func (p *Provider) Schema(_ context.Context, _ provider.SchemaRequest, resp *provider.SchemaResponse) {
 	useAppOauthScopedTokenBlock := schema.ListNestedBlock{
+		Validators: []validator.List{
+			listvalidator.SizeAtMost(1),
+		},
 		NestedObject: schema.NestedBlockObject{
 			Attributes: map[string]schema.Attribute{
 				"pd_client_id":     schema.StringAttribute{Optional: true},


### PR DESCRIPTION
According to https://developer.hashicorp.com/terraform/plugin/framework/migrating/attributes-blocks/blocks, when migrating the schema config block to Plugin Framework, a size validator is needed to reflect the equivalent of `MaxItems: 1` in the [corresponding SDKv2 block](https://github.com/akamai/terraform-provider-akamai/blob/9dbd942f4a48cfdb27448fe7809305ece6783453/pkg/akamai/sdk_provider.go#L38).

We discovered this downstream when consuming the Plugin Framework schema, and our model inaccurately did not flatten the config block.

Thank you for considering this pull request!

Refs:
- pulumi/pulumi-pagerduty#569 (downstream bug report)
