### PR TITLE
Anchor start_time_of_day validation so junk-wrapped times are rejected

### DIFF
--- a/pagerduty/resource_pagerduty_schedule.go
+++ b/pagerduty/resource_pagerduty_schedule.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"regexp"
 	"strings"
 	"time"
 
@@ -154,7 +153,7 @@ func resourcePagerDutySchedule() *schema.Resource {
 									"start_time_of_day": {
 										Type:         schema.TypeString,
 										Required:     true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile(`([0-1][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]`), "must be of 00:00:00 format"),
+										ValidateFunc: util.ValidateTimeOfDay,
 									},
 
 									"start_day_of_week": {

--- a/util/util.go
+++ b/util/util.go
@@ -58,6 +58,23 @@ func GenErrorTimeFormatRFC339(value, k string) error {
 	return fmt.Errorf("%s is not a valid format for argument: %s. Expected format: %s (RFC3339)", value, k, time.RFC3339)
 }
 
+// timeOfDayRegex matches a 24-hour HH:MM:SS time of day. The pattern is
+// anchored so that only the whole string is a valid time; without the anchors
+// a substring match would let junk-wrapped values such as "12:30:00xyz" or
+// "xyz08:00:00" pass validation.
+var timeOfDayRegex = regexp.MustCompile(`^([0-1][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$`)
+
+// ValidateTimeOfDay validates that a string is a 24-hour HH:MM:SS time of day,
+// e.g. "08:00:00".
+func ValidateTimeOfDay(v interface{}, k string) (we []string, errors []error) {
+	value := v.(string)
+	if !timeOfDayRegex.MatchString(value) {
+		errors = append(errors, fmt.Errorf("%s is not a valid format for argument: %s. Expected format: HH:MM:SS, e.g. 08:00:00", value, k))
+	}
+
+	return
+}
+
 func SuppressRFC3339Diff(k, oldTime, newTime string, d *schema.ResourceData) bool {
 	oldT, newT, err := ParseRFC3339Time(k, oldTime, newTime)
 	if err != nil {

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -41,3 +41,31 @@ func TestValidateTZValueDiagFunc(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateTimeOfDay(t *testing.T) {
+	cases := []struct {
+		given   string
+		wantErr bool
+	}{
+		// Valid HH:MM:SS values.
+		{given: "08:00:00", wantErr: false},
+		{given: "00:00:00", wantErr: false},
+		{given: "23:59:59", wantErr: false},
+		// Out-of-range components.
+		{given: "24:00:00", wantErr: true},
+		{given: "12:60:00", wantErr: true},
+		// Junk-wrapped values that must be rejected once the regex is anchored.
+		{given: "12:30:00xyz", wantErr: true},
+		{given: "xyz08:00:00", wantErr: true},
+		{given: "99:08:00:00", wantErr: true},
+		{given: "", wantErr: true},
+	}
+
+	for _, c := range cases {
+		_, errs := ValidateTimeOfDay(c.given, "start_time_of_day")
+		gotErr := len(errs) > 0
+		if gotErr != c.wantErr {
+			t.Errorf("ValidateTimeOfDay(%q): wantErr=%v, got errs=%v", c.given, c.wantErr, errs)
+		}
+	}
+}


### PR DESCRIPTION
## What

`pagerduty_schedule` validates each layer restriction's `start_time_of_day` (HH:MM:SS) with an **unanchored** regex passed to `validation.StringMatch`:

```go
ValidateFunc: validation.StringMatch(regexp.MustCompile(`([0-1][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]`), "must be of 00:00:00 format"),
```

`validation.StringMatch` does a **substring** match, so the missing `^...$` anchors let junk-wrapped values validate as OK. All of these currently pass:

- `"12:30:00xyz"`
- `"xyz08:00:00"`
- `"99:08:00:00"`

## Fix

Extract the check into a named, **anchored** `util.ValidateTimeOfDay` validator (mirroring the existing `util.ValidateRFC3339`), and wire the schedule resource to it. The regex becomes `^([0-1][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$`.

## Test (red → green)

Added `TestValidateTimeOfDay` in `util/util_test.go`. It exercises the production validator directly.

- **Red** (regex left unanchored): `12:30:00xyz`, `xyz08:00:00`, `99:08:00:00` are accepted → test FAILS.
- **Green** (anchored): valid times (`08:00:00`, `00:00:00`, `23:59:59`) pass; junk-wrapped and out-of-range (`24:00:00`, `12:60:00`) are rejected → test PASSES.

```
$ go test ./util/ -run TestValidateTimeOfDay
ok  github.com/PagerDuty/terraform-provider-pagerduty/util
```

Pure unit test — no acceptance test or API credentials required.

## Notes

- No CHANGELOG entry added — the changelog looks maintainer-cut per release with PR numbers; happy to add an entry in your preferred section/format.
- for the record: patch drafted with AI assistance, reviewed and verified by me.