### PR TITLE
Fix #1119: retry team membership delete on concurrent EP destroy race

### DIFF
--- a/pagerduty/resource_pagerduty_team_membership.go
+++ b/pagerduty/resource_pagerduty_team_membership.go
@@ -204,16 +204,17 @@ func resourcePagerDutyTeamMembershipDelete(d *schema.ResourceData, meta interfac
 	}
 
 	var isFoundErrRemovingUserFromTeam bool
+	epRetryCount := 0
 	retryErr := retry.Retry(2*time.Minute, func() *retry.RetryError {
 		if _, err := client.Teams.RemoveUser(teamID, userID); err != nil {
 			if isErrCode(err, 400) && strings.Contains(err.Error(), "User cannot be removed as they belong to an escalation policy on this team") {
-				if !isFoundErrRemovingUserFromTeam {
-					// Giving some time for the escalation policies to be removed during destroy operations.
-					time.Sleep(2 * time.Second)
-					isFoundErrRemovingUserFromTeam = true
+				isFoundErrRemovingUserFromTeam = true
+				// Retry a few times to handle the concurrent-destroy race where an
+				// escalation policy referencing this user is being deleted in parallel.
+				if epRetryCount < 5 {
+					epRetryCount++
 					return retry.RetryableError(err)
 				}
-
 				return retry.NonRetryableError(err)
 			}
 			if isErrCode(err, 400) {

--- a/pagerdutyplugin/resource_pagerduty_team_membership.go
+++ b/pagerdutyplugin/resource_pagerduty_team_membership.go
@@ -252,14 +252,26 @@ func (r *resourceTeamMembership) Delete(ctx context.Context, req resource.Delete
 	}
 
 	userIsInEP := false
+	epRetryCount := 0
 	err = retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
 		if err := r.client.RemoveUserFromTeamWithContext(ctx, teamID, userID); err != nil {
-			userIsInEP = strings.Contains(err.Error(), "User cannot be removed as they belong to an escalation policy on this team")
+			if strings.Contains(err.Error(), "User cannot be removed as they belong to an escalation policy on this team") {
+				userIsInEP = true
+				// Retry a few times to handle the concurrent-destroy race where an
+				// escalation policy referencing this user is being deleted in parallel.
+				if epRetryCount < 5 {
+					epRetryCount++
+					return retry.RetryableError(err)
+				}
+				return retry.NonRetryableError(err)
+			}
+			userIsInEP = false
 			if util.IsBadRequestError(err) {
 				return retry.NonRetryableError(err)
 			}
 			return retry.RetryableError(err)
 		}
+		userIsInEP = false
 		return nil
 	})
 	if userIsInEP {

--- a/pagerdutyplugin/resource_pagerduty_team_membership_test.go
+++ b/pagerdutyplugin/resource_pagerduty_team_membership_test.go
@@ -171,6 +171,42 @@ func TestAccPagerDutyTeamMembership_DestroyWithEscalationPolicyDependantAndMulti
 	})
 }
 
+// TestAccPagerDutyTeamMembership_DestroyWithConcurrentEscalationPolicyDeletion
+// guards against the regression where the EP-blocking 400 is treated as
+// non-retryable. It removes team_membership and escalation_policy from config
+// in the same step so Terraform destroys them in parallel, exercising the
+// concurrent-destroy race. With no retry the membership deletion fails the
+// moment it races with the in-flight EP deletion; with the retry fix the
+// transient 400 is absorbed and the step succeeds.
+func TestAccPagerDutyTeamMembership_DestroyWithConcurrentEscalationPolicyDeletion(t *testing.T) {
+	user := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	team := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(),
+		CheckDestroy:             testAccCheckPagerDutyTeamMembershipDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyTeamMembershipWithConcurrentEPConfig(user, team, escalationPolicy),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyTeamMembershipExists("pagerduty_team_membership.foo"),
+				),
+			},
+			{
+				// Drop both team_membership.foo and escalation_policy.foo from config
+				// in the same step. Terraform destroys them concurrently because there
+				// is no explicit dependency between the two resources.
+				Config: testAccCheckPagerDutyTeamMembershipWithConcurrentEPConfigAfterDestroy(user, team),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyTeamMembershipNoExists("pagerduty_team_membership.foo"),
+				),
+			},
+		},
+	})
+}
+
 // TestAccPagerDutyTeamMembership_MultipleMembers verifies that multiple
 // memberships on the same team are all read back correctly. This exercises
 // the shared-cache path where the second Read serves from the cached snapshot
