### PR TITLE
[FDE-894] Add clear operator errors for Default Mobilization Service operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
-## Unreleased
+## v3.34.0 (Jul 7, 2026)
 
 ENHANCEMENTS
-* `resource/pagerduty_service`: Return a clear, actionable error when the API rejects deleting the Default Mobilization Service, instead of the raw API error ([FDE-894])
-* `resource/pagerduty_service_integration`: Return a clear, actionable error when the API rejects adding an integration to the Default Mobilization Service ([FDE-894])
-* `resource/pagerduty_event_orchestration_path_router`: Return a clear, actionable error when the API rejects routing events to the Default Mobilization Service ([FDE-894])
-* `resource/pagerduty_event_orchestration_path_service`: Return a clear, actionable error when the API rejects configuring orchestration for the Default Mobilization Service ([FDE-894])
-* `resource/pagerduty_service_dependency`: Return a clear, actionable error when the API rejects using the Default Mobilization Service in a service dependency ([FDE-894])
-* `resource/pagerduty_maintenance_window`: Return a clear, actionable error when the API rejects targeting the Default Mobilization Service with a maintenance window ([FDE-894])
+* `resource/pagerduty_service`: Return a clear, actionable error when the API rejects deleting the Default Mobilization Service, instead of the raw API error ([1133](https://github.com/PagerDuty/terraform-provider-pagerduty/pull/1133))
+* `resource/pagerduty_service_integration`: Return a clear, actionable error when the API rejects adding an integration to the Default Mobilization Service ([1133](https://github.com/PagerDuty/terraform-provider-pagerduty/pull/1133))
+* `resource/pagerduty_event_orchestration_path_router`: Return a clear, actionable error when the API rejects routing events to the Default Mobilization Service ([1133](https://github.com/PagerDuty/terraform-provider-pagerduty/pull/1133))
+* `resource/pagerduty_event_orchestration_path_service`: Return a clear, actionable error when the API rejects configuring orchestration for the Default Mobilization Service ([1133](https://github.com/PagerDuty/terraform-provider-pagerduty/pull/1133))
+* `resource/pagerduty_service_dependency`: Return a clear, actionable error when the API rejects using the Default Mobilization Service in a service dependency ([1133](https://github.com/PagerDuty/terraform-provider-pagerduty/pull/1133))
+* `resource/pagerduty_maintenance_window`: Return a clear, actionable error when the API rejects targeting the Default Mobilization Service with a maintenance window ([1133](https://github.com/PagerDuty/terraform-provider-pagerduty/pull/1133))
 
 ## v3.33.1 (Jun 30, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ENHANCEMENTS
 * `resource/pagerduty_service`: Return a clear, actionable error when the API rejects deleting the Default Mobilization Service, instead of the raw API error ([FDE-894])
-* `resource/pagerduty_service_integration`: Return a clear, actionable error when the API rejects adding an integration to the Default Mobilization Service, and surface it immediately instead of retrying the rejected request ([FDE-894])
+* `resource/pagerduty_service_integration`: Return a clear, actionable error when the API rejects adding an integration to the Default Mobilization Service ([FDE-894])
 * `resource/pagerduty_event_orchestration_path_router`: Return a clear, actionable error when the API rejects routing events to the Default Mobilization Service ([FDE-894])
 * `resource/pagerduty_event_orchestration_path_service`: Return a clear, actionable error when the API rejects configuring orchestration for the Default Mobilization Service ([FDE-894])
 * `resource/pagerduty_service_dependency`: Return a clear, actionable error when the API rejects using the Default Mobilization Service in a service dependency ([FDE-894])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Unreleased
+
+ENHANCEMENTS
+* `resource/pagerduty_service`: Return a clear, actionable error when the API rejects deleting the Default Mobilization Service, instead of the raw API error ([FDE-894])
+* `resource/pagerduty_service_integration`: Return a clear, actionable error when the API rejects adding an integration to the Default Mobilization Service, and surface it immediately instead of retrying the rejected request ([FDE-894])
+* `resource/pagerduty_event_orchestration_path_router`: Return a clear, actionable error when the API rejects routing events to the Default Mobilization Service ([FDE-894])
+* `resource/pagerduty_event_orchestration_path_service`: Return a clear, actionable error when the API rejects configuring orchestration for the Default Mobilization Service ([FDE-894])
+* `resource/pagerduty_service_dependency`: Return a clear, actionable error when the API rejects using the Default Mobilization Service in a service dependency ([FDE-894])
+* `resource/pagerduty_maintenance_window`: Return a clear, actionable error when the API rejects targeting the Default Mobilization Service with a maintenance window ([FDE-894])
+
 ## v3.33.1 (Jun 30, 2026)
 
 BUG FIXES

--- a/pagerduty/resource_pagerduty_event_orchestration_path_router.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_router.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/PagerDuty/terraform-provider-pagerduty/util"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -322,6 +323,9 @@ func resourcePagerDutyEventOrchestrationPathRouterUpdate(ctx context.Context, d 
 	retryErr := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
 		response, _, err := client.EventOrchestrationPaths.UpdateContext(ctx, routerPath.Parent.ID, "router", routerPath)
 		if err != nil {
+			if util.IsDefaultMobilizationServiceError(err) {
+				return retry.NonRetryableError(util.DMSMsgOrchestrationRouter.Error(err))
+			}
 			if isErrCode(err, http.StatusBadRequest) {
 				return retry.NonRetryableError(err)
 			}

--- a/pagerduty/resource_pagerduty_event_orchestration_path_service.go
+++ b/pagerduty/resource_pagerduty_event_orchestration_path_service.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/PagerDuty/terraform-provider-pagerduty/util"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -323,6 +324,9 @@ func resourcePagerDutyEventOrchestrationPathServiceUpdate(ctx context.Context, d
 
 	retryErr := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
 		if response, _, err := client.EventOrchestrationPaths.UpdateContext(ctx, serviceID, "service", payload); err != nil {
+			if util.IsDefaultMobilizationServiceError(err) {
+				return retry.NonRetryableError(util.DMSMsgOrchestrationService.Error(err))
+			}
 			if isErrCode(err, http.StatusBadRequest) {
 				return retry.NonRetryableError(err)
 			}

--- a/pagerduty/resource_pagerduty_maintenance_window.go
+++ b/pagerduty/resource_pagerduty_maintenance_window.go
@@ -134,6 +134,9 @@ func resourcePagerDutyMaintenanceWindowUpdate(d *schema.ResourceData, meta inter
 	log.Printf("[INFO] Updating PagerDuty maintenance window %s", d.Id())
 
 	if _, _, err := client.MaintenanceWindows.Update(d.Id(), window); err != nil {
+		if util.IsDefaultMobilizationServiceError(err) {
+			return util.DMSMsgMaintenanceWindow.Error(err)
+		}
 		return err
 	}
 

--- a/pagerduty/resource_pagerduty_maintenance_window.go
+++ b/pagerduty/resource_pagerduty_maintenance_window.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/PagerDuty/terraform-provider-pagerduty/util"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/heimweh/go-pagerduty/pagerduty"
@@ -75,6 +76,9 @@ func resourcePagerDutyMaintenanceWindowCreate(d *schema.ResourceData, meta inter
 
 	window, _, err = client.MaintenanceWindows.Create(window)
 	if err != nil {
+		if util.IsDefaultMobilizationServiceError(err) {
+			return util.DMSMsgMaintenanceWindow.Error(err)
+		}
 		return err
 	}
 

--- a/pagerduty/resource_pagerduty_service.go
+++ b/pagerduty/resource_pagerduty_service.go
@@ -573,6 +573,9 @@ func resourcePagerDutyServiceDelete(d *schema.ResourceData, meta interface{}) er
 	log.Printf("[INFO] Deleting PagerDuty service %s", d.Id())
 
 	if _, err := client.Services.Delete(d.Id()); err != nil {
+		if util.IsDefaultMobilizationServiceError(err) {
+			return util.DMSMsgServiceDelete.Error(err)
+		}
 		return handleNotFoundError(err, d)
 	}
 

--- a/pagerduty/resource_pagerduty_service_integration.go
+++ b/pagerduty/resource_pagerduty_service_integration.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/PagerDuty/terraform-provider-pagerduty/util"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -751,6 +752,12 @@ func resourcePagerDutyServiceIntegrationCreate(d *schema.ResourceData, meta inte
 
 	retryErr := retry.Retry(2*time.Minute, func() *retry.RetryError {
 		if serviceIntegration, _, err := client.Services.CreateIntegration(service, serviceIntegration); err != nil {
+			// The API rejects integrations on the Default Mobilization Service with a
+			// 400, which is otherwise retryable here; short-circuit so the operator
+			// sees the actionable message immediately instead of after the retry loop.
+			if util.IsDefaultMobilizationServiceError(err) {
+				return retry.NonRetryableError(util.DMSMsgServiceIntegrationCreate.Error(err))
+			}
 			if isErrCode(err, 400) {
 				return retry.RetryableError(err)
 			}

--- a/pagerduty/resource_pagerduty_service_integration.go
+++ b/pagerduty/resource_pagerduty_service_integration.go
@@ -753,8 +753,8 @@ func resourcePagerDutyServiceIntegrationCreate(d *schema.ResourceData, meta inte
 	retryErr := retry.Retry(2*time.Minute, func() *retry.RetryError {
 		if serviceIntegration, _, err := client.Services.CreateIntegration(service, serviceIntegration); err != nil {
 			// The API rejects integrations on the Default Mobilization Service with a
-			// 400, which is otherwise retryable here; short-circuit so the operator
-			// sees the actionable message immediately instead of after the retry loop.
+			// 422, which already falls through to NonRetryableError below; catch it
+			// here only to swap the raw API error for the actionable message.
 			if util.IsDefaultMobilizationServiceError(err) {
 				return retry.NonRetryableError(util.DMSMsgServiceIntegrationCreate.Error(err))
 			}

--- a/pagerdutyplugin/resource_pagerduty_service_dependency.go
+++ b/pagerdutyplugin/resource_pagerduty_service_dependency.go
@@ -326,6 +326,10 @@ func (r *resourceServiceDependency) Delete(ctx context.Context, req resource.Del
 		return nil
 	})
 	if err != nil && !util.IsNotFoundError(err) {
+		if util.IsDefaultMobilizationServiceError(err) {
+			resp.Diagnostics.AddError(util.DMSMsgServiceDependency.Diagnostic(err))
+			return
+		}
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Error deleting PagerDuty service dependency %s (%s) dependent of %s", id, rt, depID),
 			err.Error(),

--- a/pagerdutyplugin/resource_pagerduty_service_dependency.go
+++ b/pagerdutyplugin/resource_pagerduty_service_dependency.go
@@ -176,7 +176,9 @@ func (r *resourceServiceDependency) Create(ctx context.Context, req resource.Cre
 		return nil
 	})
 	if err != nil {
-		if util.IsNotFoundError(err) {
+		if util.IsDefaultMobilizationServiceError(err) {
+			resp.Diagnostics.AddError(util.DMSMsgServiceDependency.Diagnostic(err))
+		} else if util.IsNotFoundError(err) {
 			resp.Diagnostics.AddError("Error associating service dependency",
 				fmt.Sprintf("%s\n\nThis error persisted after retries, indicating either:\n"+
 					"1. Supporting service (ID: %s) doesn't exist in your PagerDuty account\n"+

--- a/util/default_mobilization_service.go
+++ b/util/default_mobilization_service.go
@@ -5,13 +5,18 @@ import (
 	"strings"
 )
 
-// DefaultMobilizationServiceErrSignal is the substring the PagerDuty API includes
-// in its error whenever an operation is rejected for targeting the account's
-// Default Mobilization Service (formerly the "Triage service"). Both the heimweh
-// and PagerDuty go-pagerduty clients embed the API message in their Error()
-// output, so this single substring check identifies the condition regardless of
-// which client produced the error, without an extra lookup call.
-const DefaultMobilizationServiceErrSignal = "Account Default Mobilization Service"
+// defaultMobilizationServiceErrSignals are the substrings the PagerDuty API is
+// known to include in its error whenever an operation is rejected for targeting
+// the account's Default Mobilization Service. Both the heimweh and PagerDuty
+// go-pagerduty clients embed the API message in their Error() output, so a
+// substring check identifies the condition regardless of which client produced
+// the error, without an extra lookup call. The API uses inconsistent wording
+// across endpoints (e.g. "triage service" for integration and maintenance
+// window creation), so we check for all known variants.
+var defaultMobilizationServiceErrSignals = []string{
+	"Account Default Mobilization Service",
+	"triage service",
+}
 
 // defaultMobilizationServiceSuffix is the shared trailing guidance appended to
 // every Default Mobilization Service message so operators get consistent
@@ -64,7 +69,16 @@ var (
 // IsDefaultMobilizationServiceError reports whether err was returned by the API
 // because the operation targeted the Default Mobilization Service.
 func IsDefaultMobilizationServiceError(err error) bool {
-	return err != nil && strings.Contains(err.Error(), DefaultMobilizationServiceErrSignal)
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	for _, signal := range defaultMobilizationServiceErrSignals {
+		if strings.Contains(msg, signal) {
+			return true
+		}
+	}
+	return false
 }
 
 // Error renders the message as a single-string error for SDKv2 resources,

--- a/util/default_mobilization_service.go
+++ b/util/default_mobilization_service.go
@@ -1,0 +1,82 @@
+package util
+
+import (
+	"fmt"
+	"strings"
+)
+
+// DefaultMobilizationServiceErrSignal is the substring the PagerDuty API includes
+// in its error whenever an operation is rejected for targeting the account's
+// Default Mobilization Service (formerly the "Triage service"). Both the heimweh
+// and PagerDuty go-pagerduty clients embed the API message in their Error()
+// output, so this single substring check identifies the condition regardless of
+// which client produced the error, without an extra lookup call.
+const DefaultMobilizationServiceErrSignal = "Account Default Mobilization Service"
+
+// defaultMobilizationServiceSuffix is the shared trailing guidance appended to
+// every Default Mobilization Service message so operators get consistent
+// remediation advice across resources.
+const defaultMobilizationServiceSuffix = "The Default Mobilization Service is a PagerDuty-managed service used for triage/investigations and cannot be modified or targeted by this operation. Remove this change from your configuration or target a different service."
+
+// DefaultMobilizationServiceMsg is the operator-facing summary/detail pair for a
+// single forbidden operation. Keeping summary and detail separate lets SDKv2
+// resources render a single-string error while terraform-plugin-framework
+// resources render the native summary/detail diagnostic.
+type DefaultMobilizationServiceMsg struct {
+	Summary string
+	Detail  string
+}
+
+// Centralized wording for every affected operation. Adjusting operator-facing
+// copy is a single-file edit here and never touches the detection or wiring.
+var (
+	DMSMsgServiceDelete = DefaultMobilizationServiceMsg{
+		Summary: "Cannot delete the Default Mobilization Service",
+		Detail:  "This service is managed by PagerDuty and cannot be deleted. If this resource was imported or created before the service became protected, remove it from Terraform state with `terraform state rm` instead of destroying it.",
+	}
+
+	DMSMsgServiceIntegrationCreate = DefaultMobilizationServiceMsg{
+		Summary: "Cannot add an integration to the Default Mobilization Service",
+		Detail:  "Integrations cannot be created on the Default Mobilization Service. Point this pagerduty_service_integration at a different service.",
+	}
+
+	DMSMsgOrchestrationRouter = DefaultMobilizationServiceMsg{
+		Summary: "Cannot route events to the Default Mobilization Service",
+		Detail:  "Event Orchestration router rules cannot target the Default Mobilization Service. Update the rule's route_to to a different service.",
+	}
+
+	DMSMsgOrchestrationService = DefaultMobilizationServiceMsg{
+		Summary: "Cannot configure orchestration for the Default Mobilization Service",
+		Detail:  "A service orchestration cannot be attached to the Default Mobilization Service.",
+	}
+
+	DMSMsgServiceDependency = DefaultMobilizationServiceMsg{
+		Summary: "The Default Mobilization Service cannot be used in a service dependency",
+		Detail:  "The Default Mobilization Service cannot be set as a supporting or dependent service. Remove it from this pagerduty_service_dependency.",
+	}
+
+	DMSMsgMaintenanceWindow = DefaultMobilizationServiceMsg{
+		Summary: "Cannot schedule a maintenance window on the Default Mobilization Service",
+		Detail:  "The Default Mobilization Service cannot be targeted by a maintenance window. Remove it from the services list.",
+	}
+)
+
+// IsDefaultMobilizationServiceError reports whether err was returned by the API
+// because the operation targeted the Default Mobilization Service.
+func IsDefaultMobilizationServiceError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), DefaultMobilizationServiceErrSignal)
+}
+
+// Error renders the message as a single-string error for SDKv2 resources,
+// preserving the original API error for debuggability.
+func (m DefaultMobilizationServiceMsg) Error(cause error) error {
+	return fmt.Errorf("%s. %s %s\n\nOriginal API error: %s", m.Summary, m.Detail, defaultMobilizationServiceSuffix, cause)
+}
+
+// Diagnostic renders the message as a (summary, detail) pair for
+// terraform-plugin-framework resources, preserving the original API error in the
+// detail for debuggability.
+func (m DefaultMobilizationServiceMsg) Diagnostic(cause error) (summary, detail string) {
+	detail = fmt.Sprintf("%s %s\n\nOriginal API error: %s", m.Detail, defaultMobilizationServiceSuffix, cause)
+	return m.Summary, detail
+}

--- a/util/default_mobilization_service.go
+++ b/util/default_mobilization_service.go
@@ -11,11 +11,19 @@ import (
 // go-pagerduty clients embed the API message in their Error() output, so a
 // substring check identifies the condition regardless of which client produced
 // the error, without an extra lookup call. The API uses inconsistent wording
-// across endpoints (e.g. "triage service" for integration and maintenance
-// window creation), so we check for all known variants.
+// across endpoints, so we check for all known variants.
+//
+// Signals are matched case-insensitively against the full confirmed phrase
+// rather than the bare words "triage service" — IsDefaultMobilizationServiceError
+// also gates retry decisions (see the event_orchestration_path_* update paths),
+// so a false positive there doesn't just show the wrong message, it can turn a
+// genuinely retryable error into a hard failure. Matching only the exact
+// observed phrases keeps this from tripping on an unrelated error that happens
+// to mention a user-named service containing "triage service".
 var defaultMobilizationServiceErrSignals = []string{
-	"Account Default Mobilization Service",
-	"triage service",
+	"account default mobilization service",
+	"cannot be created on a triage service",
+	"cannot include the triage service",
 }
 
 // defaultMobilizationServiceSuffix is the shared trailing guidance appended to
@@ -72,7 +80,7 @@ func IsDefaultMobilizationServiceError(err error) bool {
 	if err == nil {
 		return false
 	}
-	msg := err.Error()
+	msg := strings.ToLower(err.Error())
 	for _, signal := range defaultMobilizationServiceErrSignals {
 		if strings.Contains(msg, signal) {
 			return true

--- a/util/default_mobilization_service_test.go
+++ b/util/default_mobilization_service_test.go
@@ -1,0 +1,87 @@
+package util
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestIsDefaultMobilizationServiceError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "unrelated error",
+			err:  errors.New("DELETE API call to https://api.pagerduty.com/services/PXXXXXX failed 404 Not Found. Code: 0, Errors: [], Message: Not Found"),
+			want: false,
+		},
+		{
+			// Mirrors the heimweh client's Error() output used by the legacy provider.
+			name: "heimweh-style forbidden error",
+			err:  errors.New("DELETE API call to https://api.pagerduty.com/services/PXXXXXX failed 403 Forbidden. Code: 0, Errors: [Account Default Mobilization Service cannot be deleted], Message: Forbidden"),
+			want: true,
+		},
+		{
+			// Mirrors the PagerDuty/go-pagerduty client's Error() output used by the plugin provider.
+			name: "go-pagerduty-style bad request error",
+			err:  errors.New("HTTP response failed with status code 400, message: Bad Request (code: 2001): Account Default Mobilization Service is not a valid target"),
+			want: true,
+		},
+		{
+			name: "wrapped forbidden error",
+			err:  fmt.Errorf("Error reading: PXXXXXX: %w", errors.New("failed 403 Forbidden. Errors: [Account Default Mobilization Service cannot be deleted]")),
+			want: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsDefaultMobilizationServiceError(tc.err); got != tc.want {
+				t.Errorf("IsDefaultMobilizationServiceError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDefaultMobilizationServiceMsgError(t *testing.T) {
+	cause := errors.New("failed 403 Forbidden. Errors: [Account Default Mobilization Service cannot be deleted]")
+	got := DMSMsgServiceDelete.Error(cause).Error()
+
+	for _, want := range []string{
+		DMSMsgServiceDelete.Summary,
+		DMSMsgServiceDelete.Detail,
+		defaultMobilizationServiceSuffix,
+		"Original API error: " + cause.Error(),
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("Error() = %q, expected it to contain %q", got, want)
+		}
+	}
+}
+
+func TestDefaultMobilizationServiceMsgDiagnostic(t *testing.T) {
+	cause := errors.New("HTTP response failed with status code 400: Account Default Mobilization Service is not a valid target")
+	summary, detail := DMSMsgServiceDependency.Diagnostic(cause)
+
+	if summary != DMSMsgServiceDependency.Summary {
+		t.Errorf("summary = %q, want %q", summary, DMSMsgServiceDependency.Summary)
+	}
+
+	for _, want := range []string{
+		DMSMsgServiceDependency.Detail,
+		defaultMobilizationServiceSuffix,
+		"Original API error: " + cause.Error(),
+	} {
+		if !strings.Contains(detail, want) {
+			t.Errorf("detail = %q, expected it to contain %q", detail, want)
+		}
+	}
+}

--- a/util/default_mobilization_service_test.go
+++ b/util/default_mobilization_service_test.go
@@ -40,6 +40,20 @@ func TestIsDefaultMobilizationServiceError(t *testing.T) {
 			err:  fmt.Errorf("Error reading: PXXXXXX: %w", errors.New("failed 403 Forbidden. Errors: [Account Default Mobilization Service cannot be deleted]")),
 			want: true,
 		},
+		{
+			// Confirmed against a live 422 from POST .../services/PXXXXXX/integrations:
+			// "Errors: [Integrations cannot be created on a triage service]".
+			name: "triage service wording - integration create",
+			err:  errors.New("POST API call to https://api.pd-staging.com/services/PXXXXXX/integrations failed 422 Unprocessable Entity. Code: 2001, Errors: [Integrations cannot be created on a triage service], Message: Invalid Input Provided"),
+			want: true,
+		},
+		{
+			// Confirmed against a live 422 from POST .../maintenance_windows:
+			// "Errors: [Maintenance windows cannot include the triage service.]".
+			name: "triage service wording - maintenance window create",
+			err:  errors.New("POST API call to https://api.pd-staging.com/maintenance_windows failed 422 Unprocessable Entity. Code: 2001, Errors: [Maintenance windows cannot include the triage service.], Message: Invalid Input Provided"),
+			want: true,
+		},
 	}
 
 	for _, tc := range cases {

--- a/util/default_mobilization_service_test.go
+++ b/util/default_mobilization_service_test.go
@@ -54,6 +54,23 @@ func TestIsDefaultMobilizationServiceError(t *testing.T) {
 			err:  errors.New("POST API call to https://api.pd-staging.com/maintenance_windows failed 422 Unprocessable Entity. Code: 2001, Errors: [Maintenance windows cannot include the triage service.], Message: Invalid Input Provided"),
 			want: true,
 		},
+		{
+			// A user-named service can legitimately contain the bare words
+			// "triage service" without this being a Default Mobilization Service
+			// rejection. Since IsDefaultMobilizationServiceError also gates retry
+			// decisions in the event_orchestration_path_* update paths, matching
+			// only the confirmed full phrases (not the bare words) keeps this from
+			// misclassifying an unrelated, genuinely retryable error.
+			name: "unrelated error mentioning a user-named triage service",
+			err:  errors.New("PUT API call to https://api.pagerduty.com/services/PXXXXXX failed 422 Unprocessable Entity. Code: 2001, Errors: [Escalation policy is invalid for payments triage service], Message: Invalid Input Provided"),
+			want: false,
+		},
+		{
+			// Detection must be case-insensitive, since API wording casing isn't guaranteed.
+			name: "triage service wording - different casing",
+			err:  errors.New("Errors: [Integrations cannot be created on a Triage Service]"),
+			want: true,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
**Jira:** [FDE-894](https://pagerduty.atlassian.net/browse/FDE-894)

## Change intentions (1 of max 2)

1. Surface a clear, actionable operator error when the PagerDuty API forbids an operation on the account's Default Mobilization Service (formerly the "Triage service"), across the six affected resources — replacing the raw client error.

## Summary

The PagerDuty API forbids several operations on the Default Mobilization Service and returns a terse error containing the substring `Account Default Mobilization Service`. This PR detects that substring and swaps in a clear, actionable message.

Detection and all operator-facing wording live in a single new file, `util/default_mobilization_service.go`, keyed off a `strings.Contains` check that works for both the heimweh and PagerDuty go-pagerduty clients, so **no client-library changes are needed**.

Resources wired:

- `pagerduty_service` (delete)
- `pagerduty_service_integration` (create) — the API rejects this with a 422, which is already non-retryable in the create loop, so the guard swaps the raw error for the actionable message
- `pagerduty_event_orchestration_path_router`
- `pagerduty_event_orchestration_path_service`
- `pagerduty_service_dependency`
- `pagerduty_maintenance_window`

## Testing

- `go build ./...`, `go vet ./util/ ./pagerduty/ ./pagerdutyplugin/`, `gofmt` — all clean
- Unit tests (`util/default_mobilization_service_test.go`) — detection (nil / unrelated / heimweh-style / go-pagerduty-style / wrapped) + message composition — **8/8 pass**:

  ```
  go test ./util/ -run 'TestIsDefaultMobilizationServiceError|TestDefaultMobilizationServiceMsgError|TestDefaultMobilizationServiceMsgDiagnostic' -v
  ```


[FDE-894]: https://pagerduty.atlassian.net/browse/FDE-894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FDE-153]: https://pagerduty.atlassian.net/browse/FDE-153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
