### PR TITLE
Fix #1117: retry pagerduty_user create on transient account lock error

### DIFF
--- a/pagerduty/provider.go
+++ b/pagerduty/provider.go
@@ -187,6 +187,16 @@ func isErrCode(err error, code int) bool {
 	return false
 }
 
+// isAccountLockError returns true when the PagerDuty API rejects a write
+// because it couldn't acquire an account-level lock under concurrent load.
+// This is transient and safe to retry.
+func isAccountLockError(err error) bool {
+	if e, ok := err.(*pagerduty.Error); ok {
+		return strings.Contains(fmt.Sprintf("%v", e.Errors), "could not be locked")
+	}
+	return false
+}
+
 func isMalformedNotFoundError(err error) bool {
 	// There are some errors that doesn't stick to expected error interface and
 	// fallback to a simple text error message that can be capture by this regexp.

--- a/pagerduty/resource_pagerduty_user.go
+++ b/pagerduty/resource_pagerduty_user.go
@@ -159,12 +159,22 @@ func resourcePagerDutyUserCreate(d *schema.ResourceData, meta interface{}) error
 
 	log.Printf("[INFO] Creating PagerDuty user %s", user.Name)
 
-	user, _, err = client.Users.Create(user)
-	if err != nil {
-		return err
+	var createdUser *pagerduty.User
+	retryErr := retry.Retry(2*time.Minute, func() *retry.RetryError {
+		createdUser, _, err = client.Users.Create(user)
+		if err != nil {
+			if isErrCode(err, http.StatusBadRequest) && isAccountLockError(err) {
+				return retry.RetryableError(err)
+			}
+			return retry.NonRetryableError(err)
+		}
+		return nil
+	})
+	if retryErr != nil {
+		return retryErr
 	}
 
-	d.SetId(user.ID)
+	d.SetId(createdUser.ID)
 
 	return resourcePagerDutyUserUpdate(d, meta)
 }


### PR DESCRIPTION
Concurrent user creation can trigger a PagerDuty API 400 (code 2001) with "account could not be locked". Wrap the Users.Create call in a retry.Retry block and classify this specific error as retryable, while all other 400s remain non-retryable immediately.

The response is captured in a separate variable to avoid overwriting the input user struct with nil on a failed attempt.