### PR TITLE
Fix ValidateConfig failing when type uses a variable

### DIFF
--- a/pagerdutyplugin/resource_pagerduty_alert_grouping_setting.go
+++ b/pagerdutyplugin/resource_pagerduty_alert_grouping_setting.go
@@ -121,6 +121,13 @@ func (r *resourceAlertGroupingSetting) ValidateConfig(ctx context.Context, req r
 		return
 	}
 
+	// When type is unknown (e.g. provided via a variable), we cannot
+	// validate cross-attribute constraints yet — skip until the value
+	// is resolved.
+	if model.Type.IsUnknown() {
+		return
+	}
+
 	t := pagerduty.AlertGroupingSettingType(model.Type.ValueString())
 	if t == pagerduty.AlertGroupingSettingTimeType {
 		if len(model.Services.Elements()) > 1 {
@@ -142,7 +149,8 @@ func (r *resourceAlertGroupingSetting) ValidateConfig(ctx context.Context, req r
 		}
 	}
 
-	if t != pagerduty.AlertGroupingSettingTimeType && !model.Config.Attributes()["timeout"].IsNull() {
+	timeout := model.Config.Attributes()["timeout"]
+	if t != pagerduty.AlertGroupingSettingTimeType && !timeout.IsNull() && !timeout.IsUnknown() {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("config").AtName("timeout"),
 			"Invalid configuration",

--- a/pagerdutyplugin/resource_pagerduty_alert_grouping_setting_test.go
+++ b/pagerdutyplugin/resource_pagerduty_alert_grouping_setting_test.go
@@ -724,6 +724,45 @@ resource "pagerduty_alert_grouping_setting" "%[1]s" {
 	})
 }
 
+func TestAccPagerDutyAlertGroupingSetting_VariableType_SkipsTimeoutValidation(t *testing.T) {
+	ref := fmt.Sprint("tf-", acctest.RandString(5))
+	service := fmt.Sprint("tf-", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+variable "grouping_type" {
+	type    = string
+	default = "time"
+}
+
+data "pagerduty_escalation_policy" "default" {
+	name = "Default"
+}
+
+resource "pagerduty_service" "%[2]s" {
+	name = "%[2]s"
+	escalation_policy = data.pagerduty_escalation_policy.default.id
+}
+
+resource "pagerduty_alert_grouping_setting" "%[1]s" {
+	name = "%[1]s"
+	type = var.grouping_type
+	services = [pagerduty_service.%[2]s.id]
+	config {
+		timeout = 60
+	}
+}`, ref, service),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccPagerDutyAlertGroupingSettingServiceNotExist(ref, service, name string) string {
 	return fmt.Sprintf(`
 data "pagerduty_escalation_policy" "default" {


### PR DESCRIPTION
## Summary

Fixes #1115.

`ValidateConfig` runs before variable values are resolved, so attributes referencing variables appear as "unknown". `ValueString()` on an unknown `types.String` returns `""`, causing the timeout validation added in #1110 to fire incorrectly:

```
'timeout' is only applicable when type is "time", got ""
```

This PR:
- Skips cross-attribute validation in `ValidateConfig` when `type` is unknown (early return)
- Guards the `timeout` check against `timeout` itself being unknown
- Adds an acceptance test that reproduces the issue using `type = var.grouping_type`

The existing `TestAccPagerDutyAlertGroupingSetting_Intelligent_TimeoutRejected` test continues to pass — literal values are known at validation time, so the error still fires correctly for actual misconfigurations. The new test fails with the `'timeout' is only applicable when type is "time", got ""` message without the new code.