### PR TITLE
Fix #1123: schedulev2 inconsistent result on active-event field change

### DIFF
--- a/pagerdutyplugin/resource_pagerduty_schedulev2.go
+++ b/pagerdutyplugin/resource_pagerduty_schedulev2.go
@@ -81,7 +81,7 @@ func (r *resourceScheduleV2) Schema(_ context.Context, _ resource.SchemaRequest,
 									"id": schema.StringAttribute{
 										Computed:      true,
 										Description:   "The ID of the event.",
-										PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+										PlanModifiers: []planmodifier.String{eventIDPlanModifier{}},
 									},
 									"name": schema.StringAttribute{
 										Required:    true,
@@ -914,6 +914,54 @@ func flattenEventV3(ctx context.Context, evt *pagerduty.EventV3, diags *diag.Dia
 	}
 
 	return evtModel
+}
+
+// eventIDPlanModifier behaves like UseStateForUnknown for the event ID, except
+// when the planned changes will force the provider to DELETE+CREATE the event
+// server-side (which the API requires for active events when shift-defining
+// fields change). In that case the resulting event has a new server-assigned
+// ID, so we must mark the planned ID as unknown to avoid Terraform's
+// "Provider produced inconsistent result after apply" check (issue #1123).
+type eventIDPlanModifier struct{}
+
+func (eventIDPlanModifier) Description(context.Context) string {
+	return "Preserves the event ID across plans, except when active-event field changes will force a server-side delete+recreate."
+}
+
+func (m eventIDPlanModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (eventIDPlanModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	// Resource creation: leave the framework default (unknown).
+	if req.StateValue.IsNull() {
+		return
+	}
+	// Resource destruction: nothing to plan.
+	if req.PlanValue.IsNull() {
+		return
+	}
+
+	parent := req.Path.ParentPath()
+	var stateEvt, planEvt eventV2Model
+	if d := req.State.GetAttribute(ctx, parent, &stateEvt); d.HasError() {
+		resp.Diagnostics.Append(d...)
+		return
+	}
+	if d := req.Plan.GetAttribute(ctx, parent, &planEvt); d.HasError() {
+		resp.Diagnostics.Append(d...)
+		return
+	}
+
+	// If the event is currently active and shift-defining fields are changing,
+	// the Update path will DELETE and CREATE the event, producing a new ID.
+	if isEventActive(stateEvt) && eventsDifferBeyondEffectiveUntil(ctx, stateEvt, planEvt) {
+		resp.PlanValue = types.StringUnknown()
+		return
+	}
+
+	// Stable case: keep the prior ID so plans show no spurious id churn.
+	resp.PlanValue = req.StateValue
 }
 
 // isEventActive returns true when an event's effective_since is in the past,

--- a/pagerdutyplugin/resource_pagerduty_schedulev2_test.go
+++ b/pagerdutyplugin/resource_pagerduty_schedulev2_test.go
@@ -309,6 +309,63 @@ func TestAccPagerDutyScheduleV2_PastEffectiveSince(t *testing.T) {
 	})
 }
 
