### PR TITLE
[DO NOT MERGE UNTIL GA] UA-1146: Add ua_runner to runner_type validation enum

### DIFF
--- a/pagerduty/resource_pagerduty_automation_actions_runner.go
+++ b/pagerduty/resource_pagerduty_automation_actions_runner.go
@@ -31,6 +31,7 @@ func resourcePagerDutyAutomationActionsRunner() *schema.Resource {
 				ValidateDiagFunc: validateValueDiagFunc([]string{
 					"sidecar",
 					"runbook",
+					"ua_runner",
 				}),
 				ForceNew: true, // Requires creation of new resource while support for update is not implemented
 			},

--- a/website/docs/d/automation_actions_runner.html.markdown
+++ b/website/docs/d/automation_actions_runner.html.markdown
@@ -31,7 +31,7 @@ The following attributes are exported:
 * `id` - The ID of the found runner.
 * `name` - The name of the found runner.
 * `type` - The type of object. The value returned will be `runner`.
-* `runner_type` - The type of runner. Allowed values are `sidecar` and `runbook`.
+* `runner_type` - The type of runner. Allowed values are `sidecar`, `runbook`, and `ua_runner`.
 * `creation_time` - The time runner was created. Represented as an ISO 8601 timestamp.
 * `description` - (Optional) The description of the runner.
 * `last_seen` - (Optional) The last time runner has been seen. Represented as an ISO 8601 timestamp.


### PR DESCRIPTION
- Adds `ua_runner` to the `runner_type` validation enum in
  `resource_pagerduty_automation_actions_runner.go`
  - This allows Terraform to recognize `ua_runner` as a valid runner type for
  import/read operations
  - Creation via Terraform is still restricted to `runbook` type only (ua_runners are
   created through the Connectors UI)