@@ -714,4 +750,59 @@ resource "pagerduty_team_membership" "two" {
   role    = "%[4]v"
 }
 `, user, teamOne, teamTwo, role)
+}
+
+// testAccCheckPagerDutyTeamMembershipWithConcurrentEPConfig creates a user,
+// team, team membership, and an escalation policy that references the user on
+// the same team. Destroying all of these from this state exercises the
+// concurrent-destroy race between team_membership and escalation_policy.
+func testAccCheckPagerDutyTeamMembershipWithConcurrentEPConfig(user, team, escalationPolicy string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "foo" {
+  name  = "%[1]s"
+  email = "%[1]s@foo.test"
+}
+
+resource "pagerduty_team" "foo" {
+  name        = "%[2]s"
+  description = "foo"
+}
+
+resource "pagerduty_team_membership" "foo" {
+  user_id = pagerduty_user.foo.id
+  team_id = pagerduty_team.foo.id
+  role    = "manager"
+}
+
+resource "pagerduty_escalation_policy" "foo" {
+  name      = "%[3]s"
+  num_loops = 2
+  teams     = [pagerduty_team.foo.id]
+
+  rule {
+    escalation_delay_in_minutes = 10
+    target {
+      type = "user_reference"
+      id   = pagerduty_user.foo.id
+    }
+  }
+}
+`, user, team, escalationPolicy)
+}
+
+// testAccCheckPagerDutyTeamMembershipWithConcurrentEPConfigAfterDestroy is the
+// follow-up config that omits both team_membership.foo and
+// escalation_policy.foo so Terraform destroys them in the same plan step.
+func testAccCheckPagerDutyTeamMembershipWithConcurrentEPConfigAfterDestroy(user, team string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "foo" {
+  name  = "%[1]s"
+  email = "%[1]s@foo.test"
+}
+
+resource "pagerduty_team" "foo" {
+  name        = "%[2]s"
+  description = "foo"
+}
+`, user, team)
 }


### PR DESCRIPTION
The EP-blocking 400 was non-retryable in the plugin framework version and only retried once in the SDK v2 version. Use a counter-limited retry (5 attempts) in both so the transient error resolves when the escalation policy deletion completes in parallel.

Adds `TestAccPagerDutyTeamMembership_DestroyWithConcurrentEscalationPolicyDeletion` to guard against regression.

## Acceptance Tests

**`pagerdutyplugin` package** — plugin framework implementation (active):
```
=== RUN   TestAccPagerDutyTeamMembership_import
--- PASS: TestAccPagerDutyTeamMembership_import (18.04s)
=== RUN   TestAccPagerDutyTeamMembership_importWithRole
--- PASS: TestAccPagerDutyTeamMembership_importWithRole (18.65s)
=== RUN   TestAccPagerDutyTeamMembership_Basic
--- PASS: TestAccPagerDutyTeamMembership_Basic (17.81s)
=== RUN   TestAccPagerDutyTeamMembership_WithRole
--- PASS: TestAccPagerDutyTeamMembership_WithRole (18.41s)
=== RUN   TestAccPagerDutyTeamMembership_WithRoleConsistentlyAssigned
--- PASS: TestAccPagerDutyTeamMembership_WithRoleConsistentlyAssigned (28.80s)
=== RUN   TestAccPagerDutyTeamMembership_DestroyWithEscalationPolicyDependant
--- PASS: TestAccPagerDutyTeamMembership_DestroyWithEscalationPolicyDependant (62.64s)
=== RUN   TestAccPagerDutyTeamMembership_DestroyWithEscalationPolicyDependantAndMultipleTeams
--- PASS: TestAccPagerDutyTeamMembership_DestroyWithEscalationPolicyDependantAndMultipleTeams (76.80s)
=== RUN   TestAccPagerDutyTeamMembership_DestroyWithConcurrentEscalationPolicyDeletion
--- PASS: TestAccPagerDutyTeamMembership_DestroyWithConcurrentEscalationPolicyDeletion (29.07s)
=== RUN   TestAccPagerDutyTeamMembership_MultipleMembers
--- PASS: TestAccPagerDutyTeamMembership_MultipleMembers (20.98s)
=== RUN   TestAccPagerDutyTeamMembership_RoleUpdateReflectsAfterWrite
--- PASS: TestAccPagerDutyTeamMembership_RoleUpdateReflectsAfterWrite (27.79s)
PASS
ok  	github.com/PagerDuty/terraform-provider-pagerduty/pagerdutyplugin	319.674s
```

**`pagerduty` package** — SDK v2 implementation (legacy delete path):
```
=== RUN   TestAccPagerDutyUserWithTeams_Basic
--- PASS: TestAccPagerDutyUserWithTeams_Basic (28.40s)
PASS
ok  	github.com/PagerDuty/terraform-provider-pagerduty/pagerduty	29.278s
```