+// TestAccPagerDutyScheduleV2_ActiveEventFieldChange reproduces issue #1123:
+// when an event becomes active (effective_since in the past) and the user
+// changes a shift-defining field (start_time/end_time), the provider's
+// Update path must DELETE+CREATE the underlying event because the API
+// rejects PUTs that mutate those fields on active events. The new event
+// gets a new server-assigned ID. Without a plan modifier that marks the
+// ID as unknown for this case, Terraform fails the apply with
+// "Provider produced inconsistent result after apply".
+func TestAccPagerDutyScheduleV2_ActiveEventFieldChange(t *testing.T) {
+	if v := os.Getenv("PAGERDUTY_ACC_SCHEDULE_V3"); v == "" {
+		t.Skip("PAGERDUTY_ACC_SCHEDULE_V3 must be set to run v3 schedule acceptance tests")
+	}
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.test", username)
+	scheduleName := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	// Past effective_since makes the event active immediately. The API
+	// normalizes the value server-side; the provider preserves the configured
+	// value in state, so subsequent updates still see an active event.
+	effectiveSince := time.Now().UTC().Add(-48 * time.Hour).Format(time.RFC3339)
+	startTime := time.Now().UTC().Add(24*time.Hour).Format("2006-01-02") + "T09:00:00Z"
+	endTime := time.Now().UTC().Add(24*time.Hour).Format("2006-01-02") + "T17:00:00Z"
+	startTimeUpdated := time.Now().UTC().Add(48*time.Hour).Format("2006-01-02") + "T09:00:00Z"
+	endTimeUpdated := time.Now().UTC().Add(48*time.Hour).Format("2006-01-02") + "T17:00:00Z"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(),
+		CheckDestroy:             testAccCheckPagerDutyScheduleV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPagerDutyScheduleV2Config(username, email, scheduleName, effectiveSince, startTime, endTime),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyScheduleV2Exists("pagerduty_schedulev2.test"),
+					resource.TestCheckResourceAttrSet("pagerduty_schedulev2.test", "rotation.0.event.0.id"),
+				),
+			},
+			{
+				// Shift the start/end by 24h on an already-active event.
+				// Pre-fix this apply errors with "inconsistent result after apply"
+				// because the new event ID differs from state.
+				Config: testAccPagerDutyScheduleV2Config(username, email, scheduleName, effectiveSince, startTimeUpdated, endTimeUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyScheduleV2Exists("pagerduty_schedulev2.test"),
+					resource.TestCheckResourceAttrSet("pagerduty_schedulev2.test", "rotation.0.event.0.id"),
+				),
+			},
+			{
+				// Re-plan with the same config: must be empty.
+				Config:             testAccPagerDutyScheduleV2Config(username, email, scheduleName, effectiveSince, startTimeUpdated, endTimeUpdated),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 func TestAccPagerDutyScheduleV2_EffectiveUntil(t *testing.T) {
 	if v := os.Getenv("PAGERDUTY_ACC_SCHEDULE_V3"); v == "" {
 		t.Skip("PAGERDUTY_ACC_SCHEDULE_V3 must be set to run v3 schedule acceptance tests")


### PR DESCRIPTION
Closes #1123

Jira: FDE-492

## Problem

When an active event's `start_time` / `end_time` / `recurrence` / `assignment_strategy` changes, the API rejects PUT updates and the provider falls back to DELETE+CREATE, producing a new server-assigned event ID. The previous `UseStateForUnknown` plan modifier on `event.id` forced the planned ID to match the prior state value, so the post-apply ID mismatch tripped Terraform's "Provider produced inconsistent result after apply" check.

## Fix

Replace it with a custom plan modifier (`eventIDPlanModifier`) that marks the ID as unknown **only** when the state event is active (`effective_since` in the past) and shift-defining fields differ. In all other cases it preserves the state ID, so stable plans show no spurious id churn.

## Test plan

### Acceptance tests (`TF_ACC=1 PAGERDUTY_ACC_SCHEDULE_V3=1 go test ./pagerdutyplugin -run ...`)

Resource (`pagerduty_schedulev2`) — 11/11 pass:

```
=== RUN   TestAccPagerDutyScheduleV2_Basic
--- PASS: TestAccPagerDutyScheduleV2_Basic (18.76s)
=== RUN   TestAccPagerDutyScheduleV2_Update
--- PASS: TestAccPagerDutyScheduleV2_Update (28.56s)
=== RUN   TestAccPagerDutyScheduleV2_MultipleRotations
--- PASS: TestAccPagerDutyScheduleV2_MultipleRotations (18.92s)
=== RUN   TestAccPagerDutyScheduleV2_Import
--- PASS: TestAccPagerDutyScheduleV2_Import (19.99s)
=== RUN   TestAccPagerDutyScheduleV2_PastEffectiveSince
--- PASS: TestAccPagerDutyScheduleV2_PastEffectiveSince (23.54s)
=== RUN   TestAccPagerDutyScheduleV2_ActiveEventFieldChange
--- PASS: TestAccPagerDutyScheduleV2_ActiveEventFieldChange (33.52s)
=== RUN   TestAccPagerDutyScheduleV2_EffectiveUntil
--- PASS: TestAccPagerDutyScheduleV2_EffectiveUntil (42.82s)
=== RUN   TestAccPagerDutyScheduleV2_UpdateEvents
--- PASS: TestAccPagerDutyScheduleV2_UpdateEvents (35.35s)
=== RUN   TestAccPagerDutyScheduleV2_RotationCountChange
--- PASS: TestAccPagerDutyScheduleV2_RotationCountChange (41.89s)
=== RUN   TestAccPagerDutyScheduleV2_EveryMemberStrategy
--- PASS: TestAccPagerDutyScheduleV2_EveryMemberStrategy (18.33s)
=== RUN   TestAccPagerDutyScheduleV2_WithEscalationPolicy
--- PASS: TestAccPagerDutyScheduleV2_WithEscalationPolicy (26.46s)
PASS
ok  	github.com/PagerDuty/terraform-provider-pagerduty/pagerdutyplugin	308.853s
```

Data source (`pagerduty_schedulev2`) — 1/1 pass (plus legacy `pagerduty_schedule` DS sanity):

```
=== RUN   TestAccDataSourcePagerDutySchedule_Basic
--- PASS: TestAccDataSourcePagerDutySchedule_Basic (18.74s)
=== RUN   TestAccDataSourcePagerDutyScheduleV2_Basic
--- PASS: TestAccDataSourcePagerDutyScheduleV2_Basic (18.51s)
PASS
ok  	github.com/PagerDuty/terraform-provider-pagerduty/pagerdutyplugin	37.912s
```

### New regression test

`TestAccPagerDutyScheduleV2_ActiveEventFieldChange` reproduces the issue: creates a schedule with `effective_since` 48h in the past (event becomes active immediately on the server side), then updates `start_time`/`end_time`. Without the fix it fails with the exact error from #1123:

```
Error: Provider produced inconsistent result after apply
... .rotation[0].event[0].id: was cty.StringVal("AGO5UNZZR55CPMG537EF4UOYLE"),
    but now cty.StringVal("AGO5UN3B2N7PVN4IAHKSGGIHAU").
--- FAIL: TestAccPagerDutyScheduleV2_ActiveEventFieldChange (23.87s)
```

With the fix applied: `--- PASS: TestAccPagerDutyScheduleV2_ActiveEventFieldChange (33.52s)`.

### End-to-end real-HCL repro

Ran the exact configuration from issue #1123 against a real PagerDuty account using a dev override pointing at the patched provider:

1. Initial apply (Mon Apr 27 start, `effective_since=2026-04-27T09:00:00Z` — already in the past) → succeeded.
2. Update apply (shift to Tue Apr 28). Plan correctly shows `id = "AGO5..." -> (known after apply)`. Apply: `Modifications complete after 2s`.
3. Re-plan with same config → `No changes. Your infrastructure matches the configuration.` (exit 0, no drift).
4. Destroy → clean.
