### PR TITLE
Fix DMS error detection to match real API wording (FDE-894)

### DIFF
--- a/util/default_mobilization_service.go
+++ b/util/default_mobilization_service.go
@@ -5,13 +5,18 @@ import (
 	"strings"
 )
 
-// DefaultMobilizationServiceErrSignal is the substring the PagerDuty API includes
-// in its error whenever an operation is rejected for targeting the account's
-// Default Mobilization Service (formerly the "Triage service"). Both the heimweh
-// and PagerDuty go-pagerduty clients embed the API message in their Error()
-// output, so this single substring check identifies the condition regardless of
-// which client produced the error, without an extra lookup call.
-const DefaultMobilizationServiceErrSignal = "Account Default Mobilization Service"
+// defaultMobilizationServiceErrSignals are the substrings the PagerDuty API is
+// known to include in its error whenever an operation is rejected for targeting
+// the account's Default Mobilization Service. Both the heimweh and PagerDuty
+// go-pagerduty clients embed the API message in their Error() output, so a
+// substring check identifies the condition regardless of which client produced
+// the error, without an extra lookup call. The API uses inconsistent wording
+// across endpoints (e.g. "triage service" for integration and maintenance
+// window creation), so we check for all known variants.
+var defaultMobilizationServiceErrSignals = []string{
+	"Account Default Mobilization Service",
+	"triage service",
+}
 
 // defaultMobilizationServiceSuffix is the shared trailing guidance appended to
 // every Default Mobilization Service message so operators get consistent
@@ -64,7 +69,16 @@ var (
 // IsDefaultMobilizationServiceError reports whether err was returned by the API
 // because the operation targeted the Default Mobilization Service.
 func IsDefaultMobilizationServiceError(err error) bool {
-	return err != nil && strings.Contains(err.Error(), DefaultMobilizationServiceErrSignal)
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	for _, signal := range defaultMobilizationServiceErrSignals {
+		if strings.Contains(msg, signal) {
+			return true
+		}
+	}
+	return false
 }
 
 // Error renders the message as a single-string error for SDKv2 resources,

--- a/util/default_mobilization_service.go
+++ b/util/default_mobilization_service.go
@@ -11,11 +11,19 @@ import (
 // go-pagerduty clients embed the API message in their Error() output, so a
 // substring check identifies the condition regardless of which client produced
 // the error, without an extra lookup call. The API uses inconsistent wording
-// across endpoints (e.g. "triage service" for integration and maintenance
-// window creation), so we check for all known variants.
+// across endpoints, so we check for all known variants.
+//
+// Signals are matched case-insensitively against the full confirmed phrase
+// rather than the bare words "triage service" — IsDefaultMobilizationServiceError
+// also gates retry decisions (see the event_orchestration_path_* update paths),
+// so a false positive there doesn't just show the wrong message, it can turn a
+// genuinely retryable error into a hard failure. Matching only the exact
+// observed phrases keeps this from tripping on an unrelated error that happens
+// to mention a user-named service containing "triage service".
 var defaultMobilizationServiceErrSignals = []string{
-	"Account Default Mobilization Service",
-	"triage service",
+	"account default mobilization service",
+	"cannot be created on a triage service",
+	"cannot include the triage service",
 }
 
 // defaultMobilizationServiceSuffix is the shared trailing guidance appended to
@@ -72,7 +80,7 @@ func IsDefaultMobilizationServiceError(err error) bool {
 	if err == nil {
 		return false
 	}
-	msg := err.Error()
+	msg := strings.ToLower(err.Error())
 	for _, signal := range defaultMobilizationServiceErrSignals {
 		if strings.Contains(msg, signal) {
 			return true

--- a/util/default_mobilization_service_test.go
+++ b/util/default_mobilization_service_test.go
@@ -40,6 +40,20 @@ func TestIsDefaultMobilizationServiceError(t *testing.T) {
 			err:  fmt.Errorf("Error reading: PXXXXXX: %w", errors.New("failed 403 Forbidden. Errors: [Account Default Mobilization Service cannot be deleted]")),
 			want: true,
 		},
+		{
+			// Confirmed against a live 422 from POST .../services/PXXXXXX/integrations:
+			// "Errors: [Integrations cannot be created on a triage service]".
+			name: "triage service wording - integration create",
+			err:  errors.New("POST API call to https://api.pd-staging.com/services/PXXXXXX/integrations failed 422 Unprocessable Entity. Code: 2001, Errors: [Integrations cannot be created on a triage service], Message: Invalid Input Provided"),
+			want: true,
+		},
+		{
+			// Confirmed against a live 422 from POST .../maintenance_windows:
+			// "Errors: [Maintenance windows cannot include the triage service.]".
+			name: "triage service wording - maintenance window create",
+			err:  errors.New("POST API call to https://api.pd-staging.com/maintenance_windows failed 422 Unprocessable Entity. Code: 2001, Errors: [Maintenance windows cannot include the triage service.], Message: Invalid Input Provided"),
+			want: true,
+		},
 	}
 
 	for _, tc := range cases {

--- a/util/default_mobilization_service_test.go
+++ b/util/default_mobilization_service_test.go
@@ -54,6 +54,23 @@ func TestIsDefaultMobilizationServiceError(t *testing.T) {
 			err:  errors.New("POST API call to https://api.pd-staging.com/maintenance_windows failed 422 Unprocessable Entity. Code: 2001, Errors: [Maintenance windows cannot include the triage service.], Message: Invalid Input Provided"),
 			want: true,
 		},
+		{
+			// A user-named service can legitimately contain the bare words
+			// "triage service" without this being a Default Mobilization Service
+			// rejection. Since IsDefaultMobilizationServiceError also gates retry
+			// decisions in the event_orchestration_path_* update paths, matching
+			// only the confirmed full phrases (not the bare words) keeps this from
+			// misclassifying an unrelated, genuinely retryable error.
+			name: "unrelated error mentioning a user-named triage service",
+			err:  errors.New("PUT API call to https://api.pagerduty.com/services/PXXXXXX failed 422 Unprocessable Entity. Code: 2001, Errors: [Escalation policy is invalid for payments triage service], Message: Invalid Input Provided"),
+			want: false,
+		},
+		{
+			// Detection must be case-insensitive, since API wording casing isn't guaranteed.
+			name: "triage service wording - different casing",
+			err:  errors.New("Errors: [Integrations cannot be created on a Triage Service]"),
+			want: true,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary
- Live testing against staging surfaced that the API returns "...triage service" wording for `pagerduty_service_integration` create and `pagerduty_maintenance_window` create/update, not the `"Account Default Mobilization Service"` substring `IsDefaultMobilizationServiceError` checked for.
- As a result, the guardrails added in this branch silently never fired for those two operations, and users still saw the raw API error instead of the friendly message.
- Broadened detection to check for both known wordings.

## Test plan
- [x] `go test ./util/...` passes, including two new cases reproducing the exact staging 422 responses observed
- [x] Verified locally against `api.pd-staging.com` with a dev_overrides build:
  - `pagerduty_service_integration` create on the DMS now returns the friendly `DMSMsgServiceIntegrationCreate` message
  - `pagerduty_maintenance_window` create on the DMS now returns the friendly `DMSMsgMaintenanceWindow` message