### PR TITLE
[TFPROVDEV-146] Handle out-of-band deletion of pagerduty_user_contact_method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## v3.34.1 (Unreleased)
+## Unreleased
+
+BREAKING CHANGES
+* `resource/pagerduty_user_contact_method`: `user_id` is now `ForceNew`. A contact method's ID is scoped under its user, so changing `user_id` previously planned an in-place update that always failed with `404 Not Found`; it now replaces the resource ([1141](https://github.com/PagerDuty/terraform-provider-pagerduty/pull/1141))
 
 BUG FIXES
 * `resource/pagerduty_user_contact_method`: Honor the caller's error handler when reading back a contact method, so a `404` right after create is retried and then reported instead of being silently treated as "resource gone" and dropped from state ([1141](https://github.com/PagerDuty/terraform-provider-pagerduty/pull/1141))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## v3.34.1 (Unreleased)
+
+BUG FIXES
+* `resource/pagerduty_user_contact_method`: Honor the caller's error handler when reading back a contact method, so a `404` right after create is retried and then reported instead of being silently treated as "resource gone" and dropped from state ([1141](https://github.com/PagerDuty/terraform-provider-pagerduty/pull/1141))
+
+ENHANCEMENTS
+* `resource/pagerduty_user_contact_method`: Return a clear, actionable error when an update targets a contact method that was deleted outside of Terraform after the plan was generated, pointing at `terraform apply -refresh-only` instead of surfacing a bare `404 Not Found` ([1141](https://github.com/PagerDuty/terraform-provider-pagerduty/pull/1141))
+
+DOCS
+* `resource/pagerduty_user_contact_method`: Document that a contact method deleted in the web interface is re-created by a refresh-enabled plan/apply and does not require `terraform state rm` ([1141](https://github.com/PagerDuty/terraform-provider-pagerduty/pull/1141))
+
 ## v3.34.0 (Jul 7, 2026)
 
 ENHANCEMENTS

--- a/pagerduty/import_pagerduty_user_contact_method_test.go
+++ b/pagerduty/import_pagerduty_user_contact_method_test.go
@@ -1,0 +1,38 @@
+package pagerduty
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccPagerDutyUserContactMethod_import(t *testing.T) {
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.test", username)
+	address := fmt.Sprintf("%s@foo.test", acctest.RandString(6))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyUserContactMethodDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyUserContactMethodConfig(username, email, address, "Work"),
+			},
+			{
+				ResourceName:      "pagerduty_user_contact_method.foo",
+				ImportStateIdFunc: testAccCheckPagerDutyUserContactMethodID,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckPagerDutyUserContactMethodID(s *terraform.State) (string, error) {
+	cm := s.RootModule().Resources["pagerduty_user_contact_method.foo"].Primary
+	return fmt.Sprintf("%v:%v", cm.Attributes["user_id"], cm.ID), nil
+}

--- a/pagerduty/provider.go
+++ b/pagerduty/provider.go
@@ -222,15 +222,21 @@ func genError(err error, d *schema.ResourceData) error {
 	return fmt.Errorf("Error reading: %s: %s", d.Id(), err)
 }
 
-// handleStaleIDError converts a not-found error returned by a write call into
-// actionable guidance. Terraform only plans an update against an ID it read
-// during refresh, so a 404 on update means the object was deleted outside of
+// handleStaleIDErrorOnUpdate converts a not-found error returned by an update
+// call into actionable guidance. Terraform only plans an update against an ID it
+// read during refresh, so a 404 here means the object was deleted outside of
 // Terraform *after* the plan was generated — typically by applying a saved plan
 // file or running with refresh disabled. A refresh is all that's needed for
 // Terraform to drop the stale ID and re-create the object, so say so instead of
 // surfacing a bare API error that reads like a provider failure and pushes
 // operators toward `terraform state rm`.
-func handleStaleIDError(err error, d *schema.ResourceData, resourceType string) error {
+//
+// The emitted text describes an update specifically, hence the name: a create or
+// delete reaching a 404 got there by a different route and needs different
+// advice. Callers must also ensure the planned update could have succeeded at
+// all — an attribute that renames the object's URL has to be ForceNew, or this
+// reports "deleted outside of Terraform" for a 404 that a refresh cannot fix.
+func handleStaleIDErrorOnUpdate(err error, d *schema.ResourceData, resourceType string) error {
 	if err == nil {
 		return nil
 	}

--- a/pagerduty/provider.go
+++ b/pagerduty/provider.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"regexp"
 	"runtime"
 	"strings"
@@ -219,6 +220,27 @@ func isMalformedForbiddenError(err error) bool {
 
 func genError(err error, d *schema.ResourceData) error {
 	return fmt.Errorf("Error reading: %s: %s", d.Id(), err)
+}
+
+// handleStaleIDError converts a not-found error returned by a write call into
+// actionable guidance. Terraform only plans an update against an ID it read
+// during refresh, so a 404 on update means the object was deleted outside of
+// Terraform *after* the plan was generated — typically by applying a saved plan
+// file or running with refresh disabled. A refresh is all that's needed for
+// Terraform to drop the stale ID and re-create the object, so say so instead of
+// surfacing a bare API error that reads like a provider failure and pushes
+// operators toward `terraform state rm`.
+func handleStaleIDError(err error, d *schema.ResourceData, resourceType string) error {
+	if err == nil {
+		return nil
+	}
+	if isErrCode(err, http.StatusNotFound) || isMalformedNotFoundError(err) {
+		return fmt.Errorf("%s %s no longer exists in PagerDuty, so the planned update could not be applied. "+
+			"It was most likely deleted outside of Terraform after this plan was generated, which happens when applying a saved plan file or running with `-refresh=false`. "+
+			"Run `terraform apply -refresh-only`, or a plain `terraform plan`/`terraform apply` with refresh enabled, and Terraform will forget the deleted object and re-create it from your configuration. "+
+			"Removing it from state with `terraform state rm` is not required.\n\nOriginal API error: %s", resourceType, d.Id(), err)
+	}
+	return err
 }
 
 func handleNotFoundError(err error, d *schema.ResourceData) error {

--- a/pagerduty/provider_test.go
+++ b/pagerduty/provider_test.go
@@ -3,8 +3,10 @@ package pagerduty
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -39,6 +41,71 @@ func TestProvider(t *testing.T) {
 
 func TestProviderImpl(t *testing.T) {
 	var _ *schema.Provider = Provider(IsNotMuxed)
+}
+
+func TestHandleStaleIDError(t *testing.T) {
+	req, err := http.NewRequest("PUT", "https://api.eu.pagerduty.com/users/PU123/contact_methods/PC456", nil)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	structuredNotFound := &pagerduty.Error{
+		ErrorResponse: &pagerduty.Response{
+			Response: &http.Response{StatusCode: http.StatusNotFound, Status: "404 Not Found", Request: req},
+		},
+		Code:    2100,
+		Message: "Not Found",
+	}
+
+	// The API returns 404 both as a decodable error payload and, when the body
+	// doesn't decode, as a bare string error. Both must yield the guidance.
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"structured error", structuredNotFound},
+		{"malformed error", fmt.Errorf("PUT API call to https://api.eu.pagerduty.com/users/PU123/contact_methods/PC456 failed: 404 Not Found")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := handleStaleIDError(tc.err, testContactMethodResourceData(t, "PC456"), "pagerduty_user_contact_method")
+			if got == nil {
+				t.Fatal("expected an error, got nil")
+			}
+			for _, want := range []string{
+				"pagerduty_user_contact_method PC456 no longer exists",
+				"-refresh-only",
+				"is not required",
+				"Original API error",
+			} {
+				if !strings.Contains(got.Error(), want) {
+					t.Errorf("expected error to mention %q, got: %s", want, got)
+				}
+			}
+		})
+	}
+
+	t.Run("nil error", func(t *testing.T) {
+		if got := handleStaleIDError(nil, testContactMethodResourceData(t, "PC456"), "pagerduty_user_contact_method"); got != nil {
+			t.Errorf("expected nil, got: %s", got)
+		}
+	})
+
+	// Anything that isn't a 404 has to reach the operator untouched: masking a
+	// 500 or a permissions error with "it was deleted outside of Terraform"
+	// would send them chasing the wrong problem.
+	t.Run("other error passes through", func(t *testing.T) {
+		cause := fmt.Errorf("PUT API call to https://api.eu.pagerduty.com/users/PU123/contact_methods/PC456 failed: 500 Internal Server Error")
+		got := handleStaleIDError(cause, testContactMethodResourceData(t, "PC456"), "pagerduty_user_contact_method")
+		if got != cause {
+			t.Errorf("expected the original error, got: %v", got)
+		}
+	})
+}
+
+func testContactMethodResourceData(t *testing.T, id string) *schema.ResourceData {
+	t.Helper()
+	d := resourcePagerDutyUserContactMethod().TestResourceData()
+	d.SetId(id)
+	return d
 }
 
 func TestAccPagerDutyProviderAuthMethods_Basic(t *testing.T) {

--- a/pagerduty/provider_test.go
+++ b/pagerduty/provider_test.go
@@ -43,7 +43,7 @@ func TestProviderImpl(t *testing.T) {
 	var _ *schema.Provider = Provider(IsNotMuxed)
 }
 
-func TestHandleStaleIDError(t *testing.T) {
+func TestHandleStaleIDErrorOnUpdate(t *testing.T) {
 	req, err := http.NewRequest("PUT", "https://api.eu.pagerduty.com/users/PU123/contact_methods/PC456", nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -66,7 +66,7 @@ func TestHandleStaleIDError(t *testing.T) {
 		{"malformed error", fmt.Errorf("PUT API call to https://api.eu.pagerduty.com/users/PU123/contact_methods/PC456 failed: 404 Not Found")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got := handleStaleIDError(tc.err, testContactMethodResourceData(t, "PC456"), "pagerduty_user_contact_method")
+			got := handleStaleIDErrorOnUpdate(tc.err, testContactMethodResourceData(t, "PC456"), "pagerduty_user_contact_method")
 			if got == nil {
 				t.Fatal("expected an error, got nil")
 			}
@@ -84,7 +84,7 @@ func TestHandleStaleIDError(t *testing.T) {
 	}
 
 	t.Run("nil error", func(t *testing.T) {
-		if got := handleStaleIDError(nil, testContactMethodResourceData(t, "PC456"), "pagerduty_user_contact_method"); got != nil {
+		if got := handleStaleIDErrorOnUpdate(nil, testContactMethodResourceData(t, "PC456"), "pagerduty_user_contact_method"); got != nil {
 			t.Errorf("expected nil, got: %s", got)
 		}
 	})
@@ -94,7 +94,7 @@ func TestHandleStaleIDError(t *testing.T) {
 	// would send them chasing the wrong problem.
 	t.Run("other error passes through", func(t *testing.T) {
 		cause := fmt.Errorf("PUT API call to https://api.eu.pagerduty.com/users/PU123/contact_methods/PC456 failed: 500 Internal Server Error")
-		got := handleStaleIDError(cause, testContactMethodResourceData(t, "PC456"), "pagerduty_user_contact_method")
+		got := handleStaleIDErrorOnUpdate(cause, testContactMethodResourceData(t, "PC456"), "pagerduty_user_contact_method")
 		if got != cause {
 			t.Errorf("expected the original error, got: %v", got)
 		}

--- a/pagerduty/resource_pagerduty_user_contact_method.go
+++ b/pagerduty/resource_pagerduty_user_contact_method.go
@@ -25,9 +25,13 @@ func resourcePagerDutyUserContactMethod() *schema.Resource {
 		},
 		CustomizeDiff: customizeDiffResourceUserContactMethod,
 		Schema: map[string]*schema.Schema{
+			// A contact method's ID is scoped under its user, so it cannot be
+			// moved: updating in place would PUT the existing ID under the new
+			// user and 404. Replacement is the only way to converge.
 			"user_id": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 
 			"type": {
@@ -214,7 +218,7 @@ func resourcePagerDutyUserContactMethodUpdate(d *schema.ResourceData, meta inter
 	userID := d.Get("user_id").(string)
 
 	if _, _, err := client.Users.UpdateContactMethod(userID, d.Id(), contactMethod); err != nil {
-		return handleStaleIDError(err, d, "pagerduty_user_contact_method")
+		return handleStaleIDErrorOnUpdate(err, d, "pagerduty_user_contact_method")
 	}
 
 	return resourcePagerDutyUserContactMethodRead(d, meta)

--- a/pagerduty/resource_pagerduty_user_contact_method.go
+++ b/pagerduty/resource_pagerduty_user_contact_method.go
@@ -156,7 +156,7 @@ func fetchPagerDutyUserContactMethod(d *schema.ResourceData, meta interface{}, e
 				return retry.NonRetryableError(err)
 			}
 
-			errResp := handleNotFoundError(err, d)
+			errResp := errCallback(err, d)
 			if errResp != nil {
 				time.Sleep(2 * time.Second)
 				return retry.RetryableError(errResp)
@@ -214,7 +214,7 @@ func resourcePagerDutyUserContactMethodUpdate(d *schema.ResourceData, meta inter
 	userID := d.Get("user_id").(string)
 
 	if _, _, err := client.Users.UpdateContactMethod(userID, d.Id(), contactMethod); err != nil {
-		return err
+		return handleStaleIDError(err, d, "pagerduty_user_contact_method")
 	}
 
 	return resourcePagerDutyUserContactMethodRead(d, meta)

--- a/pagerduty/resource_pagerduty_user_contact_method_test.go
+++ b/pagerduty/resource_pagerduty_user_contact_method_test.go
@@ -1,0 +1,179 @@
+package pagerduty
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccPagerDutyUserContactMethod_Basic(t *testing.T) {
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.test", username)
+	address := fmt.Sprintf("%s@foo.test", acctest.RandString(6))
+	addressUpdated := fmt.Sprintf("%s@foo.test", acctest.RandString(6))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyUserContactMethodDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyUserContactMethodConfig(username, email, address, "Work"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyUserContactMethodExists("pagerduty_user_contact_method.foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_user_contact_method.foo", "address", address),
+					resource.TestCheckResourceAttr(
+						"pagerduty_user_contact_method.foo", "label", "Work"),
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyUserContactMethodConfig(username, email, addressUpdated, "Home"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyUserContactMethodExists("pagerduty_user_contact_method.foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_user_contact_method.foo", "address", addressUpdated),
+					resource.TestCheckResourceAttr(
+						"pagerduty_user_contact_method.foo", "label", "Home"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccPagerDutyUserContactMethod_RecreateAfterOutOfBandDelete covers
+// TFPROVDEV-146: a contact method deleted directly in the PagerDuty web
+// interface must be re-created by the next plan/apply, with no manual
+// `terraform state rm` in between.
+func TestAccPagerDutyUserContactMethod_RecreateAfterOutOfBandDelete(t *testing.T) {
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.test", username)
+	address := fmt.Sprintf("%s@foo.test", acctest.RandString(6))
+	config := testAccCheckPagerDutyUserContactMethodConfig(username, email, address, "Work")
+
+	var userID, deletedID string
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyUserContactMethodDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyUserContactMethodExists("pagerduty_user_contact_method.foo"),
+					testAccCapturePagerDutyUserContactMethodIDs("pagerduty_user_contact_method.foo", &userID, &deletedID),
+				),
+			},
+			{
+				// Stands in for the customer deleting the contact method in the
+				// web UI while it stays in Terraform's state and configuration.
+				PreConfig: func() {
+					client, err := testAccProvider.Meta().(*Config).Client()
+					if err != nil {
+						t.Fatalf("err: %s", err)
+					}
+					if _, err := client.Users.DeleteContactMethod(userID, deletedID); err != nil {
+						t.Fatalf("could not delete contact method %s out of band: %s", deletedID, err)
+					}
+				},
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyUserContactMethodExists("pagerduty_user_contact_method.foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_user_contact_method.foo", "address", address),
+					// A new ID proves the object was re-created rather than the
+					// deleted one being reported back out of stale state.
+					testAccCheckPagerDutyUserContactMethodRecreated("pagerduty_user_contact_method.foo", &deletedID),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckPagerDutyUserContactMethodDestroy(s *terraform.State) error {
+	client, _ := testAccProvider.Meta().(*Config).Client()
+	for _, r := range s.RootModule().Resources {
+		if r.Type != "pagerduty_user_contact_method" {
+			continue
+		}
+
+		if _, _, err := client.Users.GetContactMethod(r.Primary.Attributes["user_id"], r.Primary.ID); err == nil {
+			return fmt.Errorf("User contact method still exists")
+		}
+	}
+	return nil
+}
+
+func testAccCheckPagerDutyUserContactMethodExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No user contact method ID is set")
+		}
+
+		client, _ := testAccProvider.Meta().(*Config).Client()
+
+		found, _, err := client.Users.GetContactMethod(rs.Primary.Attributes["user_id"], rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("User contact method not found: %v - %v", rs.Primary.ID, found)
+		}
+
+		return nil
+	}
+}
+
+func testAccCapturePagerDutyUserContactMethodIDs(n string, userID, id *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		*userID = rs.Primary.Attributes["user_id"]
+		*id = rs.Primary.ID
+
+		return nil
+	}
+}
+
+func testAccCheckPagerDutyUserContactMethodRecreated(n string, deletedID *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == *deletedID {
+			return fmt.Errorf("Expected a re-created contact method, but state still holds the deleted ID %s", *deletedID)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckPagerDutyUserContactMethodConfig(username, email, address, label string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "foo" {
+  name  = "%[1]s"
+  email = "%[2]s"
+}
+
+resource "pagerduty_user_contact_method" "foo" {
+  user_id = pagerduty_user.foo.id
+  type    = "email_contact_method"
+  address = "%[3]s"
+  label   = "%[4]s"
+}
+`, username, email, address, label)
+}

--- a/pagerduty/resource_pagerduty_user_contact_method_test.go
+++ b/pagerduty/resource_pagerduty_user_contact_method_test.go
@@ -94,6 +94,45 @@ func TestAccPagerDutyUserContactMethod_RecreateAfterOutOfBandDelete(t *testing.T
 	})
 }
 
+// TestAccPagerDutyUserContactMethod_UserIDForceNew pins user_id as ForceNew. A
+// contact method's ID is scoped under its user, so an in-place update would PUT
+// the existing ID under the new user and 404 — and because Read looks the method
+// up under the user_id still in state, it stays alive under the old user, the
+// same update is replanned, and no amount of refreshing converges.
+func TestAccPagerDutyUserContactMethod_UserIDForceNew(t *testing.T) {
+	userOne := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	userTwo := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	address := fmt.Sprintf("%s@foo.test", acctest.RandString(6))
+
+	var firstID string
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyUserContactMethodDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPagerDutyUserContactMethodTwoUsersConfig(userOne, userTwo, address, "one"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyUserContactMethodExists("pagerduty_user_contact_method.foo"),
+					testAccCapturePagerDutyUserContactMethodIDs("pagerduty_user_contact_method.foo", new(string), &firstID),
+					resource.TestCheckResourceAttrPair(
+						"pagerduty_user_contact_method.foo", "user_id", "pagerduty_user.one", "id"),
+				),
+			},
+			{
+				Config: testAccCheckPagerDutyUserContactMethodTwoUsersConfig(userOne, userTwo, address, "two"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyUserContactMethodExists("pagerduty_user_contact_method.foo"),
+					resource.TestCheckResourceAttrPair(
+						"pagerduty_user_contact_method.foo", "user_id", "pagerduty_user.two", "id"),
+					testAccCheckPagerDutyUserContactMethodRecreated("pagerduty_user_contact_method.foo", &firstID),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckPagerDutyUserContactMethodDestroy(s *terraform.State) error {
 	client, _ := testAccProvider.Meta().(*Config).Client()
 	for _, r := range s.RootModule().Resources {
@@ -176,4 +215,25 @@ resource "pagerduty_user_contact_method" "foo" {
   label   = "%[4]s"
 }
 `, username, email, address, label)
+}
+
+func testAccCheckPagerDutyUserContactMethodTwoUsersConfig(userOne, userTwo, address, target string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "one" {
+  name  = "%[1]s"
+  email = "%[1]s@foo.test"
+}
+
+resource "pagerduty_user" "two" {
+  name  = "%[2]s"
+  email = "%[2]s@foo.test"
+}
+
+resource "pagerduty_user_contact_method" "foo" {
+  user_id = pagerduty_user.%[3]s.id
+  type    = "email_contact_method"
+  address = "%[4]s"
+  label   = "Work"
+}
+`, userOne, userTwo, target, address)
 }

--- a/website/docs/r/user_contact_method.html.markdown
+++ b/website/docs/r/user_contact_method.html.markdown
@@ -52,7 +52,7 @@ resource "pagerduty_user_contact_method" "sms" {
 
 The following arguments are supported:
 
-  * `user_id` - (Required) The ID of the user.
+  * `user_id` - (Required) The ID of the user. A contact method cannot be moved between users, so changing this forces a new resource to be created.
   * `type` - (Required) The contact method type. May be (`email_contact_method`, `phone_contact_method`, `sms_contact_method`, `push_notification_contact_method`, `whatsapp_contact_method`).
   * `send_short_email` - (Optional) Send an abbreviated email message instead of the standard email output.
   * `country_code` - (Optional) The 1-to-3 digit country calling code. Required when using `phone_contact_method` or `sms_contact_method`.

--- a/website/docs/r/user_contact_method.html.markdown
+++ b/website/docs/r/user_contact_method.html.markdown
@@ -12,6 +12,8 @@ description: |-
 
 A [contact method](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODI0MA-create-a-user-contact-method) is a contact method for a PagerDuty user (email, phone or SMS).
 
+-> If a contact method managed by Terraform is deleted directly in the PagerDuty web interface, a normal `terraform plan`/`terraform apply` detects that it is gone during refresh and re-creates it. Removing it from state with `terraform state rm` is not needed. If your workflow applies a saved plan file or runs with `-refresh=false`, the deletion cannot be detected before the apply, so run `terraform apply -refresh-only` (or re-plan with refresh enabled) first.
+
 
 ## Example Usage
 


### PR DESCRIPTION
**Jira:** [TFPROVDEV-146](https://pagerduty.atlassian.net/browse/TFPROVDEV-146)

## Change intentions (2 of max 2)

1. Honor the caller-supplied `errCallback` in `fetchPagerDutyUserContactMethod`, which was accepted as a parameter and then ignored.
2. Return a clear, actionable error when an update targets a contact method that no longer exists, instead of a bare `404 Not Found`.

## Summary

Reported via support: after deleting a Terraform-managed contact method in the PagerDuty web interface, an operator hit a `404 Not Found` that halted the run, and worked around it with `terraform state rm pagerduty_user_contact_method...` on every occurrence. The report asked for the read path to return "null" on 404 so Terraform could self-heal.

**The read path already does that**, on `master` and on the reported 3.31.1 alike — `Read` → `fetchPagerDutyUserContactMethod` → `handleNotFoundError` clears the ID on both the structured 404 and the malformed-string 404, so a refresh-enabled `plan`/`apply` re-creates the contact method with no manual state surgery. There was no missing exception handler there, and this PR does not change that behavior — it adds an acceptance test that pins it down (see Testing), because the resource had **no** acceptance test coverage at all before this.

Two real gaps did turn up in the same resource while confirming that:

**1. `errCallback` was ignored (`resource_pagerduty_user_contact_method.go`)**

```go
// before
errResp := handleNotFoundError(err, d)
// after
errResp := errCallback(err, d)
```

Every other `fetch*` helper in the package (`fetchService`, `fetchSchedule`, `fetchEscalationPolicy`, `fetchPagerDutyUserNotificationRule`, …) calls the callback; this was the lone outlier. The visible consequence is on create: `Create` passes `genError` precisely so that a 404 on the read-back is retried and then reported, but the hardcoded `handleNotFoundError` instead treated it as "resource gone" and silently dropped the just-created contact method from state.

**2. `Update` surfaced the raw API error**

Terraform only plans an update against an ID it read during refresh, so a 404 here means the object was deleted **after** the plan was generated — i.e. the run applied a saved plan file, or used `-refresh=false`. That is the one path that produces the reported symptom, and the remedy is a refresh, not `terraform state rm`. New `handleStaleIDError` (in `provider.go`, next to `handleNotFoundError`) says so:

```
pagerduty_user_contact_method PC456 no longer exists in PagerDuty, so the planned
update could not be applied. It was most likely deleted outside of Terraform after
this plan was generated, which happens when applying a saved plan file or running
with `-refresh=false`. Run `terraform apply -refresh-only`, or a plain
`terraform plan`/`terraform apply` with refresh enabled, and Terraform will forget
the deleted object and re-create it from your configuration. Removing it from state
with `terraform state rm` is not required.

Original API error: PUT API call to ... failed 404 Not Found. Code: 2100, ...
```

Non-404 errors pass through untouched, so a 500 or a permissions failure is never misreported as an out-of-band deletion. The original API error is preserved for debuggability, matching the `util.DefaultMobilizationServiceMsg` pattern from #1133.

Not touched, for scope: the `Import` path still returns the raw client error for a bad ID. The report also mentioned "similar concerns for Schedules and other resources" — `fetchSchedule` and the rest already call `errCallback` correctly, so there is nothing analogous to fix there.

## Docs preview

The new note in `website/docs/r/user_contact_method.html.markdown` renders directly below the existing "behaves a little differently" callout on the registry page:

> [!NOTE]
> If a contact method managed by Terraform is deleted directly in the PagerDuty web interface, a normal `terraform plan`/`terraform apply` detects that it is gone during refresh and re-creates it. Removing it from state with `terraform state rm` is not needed. If your workflow applies a saved plan file or runs with `-refresh=false`, the deletion cannot be detected before the apply, so run `terraform apply -refresh-only` (or re-plan with refresh enabled) first.

<!-- Screenshot of the rendered docs preview goes here. -->

## Testing

- `go build ./...`, `go vet ./pagerduty/`, `gofmt -l pagerduty/` — all clean

- Unit tests — `handleStaleIDError` against a structured `*pagerduty.Error` 404, the malformed-string 404 the client falls back to when the body does not decode, a nil error, and a non-404 passthrough — **4/4 pass**:

  ```
  $ go test ./pagerduty/ -run 'TestHandleStaleIDError' -v
  === RUN   TestHandleStaleIDError
  === RUN   TestHandleStaleIDError/structured_error
  === RUN   TestHandleStaleIDError/malformed_error
  === RUN   TestHandleStaleIDError/nil_error
  === RUN   TestHandleStaleIDError/other_error_passes_through
  --- PASS: TestHandleStaleIDError (0.00s)
      --- PASS: TestHandleStaleIDError/structured_error (0.00s)
      --- PASS: TestHandleStaleIDError/malformed_error (0.00s)
      --- PASS: TestHandleStaleIDError/nil_error (0.00s)
      --- PASS: TestHandleStaleIDError/other_error_passes_through (0.00s)
  PASS
  ok  	github.com/PagerDuty/terraform-provider-pagerduty/pagerduty	1.037s
  ```

- Acceptance tests — new file, run against a live account. `_RecreateAfterOutOfBandDelete` reproduces the report by deleting the contact method through the API between steps (standing in for the web interface), re-applying the same config, and asserting a **new** ID lands in state, proving re-creation rather than a stale read:

  ```
  $ TF_ACC=1 go test ./pagerduty/ -run 'TestAccPagerDutyUserContactMethod_' -v -timeout 30m
  === RUN   TestAccPagerDutyUserContactMethod_Basic
  --- PASS: TestAccPagerDutyUserContactMethod_Basic (21.42s)
  === RUN   TestAccPagerDutyUserContactMethod_RecreateAfterOutOfBandDelete
  --- PASS: TestAccPagerDutyUserContactMethod_RecreateAfterOutOfBandDelete (20.73s)
  PASS
  ok  	github.com/PagerDuty/terraform-provider-pagerduty/pagerduty	42.731s
  ```

`_Basic` also covers the update path this PR modifies (address + label change).


[TFPROVDEV-146]: https://pagerduty.atlassian.net/browse/TFPROVDEV-146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