### PR TITLE
Fix schedulev2 idempotency for multi-team and offset timestamps (#1127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v3.33.1 (Unreleased)
+
+BUG FIXES
+* `resource/pagerduty_schedulev2`: Preserve the configured `teams` ordering on refresh so a schedule associated with more than one team no longer shows a perpetual reorder diff ([1127](https://github.com/PagerDuty/terraform-provider-pagerduty/issues/1127))
+* `resource/pagerduty_schedulev2`: Preserve timezone-offset `start_time`/`end_time` values when they match the API's UTC-normalized return, so applying events with offset timestamps no longer fails with "Provider produced inconsistent result after apply" ([1127](https://github.com/PagerDuty/terraform-provider-pagerduty/issues/1127))
+
+DOCS
+* `resource/pagerduty_schedulev2`: Remove the obsolete `flexible-schedules-early-access` note, add a legacy-vs-shift-based version mapping table, and add a `pagerduty_schedule` → `pagerduty_schedulev2` migration guide ([1127](https://github.com/PagerDuty/terraform-provider-pagerduty/issues/1127))
+* `data/pagerduty_schedulev2`: Remove the obsolete `flexible-schedules-early-access` note ([1127](https://github.com/PagerDuty/terraform-provider-pagerduty/issues/1127))
+
 ## v3.33.0 (Jun 10, 2026)
 
 ENHANCEMENTS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 BUG FIXES
 * `resource/pagerduty_schedulev2`: Preserve the configured `teams` ordering on refresh so a schedule associated with more than one team no longer shows a perpetual reorder diff ([1127](https://github.com/PagerDuty/terraform-provider-pagerduty/issues/1127))
-* `resource/pagerduty_schedulev2`: Preserve timezone-offset `start_time`/`end_time` values when they match the API's UTC-normalized return, so applying events with offset timestamps no longer fails with "Provider produced inconsistent result after apply" ([1127](https://github.com/PagerDuty/terraform-provider-pagerduty/issues/1127))
+* `resource/pagerduty_schedulev2`: Preserve timezone-offset `start_time`/`end_time`/`effective_until` values when they match the API's UTC-normalized return, so applying events with offset timestamps no longer fails with "Provider produced inconsistent result after apply" or shows a perpetual diff ([1127](https://github.com/PagerDuty/terraform-provider-pagerduty/issues/1127))
+* `resource/pagerduty_schedulev2`: Compare `effective_since`/`effective_until` semantically when reconciling events, so a timezone-offset/UTC representation change (e.g. after import) no longer triggers a spurious update — which for an active event would needlessly DELETE+CREATE a live shift ([1127](https://github.com/PagerDuty/terraform-provider-pagerduty/issues/1127))
 
 DOCS
 * `resource/pagerduty_schedulev2`: Remove the obsolete `flexible-schedules-early-access` note, add a legacy-vs-shift-based version mapping table, and add a `pagerduty_schedule` → `pagerduty_schedulev2` migration guide ([1127](https://github.com/PagerDuty/terraform-provider-pagerduty/issues/1127))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v3.33.1 (Unreleased)
+## v3.33.1 (Jun 30, 2026)
 
 BUG FIXES
 * `resource/pagerduty_schedulev2`: Preserve the configured `teams` ordering on refresh so a schedule associated with more than one team no longer shows a perpetual reorder diff ([1127](https://github.com/PagerDuty/terraform-provider-pagerduty/issues/1127))

--- a/pagerdutyplugin/resource_pagerduty_schedulev2.go
+++ b/pagerdutyplugin/resource_pagerduty_schedulev2.go
@@ -262,6 +262,7 @@ func (r *resourceScheduleV2) createRotationsAndEvents(ctx context.Context, sched
 			// The API normalizes past effective_since dates to current time. Preserve
 			// the config value so the post-apply state matches the plan.
 			flattened.EffectiveSince = evtModel.EffectiveSince
+			preserveConfiguredEventTimes(&evtModel, &flattened)
 			preserveShiftsPerMember(&evtModel, &flattened)
 			updatedEvents = append(updatedEvents, flattened)
 		}
@@ -319,7 +320,7 @@ func (r *resourceScheduleV2) Read(ctx context.Context, req resource.ReadRequest,
 		}
 	}
 
-	updatedState := flattenScheduleV3(ctx, schedule, state.Rotations, &resp.Diagnostics)
+	updatedState := flattenScheduleV3(ctx, schedule, state.Rotations, state.Teams, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -509,6 +510,7 @@ func (r *resourceScheduleV2) reconcileEvents(ctx context.Context, scheduleID, ro
 			// Preserve the user's configured effective_since in state so subsequent
 			// plans do not show a perpetual diff.
 			flattened.EffectiveSince = desiredEvt.EffectiveSince
+			preserveConfiguredEventTimes(&desiredEvt, &flattened)
 			preserveShiftsPerMember(&desiredEvt, &flattened)
 			updatedEvents = append(updatedEvents, flattened)
 			continue
@@ -547,6 +549,7 @@ func (r *resourceScheduleV2) reconcileEvents(ctx context.Context, scheduleID, ro
 		// The API normalizes past effective_since dates to current time. Preserve
 		// the plan value so the post-apply state matches the plan.
 		flattened.EffectiveSince = desiredEvt.EffectiveSince
+		preserveConfiguredEventTimes(&desiredEvt, &flattened)
 		preserveShiftsPerMember(&desiredEvt, &flattened)
 		updatedEvents = append(updatedEvents, flattened)
 	}
@@ -603,6 +606,7 @@ func (r *resourceScheduleV2) reconcileEvents(ctx context.Context, scheduleID, ro
 		// The API normalizes past effective_since dates to current time. Preserve
 		// the plan value so the post-apply state matches the plan.
 		flattened.EffectiveSince = desiredEvt.EffectiveSince
+		preserveConfiguredEventTimes(&desiredEvt, &flattened)
 		preserveShiftsPerMember(&desiredEvt, &flattened)
 		updatedEvents = append(updatedEvents, flattened)
 	}
@@ -672,7 +676,7 @@ func (r *resourceScheduleV2) ImportState(ctx context.Context, req resource.Impor
 		}
 	}
 
-	state := flattenScheduleV3(ctx, schedule, nil, &resp.Diagnostics)
+	state := flattenScheduleV3(ctx, schedule, nil, types.ListNull(types.StringType), &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -787,16 +791,19 @@ func buildEventV3Input(ctx context.Context, model *eventV2Model, scheduleTimeZon
 	return evt, diags
 }
 
-func flattenScheduleV3(ctx context.Context, schedule *pagerduty.ScheduleV3, stateRotations []rotationV2Model, diags *diag.Diagnostics) resourceScheduleV2Model {
+func flattenScheduleV3(ctx context.Context, schedule *pagerduty.ScheduleV3, stateRotations []rotationV2Model, priorTeams types.List, diags *diag.Diagnostics) resourceScheduleV2Model {
 	// The v3 API normalizes "UTC" to "Etc/UTC". Normalize back to prevent perpetual plan diffs.
 	tz := schedule.TimeZone
 	if tz == "Etc/UTC" {
 		tz = "UTC"
 	}
 
-	teamVals := make([]attr.Value, 0, len(schedule.Teams))
-	for _, t := range schedule.Teams {
-		teamVals = append(teamVals, types.StringValue(t.ID))
+	// The API returns associated teams in an unstable order; preserve the prior
+	// state's ordering to avoid a perpetual reorder diff on the `teams` list.
+	teamIDs := orderedTeamIDs(ctx, priorTeams, schedule.Teams, diags)
+	teamVals := make([]attr.Value, 0, len(teamIDs))
+	for _, id := range teamIDs {
+		teamVals = append(teamVals, types.StringValue(id))
 	}
 	var teamsList types.List
 	if len(teamVals) == 0 {
@@ -1059,6 +1066,53 @@ func preserveShiftsPerMember(desired, flattened *eventV2Model) {
 	if len(desired.AssignmentStrategy) > 0 && len(flattened.AssignmentStrategy) > 0 {
 		flattened.AssignmentStrategy[0].ShiftsPerMember = desired.AssignmentStrategy[0].ShiftsPerMember
 	}
+}
+
+// preserveConfiguredEventTimes keeps the user's configured start_time/end_time
+// strings in state when they represent the same instant the API returned. The v3
+// API normalizes times to UTC (e.g. "...+02:00" becomes "...Z"), so without this
+// the create/update paths would store a different string than the plan, tripping
+// Terraform's "provider produced inconsistent result after apply" check.
+func preserveConfiguredEventTimes(desired, flattened *eventV2Model) {
+	if !desired.StartTime.IsNull() && semanticallyEqualTime(desired.StartTime.ValueString(), flattened.StartTime.ValueString()) {
+		flattened.StartTime = desired.StartTime
+	}
+	if !desired.EndTime.IsNull() && semanticallyEqualTime(desired.EndTime.ValueString(), flattened.EndTime.ValueString()) {
+		flattened.EndTime = desired.EndTime
+	}
+}
+
+// orderedTeamIDs reconciles the API's team list against the order recorded in
+// prior state. The v3 API returns associated teams in an unstable order, which
+// would otherwise show as a perpetual reorder diff on a `teams` list. Team IDs
+// present in prior state keep their original position; teams added out-of-band
+// (present in the API response but not in state) are appended in API order.
+func orderedTeamIDs(ctx context.Context, priorTeams types.List, apiTeams []pagerduty.TeamReferenceV3, diags *diag.Diagnostics) []string {
+	inAPI := make(map[string]bool, len(apiTeams))
+	for _, t := range apiTeams {
+		inAPI[t.ID] = true
+	}
+
+	var prior []string
+	if !priorTeams.IsNull() && !priorTeams.IsUnknown() {
+		diags.Append(priorTeams.ElementsAs(ctx, &prior, false)...)
+	}
+
+	result := make([]string, 0, len(apiTeams))
+	seen := make(map[string]bool, len(apiTeams))
+	for _, id := range prior {
+		if inAPI[id] && !seen[id] {
+			result = append(result, id)
+			seen[id] = true
+		}
+	}
+	for _, t := range apiTeams {
+		if !seen[t.ID] {
+			result = append(result, t.ID)
+			seen[t.ID] = true
+		}
+	}
+	return result
 }
 
 // semanticallyEqualTime returns true if two RFC3339 time strings represent the same instant.

--- a/pagerdutyplugin/resource_pagerduty_schedulev2.go
+++ b/pagerdutyplugin/resource_pagerduty_schedulev2.go
@@ -450,7 +450,14 @@ func (r *resourceScheduleV2) reconcileEvents(ctx context.Context, scheduleID, ro
 
 		// Skip the API call when nothing in this event has changed. This avoids
 		// sending effective_since on active events, which the API rejects (400).
+		// Adopt the configured time representations into state first: the equality
+		// check is semantic, so a currentEvt holding the API's UTC form (e.g. after
+		// import) must take the plan's string form to avoid an "inconsistent result
+		// after apply" error.
 		if eventModelsEqual(ctx, desiredEvt, currentEvt) {
+			preserveConfiguredEventTimes(&desiredEvt, &currentEvt)
+			currentEvt.EffectiveSince = desiredEvt.EffectiveSince
+			preserveShiftsPerMember(&desiredEvt, &currentEvt)
 			updatedEvents = append(updatedEvents, currentEvt)
 			continue
 		}
@@ -851,6 +858,11 @@ func flattenScheduleV3(ctx context.Context, schedule *pagerduty.ScheduleV3, stat
 				if !st.EndTime.IsNull() && semanticallyEqualTime(st.EndTime.ValueString(), evtModel.EndTime.ValueString()) {
 					evtModel.EndTime = st.EndTime
 				}
+				// effective_until is also UTC-normalized by the API; preserve the
+				// state representation when it denotes the same instant.
+				if semanticallyEqualTimeValue(st.EffectiveUntil, evtModel.EffectiveUntil) {
+					evtModel.EffectiveUntil = st.EffectiveUntil
+				}
 				// The API normalizes past effective_since dates to current time. Preserve
 				// the state value to prevent perpetual plan diffs on subsequent refresh.
 				if !st.EffectiveSince.IsNull() && !st.EffectiveSince.IsUnknown() {
@@ -984,7 +996,10 @@ func isEventActive(evt eventV2Model) bool {
 // eventsDifferBeyondEffectiveUntil returns true when the two events differ in
 // any field other than effective_until.
 func eventsDifferBeyondEffectiveUntil(ctx context.Context, a, b eventV2Model) bool {
-	if !a.Name.Equal(b.Name) || !a.EffectiveSince.Equal(b.EffectiveSince) || !a.Recurrence.Equal(b.Recurrence) {
+	// effective_since is compared semantically (the API normalizes it to UTC); a
+	// representation-only change must not be reported as a difference, since for an
+	// active event that would force a DELETE+CREATE of a live shift.
+	if !a.Name.Equal(b.Name) || !semanticallyEqualTime(a.EffectiveSince.ValueString(), b.EffectiveSince.ValueString()) || !a.Recurrence.Equal(b.Recurrence) {
 		return true
 	}
 	if !semanticallyEqualTime(a.StartTime.ValueString(), b.StartTime.ValueString()) ||
@@ -1014,9 +1029,13 @@ func eventsDifferBeyondEffectiveUntil(ctx context.Context, a, b eventV2Model) bo
 // eventModelsEqual returns true when two event models are identical in all
 // user-configurable fields, so the API update can be safely skipped.
 func eventModelsEqual(ctx context.Context, a, b eventV2Model) bool {
+	// All time fields are compared semantically: the API normalizes them to UTC,
+	// so two different string representations of the same instant must count as
+	// equal, otherwise an unchanged event is treated as modified (and an active
+	// event would be needlessly DELETE+CREATEd).
 	if !a.Name.Equal(b.Name) ||
-		!a.EffectiveSince.Equal(b.EffectiveSince) ||
-		!a.EffectiveUntil.Equal(b.EffectiveUntil) ||
+		!semanticallyEqualTime(a.EffectiveSince.ValueString(), b.EffectiveSince.ValueString()) ||
+		!semanticallyEqualTimeValue(a.EffectiveUntil, b.EffectiveUntil) ||
 		!a.Recurrence.Equal(b.Recurrence) {
 		return false
 	}
@@ -1080,6 +1099,11 @@ func preserveConfiguredEventTimes(desired, flattened *eventV2Model) {
 	if !desired.EndTime.IsNull() && semanticallyEqualTime(desired.EndTime.ValueString(), flattened.EndTime.ValueString()) {
 		flattened.EndTime = desired.EndTime
 	}
+	// effective_until is an optional ISO-8601 field the API also normalizes to
+	// UTC, so it needs the same representation-preserving guard.
+	if semanticallyEqualTimeValue(desired.EffectiveUntil, flattened.EffectiveUntil) {
+		flattened.EffectiveUntil = desired.EffectiveUntil
+	}
 }
 
 // orderedTeamIDs reconciles the API's team list against the order recorded in
@@ -1124,4 +1148,14 @@ func semanticallyEqualTime(a, b string) bool {
 		return false
 	}
 	return ta.Equal(tb)
+}
+
+// semanticallyEqualTimeValue is the nullable counterpart of semanticallyEqualTime
+// for optional time attributes (e.g. effective_until). Two null values are equal;
+// a null and a non-null are not; otherwise the underlying instants are compared.
+func semanticallyEqualTimeValue(a, b types.String) bool {
+	if a.IsNull() || b.IsNull() {
+		return a.IsNull() && b.IsNull()
+	}
+	return semanticallyEqualTime(a.ValueString(), b.ValueString())
 }

--- a/pagerdutyplugin/resource_pagerduty_schedulev2_test.go
+++ b/pagerdutyplugin/resource_pagerduty_schedulev2_test.go
@@ -769,3 +769,135 @@ resource "pagerduty_escalation_policy" "test" {
 }
 `, username, email, scheduleName, startTime, endTime, effectiveSince, escalationPolicyName)
 }
+
+// TestAccPagerDutyScheduleV2_MultipleTeamsOrderStable reproduces the team
+// reorder perpetual diff (same class as issue #1001): the v3 API returns a
+// schedule's associated teams in an unstable order, so a `teams` list with more
+// than one entry would show a spurious reorder on every plan. The provider must
+// preserve the prior-state ordering on refresh so re-planning yields no diff.
+func TestAccPagerDutyScheduleV2_MultipleTeamsOrderStable(t *testing.T) {
+	if v := os.Getenv("PAGERDUTY_ACC_SCHEDULE_V3"); v == "" {
+		t.Skip("PAGERDUTY_ACC_SCHEDULE_V3 must be set to run v3 schedule acceptance tests")
+	}
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.test", username)
+	team1 := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	team2 := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	scheduleName := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	effectiveSince := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	startTime := time.Now().UTC().Add(24*time.Hour).Format("2006-01-02") + "T09:00:00Z"
+	endTime := time.Now().UTC().Add(24*time.Hour).Format("2006-01-02") + "T17:00:00Z"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(),
+		CheckDestroy:             testAccCheckPagerDutyScheduleV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPagerDutyScheduleV2MultipleTeamsConfig(username, email, team1, team2, scheduleName, effectiveSince, startTime, endTime),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyScheduleV2Exists("pagerduty_schedulev2.test"),
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "teams.#", "2"),
+				),
+			},
+			{
+				// Re-plan with the same config. Fails if the unordered API team
+				// response produces a perpetual reorder diff.
+				Config:             testAccPagerDutyScheduleV2MultipleTeamsConfig(username, email, team1, team2, scheduleName, effectiveSince, startTime, endTime),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// TestAccPagerDutyScheduleV2_OffsetTimestamps reproduces the "inconsistent
+// result after apply" failure on start_time/end_time supplied with a timezone
+// offset (e.g. "+02:00"). The v3 API normalizes those to UTC ("Z"), so the
+// provider must preserve the configured strings in state when they represent the
+// same instant — both at apply time (consistency check) and on refresh (no diff).
+func TestAccPagerDutyScheduleV2_OffsetTimestamps(t *testing.T) {
+	if v := os.Getenv("PAGERDUTY_ACC_SCHEDULE_V3"); v == "" {
+		t.Skip("PAGERDUTY_ACC_SCHEDULE_V3 must be set to run v3 schedule acceptance tests")
+	}
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.test", username)
+	scheduleName := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	day := time.Now().UTC().Add(24 * time.Hour).Format("2006-01-02")
+	startTime := day + "T09:00:00+02:00"
+	endTime := day + "T17:00:00+02:00"
+	effectiveSince := day + "T09:00:00+02:00"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(),
+		CheckDestroy:             testAccCheckPagerDutyScheduleV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPagerDutyScheduleV2Config(username, email, scheduleName, effectiveSince, startTime, endTime),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyScheduleV2Exists("pagerduty_schedulev2.test"),
+					// State must hold the configured offset strings, not the API's UTC form.
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "rotation.0.event.0.start_time", startTime),
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "rotation.0.event.0.end_time", endTime),
+				),
+			},
+			{
+				// Re-plan with the same config. Fails if the UTC-normalized read
+				// value is not reconciled against the configured offset value.
+				Config:             testAccPagerDutyScheduleV2Config(username, email, scheduleName, effectiveSince, startTime, endTime),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func testAccPagerDutyScheduleV2MultipleTeamsConfig(username, email, team1, team2, scheduleName, effectiveSince, startTime, endTime string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "test" {
+  name  = "%s"
+  email = "%s"
+}
+
+resource "pagerduty_team" "test1" {
+  name = "%s"
+}
+
+resource "pagerduty_team" "test2" {
+  name = "%s"
+}
+
+resource "pagerduty_schedulev2" "test" {
+  name        = "%s"
+  time_zone   = "America/New_York"
+  description = "Managed by Terraform"
+
+  teams = [
+    pagerduty_team.test1.id,
+    pagerduty_team.test2.id,
+  ]
+
+  rotation {
+    event {
+      name            = "Weekly On-Call"
+      start_time      = "%s"
+      end_time        = "%s"
+      effective_since = "%s"
+      recurrence      = ["RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"]
+
+      assignment_strategy {
+        type = "rotating_member_assignment_strategy"
+
+        member {
+          type    = "user_member"
+          user_id = pagerduty_user.test.id
+        }
+      }
+    }
+  }
+}
+`, username, email, team1, team2, scheduleName, startTime, endTime, effectiveSince)
+}

--- a/pagerdutyplugin/resource_pagerduty_schedulev2_test.go
+++ b/pagerdutyplugin/resource_pagerduty_schedulev2_test.go
@@ -855,6 +855,147 @@ func TestAccPagerDutyScheduleV2_OffsetTimestamps(t *testing.T) {
 	})
 }
 
+// TestAccPagerDutyScheduleV2_OffsetEffectiveUntil guards the optional
+// effective_until field against the same UTC-normalization problem as
+// start_time/end_time: a timezone-offset value (e.g. "+02:00") would otherwise
+// fail with "Provider produced inconsistent result after apply" on create and a
+// perpetual diff on refresh.
+func TestAccPagerDutyScheduleV2_OffsetEffectiveUntil(t *testing.T) {
+	if v := os.Getenv("PAGERDUTY_ACC_SCHEDULE_V3"); v == "" {
+		t.Skip("PAGERDUTY_ACC_SCHEDULE_V3 must be set to run v3 schedule acceptance tests")
+	}
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.test", username)
+	scheduleName := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	loc := time.FixedZone("UTC+2", 2*3600)
+	day := time.Now().Add(24 * time.Hour)
+	startTime := time.Date(day.Year(), day.Month(), day.Day(), 9, 0, 0, 0, loc).Format(time.RFC3339)
+	endTime := time.Date(day.Year(), day.Month(), day.Day(), 17, 0, 0, 0, loc).Format(time.RFC3339)
+	effectiveSince := time.Date(day.Year(), day.Month(), day.Day(), 9, 0, 0, 0, loc).Format(time.RFC3339)
+	effectiveUntil := time.Now().Add(30 * 24 * time.Hour).In(loc).Format(time.RFC3339)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(),
+		CheckDestroy:             testAccCheckPagerDutyScheduleV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPagerDutyScheduleV2EffectiveUntilConfig(username, email, scheduleName, effectiveSince, effectiveUntil, startTime, endTime),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyScheduleV2Exists("pagerduty_schedulev2.test"),
+					// State must hold the configured offset string, not the API's UTC form.
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "rotation.0.event.0.effective_until", effectiveUntil),
+				),
+			},
+			{
+				Config:             testAccPagerDutyScheduleV2EffectiveUntilConfig(username, email, scheduleName, effectiveSince, effectiveUntil, startTime, endTime),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// TestAccPagerDutyScheduleV2_TimeRepresentationChangeStable guards the
+// reconcile/equality path for active events. When state holds the API's UTC form
+// (e.g. after import) and the config expresses the same instants with a timezone
+// offset, the event is semantically unchanged: it must NOT be DELETE+CREATEd
+// (its server-assigned ID must stay the same) and the apply must not error with
+// "inconsistent result after apply". The event is made active (past
+// effective_since) so a spurious recreate would destroy a live shift.
+func TestAccPagerDutyScheduleV2_TimeRepresentationChangeStable(t *testing.T) {
+	if v := os.Getenv("PAGERDUTY_ACC_SCHEDULE_V3"); v == "" {
+		t.Skip("PAGERDUTY_ACC_SCHEDULE_V3 must be set to run v3 schedule acceptance tests")
+	}
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.test", username)
+	scheduleName := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
+	// Same instants expressed two ways: UTC "Z" form and an equivalent "+02:00"
+	// offset form. effective_since is in the past so the event is active.
+	loc := time.FixedZone("UTC+2", 2*3600)
+	esInstant := time.Now().UTC().Add(-48 * time.Hour)
+	day := time.Now().UTC().Add(24 * time.Hour)
+	startInstant := time.Date(day.Year(), day.Month(), day.Day(), 9, 0, 0, 0, time.UTC)
+	endInstant := time.Date(day.Year(), day.Month(), day.Day(), 17, 0, 0, 0, time.UTC)
+
+	esZ := esInstant.Format(time.RFC3339)
+	stZ := startInstant.Format(time.RFC3339)
+	etZ := endInstant.Format(time.RFC3339)
+
+	esOff := esInstant.In(loc).Format(time.RFC3339)
+	stOff := startInstant.In(loc).Format(time.RFC3339)
+	etOff := endInstant.In(loc).Format(time.RFC3339)
+
+	var eventID string
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(),
+		CheckDestroy:             testAccCheckPagerDutyScheduleV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPagerDutyScheduleV2Config(username, email, scheduleName, esZ, stZ, etZ),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyScheduleV2Exists("pagerduty_schedulev2.test"),
+					testAccStoreScheduleV2EventID("pagerduty_schedulev2.test", &eventID),
+				),
+			},
+			{
+				// Same instants, now in offset form. The event must survive in place.
+				Config: testAccPagerDutyScheduleV2Config(username, email, scheduleName, esOff, stOff, etOff),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyScheduleV2Exists("pagerduty_schedulev2.test"),
+					// ID unchanged proves the active event was not recreated.
+					testAccCheckScheduleV2EventIDStable("pagerduty_schedulev2.test", &eventID),
+					// State adopts the configured offset representation.
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "rotation.0.event.0.start_time", stOff),
+					resource.TestCheckResourceAttr("pagerduty_schedulev2.test", "rotation.0.event.0.effective_since", esOff),
+				),
+			},
+			{
+				Config:             testAccPagerDutyScheduleV2Config(username, email, scheduleName, esOff, stOff, etOff),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// testAccStoreScheduleV2EventID records the first event's server-assigned ID so a
+// later step can assert it did not change.
+func testAccStoreScheduleV2EventID(n string, dst *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		r, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+		id := r.Primary.Attributes["rotation.0.event.0.id"]
+		if id == "" {
+			return fmt.Errorf("no event id set for %s", n)
+		}
+		*dst = id
+		return nil
+	}
+}
+
+// testAccCheckScheduleV2EventIDStable fails if the first event's ID differs from
+// the previously stored value, which would indicate a DELETE+CREATE recreate.
+func testAccCheckScheduleV2EventIDStable(n string, want *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		r, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+		got := r.Primary.Attributes["rotation.0.event.0.id"]
+		if got != *want {
+			return fmt.Errorf("event was recreated: id was %q, now %q", *want, got)
+		}
+		return nil
+	}
+}
+
 func testAccPagerDutyScheduleV2MultipleTeamsConfig(username, email, team1, team2, scheduleName, effectiveSince, startTime, endTime string) string {
 	return fmt.Sprintf(`
 resource "pagerduty_user" "test" {

--- a/website/docs/d/schedulev2.html.markdown
+++ b/website/docs/d/schedulev2.html.markdown
@@ -8,9 +8,7 @@ description: |-
 
 # pagerduty\_schedulev2
 
-Use this data source to look up a specific [v3 schedule](https://developer.pagerduty.com/api-reference/e792b51909787-create-a-schedule) by name so you can reference its ID in other resources such as escalation policies.
-
-~> **Note:** This data source requires the `flexible-schedules-early-access` early access flag on your PagerDuty account. The required `X-Early-Access` header is sent automatically by the provider.
+Use this data source to look up a specific [v3 schedule](https://developer.pagerduty.com/api-reference/e792b51909787-create-a-schedule) by name so you can reference its ID in other resources such as escalation policies. This data source looks up shift-based (v3) schedules; for legacy schedules use the [`pagerduty_schedule`](/docs/providers/pagerduty/d/schedule.html) data source.
 
 ## Example Usage
 

--- a/website/docs/r/schedulev2.html.markdown
+++ b/website/docs/r/schedulev2.html.markdown
@@ -10,7 +10,16 @@ description: |-
 
 A [v3 schedule](https://developer.pagerduty.com/api-reference/d90c4c94e3ce2-create-a-schedule) determines the time periods that users are on call using flexible rotation configurations. This resource uses the PagerDuty v3 Schedules API, which supports per-event assignment strategies and RFC 5545 recurrence rules.
 
-~> **Note:** This resource requires the `flexible-schedules-early-access` early access flag on your PagerDuty account. The required `X-Early-Access` header is sent automatically by the provider.
+## Schedule versions and resource naming
+
+The Terraform resource names do not line up one-to-one with the API version numbers, which is a common source of confusion. The table below maps the two:
+
+| Schedule type        | Terraform resource     | API version            |
+| -------------------- | ---------------------- | ---------------------- |
+| Legacy schedule      | `pagerduty_schedule`   | v2 (Accept header)     |
+| Shift-based schedule | `pagerduty_schedulev2` | v3 (in the URL path)   |
+
+`pagerduty_schedule` manages the legacy schedule (now deprecated); `pagerduty_schedulev2` manages the newer shift-based schedule. In the UI, legacy schedules are marked with a `legacy` tag on the schedules list page.
 
 ## Example Usage
 
@@ -91,6 +100,116 @@ resource "pagerduty_schedulev2" "all_hands" {
   }
 }
 ```
+
+## Migrating from `pagerduty_schedule`
+
+The legacy `pagerduty_schedule` resource models on-call coverage with `layer` blocks (a list of `users` rotating on a fixed `rotation_turn_length_seconds`, optionally constrained by `restriction` blocks). The shift-based `pagerduty_schedulev2` resource models the same coverage with `rotation` → `event` blocks, where an `assignment_strategy` decides how the listed `member`s cover each occurrence of an RFC 5545 `recurrence`.
+
+The most common legacy shape is a single layer with several users handing off once per week (a 24/7 weekly rotation) and one or more team associations. The example below shows that shape before and after migration.
+
+**Before** — legacy `pagerduty_schedule` (single `OnCall` layer, six users, weekly handoff, two teams):
+
+```hcl
+resource "pagerduty_schedule" "example_oncall" {
+  name        = "Example OnCall Schedule"
+  description = "A Example OnCall Schedule."
+  time_zone   = "Europe/Amsterdam"
+
+  layer {
+    name                         = "OnCall"
+    start                        = "2024-06-24T00:00:00-00:00"
+    rotation_virtual_start       = "2025-03-17T07:00:00+02:00"
+    rotation_turn_length_seconds = 604800 # one week
+    users = [
+      data.pagerduty_user.user1.id,
+      data.pagerduty_user.user2.id,
+      data.pagerduty_user.user3.id,
+      data.pagerduty_user.user4.id,
+      data.pagerduty_user.user5.id,
+      data.pagerduty_user.user6.id,
+    ]
+  }
+
+  teams = [
+    pagerduty_team.k8s_platform.id,
+    pagerduty_team.k8s_operational.id,
+  ]
+}
+```
+
+**After** — equivalent `pagerduty_schedulev2`:
+
+```hcl
+resource "pagerduty_schedulev2" "example_oncall" {
+  name        = "Example OnCall Schedule"
+  description = "A Example OnCall Schedule."
+  time_zone   = "Europe/Amsterdam"
+
+  teams = [
+    pagerduty_team.k8s_platform.id,
+    pagerduty_team.k8s_operational.id,
+  ]
+
+  rotation {
+    event {
+      name = "OnCall"
+
+      # A 7-day window + weekly recurrence reproduces the legacy
+      # rotation_turn_length_seconds = 604800 (one week per turn).
+      start_time      = "2025-03-17T07:00:00+02:00"
+      end_time        = "2025-03-24T07:00:00+02:00"
+      effective_since = "2025-03-17T07:00:00+02:00"
+      recurrence      = ["RRULE:FREQ=WEEKLY"]
+
+      # The layer's user list becomes rotating members. shifts_per_member = 1
+      # means each member covers one weekly occurrence before handing off.
+      assignment_strategy {
+        type              = "rotating_member_assignment_strategy"
+        shifts_per_member = 1
+
+        member {
+          type    = "user_member"
+          user_id = data.pagerduty_user.user1.id
+        }
+        member {
+          type    = "user_member"
+          user_id = data.pagerduty_user.user2.id
+        }
+        member {
+          type    = "user_member"
+          user_id = data.pagerduty_user.user3.id
+        }
+        member {
+          type    = "user_member"
+          user_id = data.pagerduty_user.user4.id
+        }
+        member {
+          type    = "user_member"
+          user_id = data.pagerduty_user.user5.id
+        }
+        member {
+          type    = "user_member"
+          user_id = data.pagerduty_user.user6.id
+        }
+      }
+    }
+  }
+}
+```
+
+Field mapping:
+
+| Legacy (`pagerduty_schedule`)         | Shift-based (`pagerduty_schedulev2`)                                  |
+| ------------------------------------- | -------------------------------------------------------------------- |
+| `layer`                               | `rotation` (one `rotation` per layer)                                |
+| `layer.name`                          | `rotation.event.name`                                                |
+| `layer.users`                         | `assignment_strategy.member` (one `member` per user)                 |
+| `layer.rotation_turn_length_seconds`  | `event.start_time`/`end_time` window + `recurrence` (e.g. one week → 7-day window + `RRULE:FREQ=WEEKLY`) |
+| `layer.rotation_virtual_start`        | `event.start_time` / `effective_since`                               |
+| `layer.restriction`                   | a narrower `event` window plus a `BYDAY`/`BYHOUR` `RRULE`            |
+| `teams`                               | `teams` (unchanged)                                                  |
+
+~> **Note:** Multiple members rotate when `assignment_strategy.type` is `"rotating_member_assignment_strategy"`; use `"every_member_assignment_strategy"` when everyone should be on call simultaneously. To reproduce a legacy `restriction` (e.g. weekday business hours), narrow the `event` window and encode the days/hours in the `RRULE` — see the *Rotating member assignment* example above.
 
 ## Argument Reference
 


### PR DESCRIPTION
Closes #1127

Migrating a legacy pagerduty_schedule with multiple users and team associations to pagerduty_schedulev2 surfaced two idempotency bugs that prevented a clean migration:

- A schedule with more than one team showed a perpetual `teams` reorder diff on every plan, because the v3 API returns associated teams in an unstable order. flattenScheduleV3 now reconciles the API response against the prior-state ordering.
- Applying an event with timezone-offset start_time/end_time (e.g. "+02:00") failed with "Provider produced inconsistent result after apply", because the v3 API normalizes times to UTC and the create/update paths stored the normalized value instead of the configured one. Those paths now preserve the configured strings when they represent the same instant, matching the existing read-path behavior.

Both fixes are confined to the read/reconcile path; the resource schema is unchanged (teams remains a ListAttribute).

Docs: remove the obsolete flexible-schedules-early-access note from the resource and data source, add a legacy-vs-shift-based version mapping table, and add a pagerduty_schedule -> pagerduty_schedulev2 migration guide.

Adds acceptance tests TestAccPagerDutyScheduleV2_MultipleTeamsOrderStable and TestAccPagerDutyScheduleV2_OffsetTimestamps.

## Acceptance Tests

Run locally against a real PagerDuty account. Each new test is a two-step case (apply, then a `PlanOnly` / `ExpectNonEmptyPlan: false` re-plan) so a PASS confirms both a clean apply and no perpetual diff.

### New tests

```
$ TF_ACC=1 PAGERDUTY_ACC_SCHEDULE_V3=1 go test ./pagerdutyplugin/ -v \
    -run 'TestAccPagerDutyScheduleV2_(MultipleTeamsOrderStable|OffsetTimestamps)$' -timeout 20m

=== RUN   TestAccPagerDutyScheduleV2_MultipleTeamsOrderStable
--- PASS: TestAccPagerDutyScheduleV2_MultipleTeamsOrderStable (24.96s)
=== RUN   TestAccPagerDutyScheduleV2_OffsetTimestamps
--- PASS: TestAccPagerDutyScheduleV2_OffsetTimestamps (23.22s)
PASS
ok  	github.com/PagerDuty/terraform-provider-pagerduty/pagerdutyplugin	49.774s
```

### Regression subset (paths touched by the read/reconcile changes)

```
$ TF_ACC=1 PAGERDUTY_ACC_SCHEDULE_V3=1 go test ./pagerdutyplugin/ -v \
    -run 'TestAccPagerDutyScheduleV2_(Basic|Update|PastEffectiveSince)$' -timeout 20m

=== RUN   TestAccPagerDutyScheduleV2_Basic
--- PASS: TestAccPagerDutyScheduleV2_Basic (18.93s)
=== RUN   TestAccPagerDutyScheduleV2_Update
--- PASS: TestAccPagerDutyScheduleV2_Update (28.47s)
=== RUN   TestAccPagerDutyScheduleV2_PastEffectiveSince
--- PASS: TestAccPagerDutyScheduleV2_PastEffectiveSince (23.42s)
PASS
ok  	github.com/PagerDuty/terraform-provider-pagerduty/pagerdutyplugin	71.827s
```
