### PR TITLE
Allow whatsapp_contact_method in notification rule

### DIFF
--- a/pagerduty/resource_pagerduty_user_notification_rule.go
+++ b/pagerduty/resource_pagerduty_user_notification_rule.go
@@ -211,9 +211,10 @@ func expandContactMethod(v interface{}) (*pagerduty.ContactMethodReference, erro
 		case "phone_contact_method":
 		case "push_notification_contact_method":
 		case "sms_contact_method":
+		case "whatsapp_contact_method":
 			// Valid
 		default:
-			return nil, fmt.Errorf("the `type` attribute of `contact_method` must be one of `email_contact_method`, `phone_contact_method`, `push_notification_contact_method` or `sms_contact_method`")
+			return nil, fmt.Errorf("the `type` attribute of `contact_method` must be one of `email_contact_method`, `phone_contact_method`, `push_notification_contact_method`, `sms_contact_method` or `whatsapp_contact_method`")
 		}
 	}
 

--- a/pagerdutyplugin/resource_pagerduty_user_notification_rule.go
+++ b/pagerdutyplugin/resource_pagerduty_user_notification_rule.go
@@ -59,6 +59,7 @@ func (r *resourceUserNotificationRule) Schema(_ context.Context, _ resource.Sche
 								"phone_contact_method",
 								"push_notification_contact_method",
 								"sms_contact_method",
+								"whatsapp_contact_method",
 							),
 						},
 					},

--- a/pagerdutyplugin/resource_pagerduty_user_notification_rule_test.go
+++ b/pagerdutyplugin/resource_pagerduty_user_notification_rule_test.go
@@ -59,7 +59,8 @@ func TestAccPagerDutyUserNotificationRuleContactMethod_Invalid(t *testing.T) {
 				ExpectError: regexp.MustCompile(
 					`Attribute contact_method.type value must be one of: \["email_contact_method"` +
 						`\s+"phone_contact_method" "push_notification_contact_method"` +
-						`\s+"sms_contact_method"\], got: "invalid_contact_method`,
+						`\s+"sms_contact_method" "whatsapp_contact_method"\], got:` +
+						`\s+"invalid_contact_method`,
 				),
 			},
 		},

--- a/website/docs/r/user_notification_rule.html.markdown
+++ b/website/docs/r/user_notification_rule.html.markdown
@@ -87,7 +87,7 @@ The following arguments are supported:
 Contact methods (`contact_method`) supports the following:
 
   * `id` - (Required) The id of the referenced contact method.
-  * `type` - (Required) The type of contact method. Can be `email_contact_method`, `phone_contact_method`, `push_notification_contact_method` or `sms_contact_method`.
+  * `type` - (Required) The type of contact method. Can be `email_contact_method`, `phone_contact_method`, `push_notification_contact_method`, `sms_contact_method` or `whatsapp_contact_method`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
```
+go test ./pagerdutyplugin -run TestAccPagerDutyUserNotificationRule -v
=== RUN   TestAccPagerDutyUserNotificationRule_import
--- PASS: TestAccPagerDutyUserNotificationRule_import (20.46s)
=== RUN   TestAccPagerDutyUserNotificationRuleContactMethod_Basic
--- PASS: TestAccPagerDutyUserNotificationRuleContactMethod_Basic (40.53s)
=== RUN   TestAccPagerDutyUserNotificationRuleContactMethod_Invalid
--- PASS: TestAccPagerDutyUserNotificationRuleContactMethod_Invalid (0.44s)
=== RUN   TestAccPagerDutyUserNotificationRuleContactMethod_Missing_id
--- PASS: TestAccPagerDutyUserNotificationRuleContactMethod_Missing_id (0.20s)
=== RUN   TestAccPagerDutyUserNotificationRuleContactMethod_Missing_type
--- PASS: TestAccPagerDutyUserNotificationRuleContactMethod_Missing_type (0.22s)
=== RUN   TestAccPagerDutyUserNotificationRuleContactMethod_Unknown_key
--- PASS: TestAccPagerDutyUserNotificationRuleContactMethod_Unknown_key (0.22s)
```